### PR TITLE
fix(api.errors): `PiquassoException` base class

### DIFF
--- a/piquasso/__init__.py
+++ b/piquasso/__init__.py
@@ -27,7 +27,7 @@ from piquasso._backends.sampling import SamplingState
 from piquasso._backends.gaussian import GaussianState
 from piquasso._backends.fock import FockState, PureFockState, PNCFockState
 
-from piquasso.core.registry import _use_plugin, _retrieve_class
+from piquasso.core import _registry
 
 from .instructions.preparations import (
     Vacuum,
@@ -115,7 +115,7 @@ _default_measurements = {
 
 
 def use(plugin):
-    _use_plugin(plugin, override=True)
+    _registry.use_plugin(plugin, override=True)
 
 
 class _DefaultPlugin(Plugin):
@@ -131,7 +131,7 @@ class _DefaultPlugin(Plugin):
     }
 
 
-_use_plugin(_DefaultPlugin)
+_registry.use_plugin(_DefaultPlugin)
 
 
 class Piquasso:
@@ -140,8 +140,8 @@ class Piquasso:
 
     def __getattr__(self, attribute):
         try:
-            return _retrieve_class(attribute)
-        except NameError:
+            return _registry.items[attribute]
+        except KeyError:
             return getattr(self._module, attribute)
 
 

--- a/piquasso/_backends/fock/general/state.py
+++ b/piquasso/_backends/fock/general/state.py
@@ -204,7 +204,7 @@ class FockState(BaseFockState):
 
     def normalize(self):
         if np.isclose(self.norm, 0):
-            raise RuntimeError("The norm of the state is 0.")
+            raise InvalidState("The norm of the state is 0.")
 
         self._density_matrix = self._density_matrix / self.norm
 

--- a/piquasso/_backends/fock/pnc/state.py
+++ b/piquasso/_backends/fock/pnc/state.py
@@ -243,7 +243,7 @@ class PNCFockState(BaseFockState):
 
     def normalize(self):
         if np.isclose(self.norm, 0):
-            raise RuntimeError("The norm of the state is 0.")
+            raise InvalidState("The norm of the state is 0.")
 
         norm = self.norm
 

--- a/piquasso/_backends/fock/pure/state.py
+++ b/piquasso/_backends/fock/pure/state.py
@@ -178,7 +178,7 @@ class PureFockState(BaseFockState):
 
     def normalize(self):
         if np.isclose(self.norm, 0):
-            raise RuntimeError("The norm of the state is 0.")
+            raise InvalidState("The norm of the state is 0.")
 
         self._state_vector = self._state_vector / np.sqrt(self.norm)
 

--- a/piquasso/api/errors.py
+++ b/piquasso/api/errors.py
@@ -13,13 +13,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-class InvalidState(Exception):
+class PiquassoException(Exception):
+    """Base class for all exceptions raised by Piquasso."""
+
+
+class InvalidState(PiquassoException):
     """Raised when an invalid state is encountered or being prepared."""
 
 
-class InvalidParameter(Exception):
+class InvalidParameter(PiquassoException):
     """Raised when an invalid parameter is specified."""
 
 
-class InvalidModes(Exception):
+class InvalidModes(PiquassoException):
     """Raised when invalid set of modes are encountered."""
+
+
+class InvalidProgram(PiquassoException):
+    """Raised when an invalid program is being created or used."""

--- a/piquasso/api/program.py
+++ b/piquasso/api/program.py
@@ -16,8 +16,8 @@
 import json
 import blackbird
 
-from piquasso.core import _context, _blackbird
-from piquasso.core.registry import _create_instance_from_mapping
+from piquasso.api.errors import InvalidProgram
+from piquasso.core import _context, _blackbird, _registry
 from piquasso.core.mixins import _RegisterMixin
 from .mode import Q
 
@@ -61,7 +61,7 @@ class Program(_RegisterMixin):
     def apply_to_program_on_register(self, program, register):
         if self.state is not None:
             if program.state is not None:
-                raise RuntimeError(
+                raise InvalidProgram(
                     "The program already has a state registered of type "
                     f"'{type(program.state).__name__}'."
                 )
@@ -133,10 +133,10 @@ class Program(_RegisterMixin):
         """
 
         return cls(
-            state=_create_instance_from_mapping(properties["state"]),
+            state=_registry.create_instance_from_mapping(properties["state"]),
             instructions=list(
                 map(
-                    _create_instance_from_mapping,
+                    _registry.create_instance_from_mapping,
                     properties["instructions"],
                 )
             )

--- a/piquasso/core/_blackbird.py
+++ b/piquasso/core/_blackbird.py
@@ -16,7 +16,7 @@
 import inspect
 from collections import OrderedDict
 
-from . import registry
+from . import _registry
 
 
 def load_instructions(blackbird_program):
@@ -29,21 +29,21 @@ def load_instructions(blackbird_program):
     """
 
     instruction_map = {
-        "Dgate": registry._retrieve_class("Displacement"),
-        "Xgate": registry._retrieve_class("PositionDisplacement"),
-        "Zgate": registry._retrieve_class("MomentumDisplacement"),
-        "Sgate": registry._retrieve_class("Squeezing"),
-        "Pgate": registry._retrieve_class("QuadraticPhase"),
+        "Dgate": _registry.items["Displacement"],
+        "Xgate": _registry.items["PositionDisplacement"],
+        "Zgate": _registry.items["MomentumDisplacement"],
+        "Sgate": _registry.items["Squeezing"],
+        "Pgate": _registry.items["QuadraticPhase"],
         "Vgate": None,
-        "Kgate": registry._retrieve_class("Kerr"),
-        "Rgate": registry._retrieve_class("Phaseshifter"),
-        "BSgate": registry._retrieve_class("Beamsplitter"),
-        "MZgate": registry._retrieve_class("MachZehnder"),
-        "S2gate": registry._retrieve_class("Squeezing2"),
-        "CXgate": registry._retrieve_class("ControlledX"),
-        "CZgate": registry._retrieve_class("ControlledZ"),
-        "CKgate": registry._retrieve_class("CrossKerr"),
-        "Fouriergate": registry._retrieve_class("Fourier"),
+        "Kgate": _registry.items["Kerr"],
+        "Rgate": _registry.items["Phaseshifter"],
+        "BSgate": _registry.items["Beamsplitter"],
+        "MZgate": _registry.items["MachZehnder"],
+        "S2gate": _registry.items["Squeezing2"],
+        "CXgate": _registry.items["ControlledX"],
+        "CZgate": _registry.items["ControlledZ"],
+        "CKgate": _registry.items["CrossKerr"],
+        "Fouriergate": _registry.items["Fourier"],
     }
 
     return [

--- a/piquasso/core/_registry.py
+++ b/piquasso/core/_registry.py
@@ -16,26 +16,17 @@
 """Module to store class definitions."""
 
 
-_items = {}
+items = {}
 
 
-def _use_plugin(plugin, override=False):
+def use_plugin(plugin, override=False):
     for name, class_ in plugin.classes.items():
         class_.__name__ = name
-        if override or name not in _items:
-            _items[name] = class_
+        if override or name not in items:
+            items[name] = class_
 
 
-def _retrieve_class(class_name):
-    class_ = _items.get(class_name)
-
-    if class_ is None:
-        raise NameError(f"Class with name '{class_name}' not found in registry.")
-
-    return class_
-
-
-def _create_instance_from_mapping(mapping):
+def create_instance_from_mapping(mapping):
     """Creates an instance using the `registry` classes from a mapping.
 
     The supported mapping format is:
@@ -59,6 +50,6 @@ def _create_instance_from_mapping(mapping):
         The created instance corresponding to the `mapping` specified.
     """
 
-    class_ = _retrieve_class(mapping["type"])
+    class_ = items[mapping["type"]]
 
     return class_.from_properties(mapping["properties"])

--- a/tests/api/program/test_program_stacking.py
+++ b/tests/api/program/test_program_stacking.py
@@ -146,11 +146,11 @@ def test_main_program_inherits_state_and_instructions_without_modes_specified(
     assert main.instructions[1] == pq.DummyInstruction(param=20).on_modes(2, 3)
 
 
-def test_state_collision_raises_RuntimeError(program):
+def test_state_collision_raises_InvalidProgram(program):
     with pq.Program() as preparation:
         pq.Q() | pq.FakeState()
 
-    with pytest.raises(RuntimeError) as error:
+    with pytest.raises(pq.api.errors.InvalidProgram) as error:
         with program:
             pq.Q() | preparation
 

--- a/tests/backends/fock/general_and_pnc/test_preparations.py
+++ b/tests/backends/fock/general_and_pnc/test_preparations.py
@@ -76,7 +76,7 @@ def test_create_annihilate_and_create(StateClass):
 
 
 @pytest.mark.parametrize("StateClass", [pq.FockState, pq.PNCFockState])
-def test_overflow_with_zero_norm_raises_RuntimeError(StateClass):
+def test_overflow_with_zero_norm_raises_InvalidState(StateClass):
     with pq.Program() as program:
         pq.Q() | StateClass(d=3, cutoff=3)
 
@@ -85,7 +85,7 @@ def test_overflow_with_zero_norm_raises_RuntimeError(StateClass):
 
         pq.Q(1, 2) | pq.Create()
 
-    with pytest.raises(RuntimeError) as error:
+    with pytest.raises(pq.api.errors.InvalidState) as error:
         program.execute()
 
     assert error.value.args[0] == "The norm of the state is 0."

--- a/tests/backends/fock/pure/test_preparations.py
+++ b/tests/backends/fock/pure/test_preparations.py
@@ -72,7 +72,7 @@ def test_create_annihilate_and_create():
     )
 
 
-def test_overflow_with_zero_norm_raises_RuntimeError():
+def test_overflow_with_zero_norm_raises_InvalidState():
     with pq.Program() as program:
         pq.Q() | pq.PureFockState(d=3, cutoff=3)
         pq.Q(2) | pq.StateVector(1) * np.sqrt(2/5)
@@ -80,7 +80,7 @@ def test_overflow_with_zero_norm_raises_RuntimeError():
 
         pq.Q(1, 2) | pq.Create()
 
-    with pytest.raises(RuntimeError) as error:
+    with pytest.raises(pq.api.errors.InvalidState) as error:
         program.execute()
 
     assert error.value.args[0] == "The norm of the state is 0."


### PR DESCRIPTION
It can be handy for the user to derive all custom Piquasso exceptions
from a single base class.

As an example, a problem could arise when the user would like to catch
all errors Piquasso raises with a code like:

```
try:
    program = pq.Program(...)
    results = program.execute()
except ??? as error:
   # Handle errors raised by Piquasso
   ...
```

Here, the `???` is implemented as `PiquassoException`. Of course, one
could list all the possible Exception classes under
`piquasso.api.errors`, but this is way nicer.

Also, there were some code where `RuntimeError` was raised, probably
from the time when there were no custom exceptions. These were rewritten
to use base classes of `PiquassoException` instead.

**Registry**

In `core.registry`, the raising of `NameError` is odd, since `NameError`
is typically raised when a name is not found, where the term *name*
means a variable to refer to an object.

The `_retrieve_class` function is not even needed: one could access the
`_items` `dict` from the module as well. To simplify, the function is
deleted, and all the usages of `_retrieve_class` is rewritten.

The `registry` module got renamed to `_registry` and used as a whole
module throughout Piquasso.