### PR TITLE
ci(.github): Testing job on GitHub

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,24 @@
+name: Tests
+
+on:
+  - pull_request
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7, 3.8]
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install tox tox-gh-actions poetry
+    - name: Test with tox
+      run: tox

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,12 @@
 envlist = py36, py37, py38
 isolated_build = True
 
+[gh-actions]
+python =
+    3.6: py36
+    3.7: py37
+    3.8: py38
+
 [testenv]
 whitelist_externals = poetry
 commands =


### PR DESCRIPTION
A testing job has been created under `.github/workflows/`. The job uses
the package `tox-gh-actions`, which is a plugin to help running `tox`
in GitHub Actions.

The `[gh-actions]` table is only used in CI, but not locally.

Source:
- https://github.com/ymyzk/tox-gh-actions