### PR TITLE
feat(instructions): Loss channel

### DIFF
--- a/piquasso/__init__.py
+++ b/piquasso/__init__.py
@@ -68,6 +68,10 @@ from .instructions.measurements import (
     GeneraldyneMeasurement,
 )
 
+from .instructions.channels import (
+    Loss,
+)
+
 
 constants.seed()
 
@@ -114,6 +118,11 @@ _default_measurements = {
 }
 
 
+_default_channels = {
+    "Loss": Loss,
+}
+
+
 def use(plugin):
     _registry.use_plugin(plugin, override=True)
 
@@ -128,6 +137,7 @@ class _DefaultPlugin(Plugin):
         **_default_preparations,
         **_default_gates,
         **_default_measurements,
+        **_default_channels,
     }
 
 
@@ -159,6 +169,7 @@ __all__ = [
     *_default_preparations.keys(),
     *_default_gates.keys(),
     *_default_measurements.keys(),
+    *_default_channels.keys(),
 ]
 
 __version__ = "0.1.3"

--- a/piquasso/_backends/sampling/circuit.py
+++ b/piquasso/_backends/sampling/circuit.py
@@ -32,6 +32,7 @@ class SamplingCircuit(Circuit):
             "Fourier": self._passive_linear,
             "Sampling": self._sampling,
             "Interferometer": self._passive_linear,
+            "Loss": self._loss,
         }
 
     def _passive_linear(self, instruction):
@@ -60,4 +61,10 @@ class SamplingCircuit(Circuit):
         self.state.results = sampling_simulator.get_classical_simulation_results(
             initial_state,
             samples_number=instruction.params["shots"]
+        )
+
+    def _loss(self, instruction):
+        self.state._apply_loss(
+            transmissivity=instruction._transmissivity,
+            modes=instruction.modes,
         )

--- a/piquasso/_backends/sampling/state.py
+++ b/piquasso/_backends/sampling/state.py
@@ -28,6 +28,8 @@ class SamplingState(State):
         self.interferometer = np.diag(np.ones(self.d, dtype=complex))
         self.results = None
 
+        self.is_lossy = False
+
     def _apply_passive_linear(self, U, modes):
         r"""
         Multiplies the interferometer of the state with the `U` matrix (representing
@@ -44,10 +46,19 @@ class SamplingState(State):
             modes (tuple[int]):
                 Distinct positive integer values which are used to represent qumodes.
         """
-        J = np.diag(np.ones(self.d, dtype=complex))
-        J[np.ix_(modes, modes)] = U
+        self._apply_matrix_on_modes(U, modes)
 
-        self.interferometer = J @  self.interferometer
+    def _apply_loss(self, transmissivity, modes):
+        self.is_lossy = True
+
+        transmission_matrix = np.diag(transmissivity)
+
+        self._apply_matrix_on_modes(transmission_matrix, modes)
+
+    def _apply_matrix_on_modes(self, matrix, modes):
+        self.interferometer[np.ix_(modes, modes)] = (
+            matrix @ self.interferometer[np.ix_(modes, modes)]
+        )
 
     @property
     def d(self):

--- a/piquasso/core/mixins.py
+++ b/piquasso/core/mixins.py
@@ -66,3 +66,9 @@ class _CodeMixin(abc.ABC):
     @abc.abstractmethod
     def _as_code(self):
         pass
+
+
+class _ScalingMixin(abc.ABC):
+    @abc.abstractmethod
+    def _autoscale(self):
+        pass

--- a/piquasso/instructions/channels.py
+++ b/piquasso/instructions/channels.py
@@ -1,0 +1,55 @@
+#
+# Copyright 2021 Budapest Quantum Computing Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+
+from piquasso.core.mixins import _ScalingMixin
+
+from piquasso.api.errors import InvalidParameter
+from piquasso.api.instruction import Instruction
+
+
+class Loss(Instruction, _ScalingMixin):
+    """Applies a loss channel to the state.
+
+    Note:
+        Currently, this instruction can only be used along with
+        `~piquasso._backends.sampling.state.SamplingState`.
+
+    Args:
+        transmissivity (numpy.ndarray): The transmissivity array.
+    """
+
+    def __init__(self, transmissivity):
+        super().__init__(transmissivity=transmissivity)
+
+        self._transmissivity = np.atleast_1d(transmissivity)
+
+    def _autoscale(self):
+        if (
+            self._transmissivity is None
+            or len(self.modes) == len(self._transmissivity)
+        ):
+            pass
+        elif len(self._transmissivity) == 1:
+            self._transmissivity = np.array(
+                [self._transmissivity[0]] * len(self.modes),
+                dtype=complex,
+            )
+        else:
+            raise InvalidParameter(
+                f"The channel {self} is not applicable to modes {self.modes} with the "
+                "specified parameters."
+            )

--- a/piquasso/instructions/gates.py
+++ b/piquasso/instructions/gates.py
@@ -54,6 +54,8 @@ from piquasso.api.errors import InvalidParameter
 from piquasso._math.takagi import takagi
 from piquasso._math.linalg import is_square, is_symmetric, is_symplectic
 
+from piquasso.core.mixins import _ScalingMixin
+
 
 class _BogoliubovTransformation(Instruction):
     def __init__(
@@ -68,7 +70,7 @@ class _BogoliubovTransformation(Instruction):
         self._displacement_vector = displacement_vector
 
 
-class _ScalableBogoliubovTransformation(_BogoliubovTransformation):
+class _ScalableBogoliubovTransformation(_BogoliubovTransformation, _ScalingMixin):
     ERROR_MESSAGE_TEMPLATE = (
         "The instruction {instruction} is not applicable to modes {modes} with the "
         "specified parameters."

--- a/tests/backends/test_sampling.py
+++ b/tests/backends/test_sampling.py
@@ -98,3 +98,13 @@ class TestSampling:
             pq.Q() | pq.Sampling(shots=1)
 
         self.program.execute()
+
+    def test_loss(self):
+        with self.program:
+            pq.Q(all) | pq.Loss(transmissivity=0.9)
+
+            pq.Q() | pq.Sampling(shots=1)
+
+        self.program.execute()
+
+        assert self.program.state.is_lossy


### PR DESCRIPTION
The Loss channel has been implemented in the `sampling` backend (for
now).

If a Loss channel is applied to the `SamplingState`, then the `is_lossy`
flag is set to `True`, which will be needed for the lossy boson
sampling.