### PR TITLE
refact(core): rename `mixins` to `_mixins` :hammer:

### DIFF
--- a/piquasso/api/instruction.py
+++ b/piquasso/api/instruction.py
@@ -13,10 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from piquasso.core.mixins import _PropertyMixin, _RegisterMixin, _CodeMixin
+from piquasso.core import _mixins
 
 
-class Instruction(_PropertyMixin, _RegisterMixin, _CodeMixin):
+class Instruction(_mixins.PropertyMixin, _mixins.RegisterMixin, _mixins.CodeMixin):
     """
     Args:
         *params: Variable length argument list.

--- a/piquasso/api/program.py
+++ b/piquasso/api/program.py
@@ -18,11 +18,11 @@ import blackbird
 
 from piquasso.api.errors import InvalidProgram
 from piquasso.core import _context, _blackbird, _registry
-from piquasso.core.mixins import _RegisterMixin
+from piquasso.core import _mixins
 from .mode import Q
 
 
-class Program(_RegisterMixin):
+class Program(_mixins.RegisterMixin):
     r"""The class representing the quantum program.
 
     A `Program` object can be used with the `with` statement. In this context, the state

--- a/piquasso/api/state.py
+++ b/piquasso/api/state.py
@@ -16,10 +16,10 @@
 import abc
 import numpy as np
 
-from piquasso.core.mixins import _PropertyMixin, _RegisterMixin, _CodeMixin
+from piquasso.core import _mixins
 
 
-class State(_PropertyMixin, _RegisterMixin, _CodeMixin, abc.ABC):
+class State(_mixins.PropertyMixin, _mixins.RegisterMixin, _mixins.CodeMixin, abc.ABC):
     """The base class from which all `*State` classes are derived.
 
     Attributes:

--- a/piquasso/core/_mixins.py
+++ b/piquasso/core/_mixins.py
@@ -17,7 +17,7 @@ import abc
 import copy
 
 
-class _PropertyMixin(abc.ABC):
+class PropertyMixin(abc.ABC):
 
     @classmethod
     @abc.abstractmethod
@@ -31,7 +31,7 @@ class _PropertyMixin(abc.ABC):
         pass
 
 
-class _WeightMixin:
+class WeightMixin:
     def __mul__(self, coefficient):
         self.params["coefficient"] *= coefficient
         return self
@@ -42,7 +42,7 @@ class _WeightMixin:
         return self.__mul__(1 / coefficient)
 
 
-class _RegisterMixin(abc.ABC):
+class RegisterMixin(abc.ABC):
     @abc.abstractmethod
     def _apply_to_program_on_register(self, *, program, register):
         """Applies the current object to the specifed program on its specified register.
@@ -62,13 +62,13 @@ class _RegisterMixin(abc.ABC):
         return copy.deepcopy(self)
 
 
-class _CodeMixin(abc.ABC):
+class CodeMixin(abc.ABC):
     @abc.abstractmethod
     def _as_code(self):
         pass
 
 
-class _ScalingMixin(abc.ABC):
+class ScalingMixin(abc.ABC):
     @abc.abstractmethod
     def _autoscale(self):
         pass

--- a/piquasso/instructions/channels.py
+++ b/piquasso/instructions/channels.py
@@ -15,13 +15,13 @@
 
 import numpy as np
 
-from piquasso.core.mixins import _ScalingMixin
+from piquasso.core import _mixins
 
 from piquasso.api.errors import InvalidParameter
 from piquasso.api.instruction import Instruction
 
 
-class Loss(Instruction, _ScalingMixin):
+class Loss(Instruction, _mixins.ScalingMixin):
     """Applies a loss channel to the state.
 
     Note:

--- a/piquasso/instructions/gates.py
+++ b/piquasso/instructions/gates.py
@@ -54,7 +54,7 @@ from piquasso.api.errors import InvalidParameter
 from piquasso._math.takagi import takagi
 from piquasso._math.linalg import is_square, is_symmetric, is_symplectic
 
-from piquasso.core.mixins import _ScalingMixin
+from piquasso.core import _mixins
 
 
 class _BogoliubovTransformation(Instruction):
@@ -70,7 +70,10 @@ class _BogoliubovTransformation(Instruction):
         self._displacement_vector = displacement_vector
 
 
-class _ScalableBogoliubovTransformation(_BogoliubovTransformation, _ScalingMixin):
+class _ScalableBogoliubovTransformation(
+    _BogoliubovTransformation,
+    _mixins.ScalingMixin,
+):
     ERROR_MESSAGE_TEMPLATE = (
         "The instruction {instruction} is not applicable to modes {modes} with the "
         "specified parameters."

--- a/piquasso/instructions/preparations.py
+++ b/piquasso/instructions/preparations.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 
-from piquasso.core.mixins import _WeightMixin
+from piquasso.core import _mixins
 from piquasso.api.instruction import Instruction
 
 
@@ -86,7 +86,7 @@ class Covariance(Instruction):
         super().__init__(cov=cov)
 
 
-class StateVector(Instruction, _WeightMixin):
+class StateVector(Instruction, _mixins.WeightMixin):
     r"""State preparation with Fock basis vectors.
 
     Example usage:
@@ -109,7 +109,7 @@ class StateVector(Instruction, _WeightMixin):
         super().__init__(occupation_numbers=occupation_numbers, coefficient=coefficient)
 
 
-class DensityMatrix(Instruction, _WeightMixin):
+class DensityMatrix(Instruction, _mixins.WeightMixin):
     r"""State preparation with density matrix elements.
 
     Example usage:


### PR DESCRIPTION
The `mixins` module in `piquasso.core` got renamed to `_mixins`, to
avoid single trailing underscore classnames in this module.