### PR TITLE
fix(GaussianState): State reduction overflow

### DIFF
--- a/piquasso/_backends/gaussian/state.py
+++ b/piquasso/_backends/gaussian/state.py
@@ -684,11 +684,9 @@ class GaussianState(State):
         shots,
         calculation,
     ):
-        state = self.reduced(modes)
-
         @lru_cache(maxsize=None)
         def get_probability(*, subspace_modes, occupation_numbers):
-            reduced_state = state.reduced(subspace_modes)
+            reduced_state = self.reduced(subspace_modes)
             return calculation(
                 reduced_state,
                 subspace_modes,

--- a/tests/backends/gaussian/test_measurements.py
+++ b/tests/backends/gaussian/test_measurements.py
@@ -309,3 +309,24 @@ def test_measure_threshold_on_all_modes(nondisplaced_program):
     results = nondisplaced_program.execute()
 
     assert results
+
+
+def test_multiple_particle_number_measurements_in_one_program():
+    first_measurement_shots = 3
+    second_measurement_shots = 4
+
+    with pq.Program() as program:
+        pq.Q() | pq.GaussianState(d=3)
+
+        pq.Q(0) | pq.Squeezing(r=1, phi=0)
+        pq.Q(0, 1) | pq.Beamsplitter(theta=1, phi=np.pi / 4)
+        pq.Q(1, 2) | pq.Beamsplitter(theta=1, phi=np.pi / 4)
+        pq.Q(0, 1) | pq.ParticleNumberMeasurement(cutoff=5, shots=3)
+        pq.Q(2) | pq.ParticleNumberMeasurement(cutoff=5, shots=4)
+
+    results = program.execute()
+
+    assert len(results) == 2
+
+    assert len(results[0].samples) == first_measurement_shots
+    assert len(results[1].samples) == second_measurement_shots


### PR DESCRIPTION
**Problem**

It turned out, that during `ParticleNumberMeasurement`, the code reduced
the state twice.

**Solution**

The first state reduction is removed.

As a final touch, a test case has been written with two
`ParticleNumberMeasurement`.