### PR TITLE
feat(piquasso): Docstring and hints

### DIFF
--- a/piquasso/__init__.py
+++ b/piquasso/__init__.py
@@ -13,6 +13,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""The Piquasso module.
+
+One can access all the instructions and states from here as attributes.
+
+Important:
+    It is preferred to access every Piquasso object from this module directly if
+    possible, especially when you're using a plugin.
+"""
+
 import sys
 
 from piquasso.api import constants
@@ -144,7 +153,11 @@ class Piquasso:
         except KeyError:
             return getattr(self._module, attribute)
 
+    def __dir__(self):
+        return dir(self._module)
 
+
+Piquasso.__doc__ = sys.modules[__name__].__doc__
 sys.modules[__name__] = Piquasso(sys.modules[__name__])
 
 


### PR DESCRIPTION
The docstring of an object is defined by its `__doc__` class attribute,
and attribute hints are defined in its `__dir__` method.

The `Piquasso` module wrapper class is used to wrap the
`piquasso` module to override the module's `__getattr__` function, but
some other double underscore attributes need to be redefined, like
`__doc__` and `__dir__`, which is done in this patch.

A small docstring has been written for the main module as well.