### PR TITLE
feat(instructions): Docstring update

### DIFF
--- a/docs/instructions/measurements.rst
+++ b/docs/instructions/measurements.rst
@@ -1,11 +1,5 @@
 Measurements
 ============
 
-.. note::
-
-   When multiple shots are specified and the evolution of the choses simulated state is
-   possible, the measurement outcome corresponding to the last shot is used to evolve
-   the state.
-
 .. automodule:: piquasso.instructions.measurements
    :members:

--- a/piquasso/_backends/gaussian/state.py
+++ b/piquasso/_backends/gaussian/state.py
@@ -140,8 +140,8 @@ class GaussianState(State):
         r"""The state's mean in the xp-ordered basis.
 
         The expectation value of the quadrature operators in xp basis, i.e.
-        :math:`\operatorname{Tr} \rho \hat{Y}`, where
-        :math:`\hat{Y} = (x_1, \dots, x_d, p_1, \dots, p_d)^T`.
+        :math:`\operatorname{Tr} \rho Y`, where
+        :math:`Y = (x_1, \dots, x_d, p_1, \dots, p_d)^T`.
 
         Returns:
             numpy.ndarray: A :math:`d`-vector.
@@ -166,7 +166,7 @@ class GaussianState(State):
         where
 
         .. math::
-            \hat{Y} = (x_1, \dots, x_d, p_1, \dots, p_d)^T,
+            Y = (x_1, \dots, x_d, p_1, \dots, p_d)^T,
 
         and :math:`\rho` is the density operator of the currently represented state.
 
@@ -201,7 +201,7 @@ class GaussianState(State):
         :math:`i`-th row and :math:`j`-th column,
 
         .. math::
-            \hat{Y} = (x_1, \dots, x_d, p_1, \dots, p_d)^T,
+            Y = (x_1, \dots, x_d, p_1, \dots, p_d)^T,
 
         and :math:`\rho` is the density operator of the currently represented state.
 
@@ -229,8 +229,8 @@ class GaussianState(State):
         Returns:
             numpy.ndarray: A :math:`2d`-vector.
                 The expectation value of the quadrature operators in
-                xp-ordering, i.e. :math:`\operatorname{Tr} \rho \hat{R}`, where
-                :math:`\hat{R} = (x_1, p_1, \dots, x_d, p_d)^T`.
+                xp-ordering, i.e. :math:`\operatorname{Tr} \rho R`, where
+                :math:`R = (x_1, p_1, \dots, x_d, p_d)^T`.
         """
         T = quad_transformation(self.d)
         return T @ self.xp_mean
@@ -256,7 +256,7 @@ class GaussianState(State):
         where
 
         .. math::
-            \hat{R} = (x_1, p_1, \dots, x_d, p_d)^T,
+            R = (x_1, p_1, \dots, x_d, p_d)^T,
 
         and :math:`\rho` is the density operator of the currently represented state.
 
@@ -308,7 +308,7 @@ class GaussianState(State):
         :math:`i`-th row and :math:`j`-th column,
 
         .. math::
-            \hat{R} = (x_1, p_1, \dots, x_d, p_d)^T,
+            R = (x_1, p_1, \dots, x_d, p_d)^T,
 
         and :math:`\rho` is the density operator of the currently represented state.
 
@@ -418,19 +418,19 @@ class GaussianState(State):
 
         .. math::
             \mu_{\vec{i}, \phi}
-                &:= \langle \hat{R}_{\vec{i}} \rangle_{\rho_{\vec{i}, \phi}}, \\
+                &:= \langle R_{\vec{i}} \rangle_{\rho_{\vec{i}, \phi}}, \\
             \sigma_{\vec{i}, \phi}
                 &:=  \langle
-                    \hat{R}_{\vec{i}} \hat{R}_{\vec{i}}^T
+                    R_{\vec{i}} R_{\vec{i}}^T
                 \rangle_{\rho_{\vec{i}, \phi}}
                 - \mu_{\vec{i}, \phi} \mu_{\vec{i}, \phi}^T,
 
         where
 
         .. math::
-            \hat{R} = (x_1, p_1, \dots, x_d, p_d)^T,
+            R = (x_1, p_1, \dots, x_d, p_d)^T,
 
-        and :math:`\hat{R}_{\vec{i}}` is just the same vector, reduced to a subsystem
+        and :math:`R_{\vec{i}}` is just the same vector, reduced to a subsystem
         specified by :math:`\vec{i}`.
 
         Args:

--- a/piquasso/_backends/gaussian/transformations.py
+++ b/piquasso/_backends/gaussian/transformations.py
@@ -30,7 +30,7 @@ def quad_transformation(d):
 
     .. math::
 
-        T \hat{Y} = T (x_1, \dots, x_d, p_1, \dots, p_d)^T
+        T Y = T (x_1, \dots, x_d, p_1, \dots, p_d)^T
             = (x_1, p_1, \dots, x_d, p_d)^T,
 
     which is very helpful in :mod:`piquasso._backends.gaussian.state`.

--- a/piquasso/instructions/gates.py
+++ b/piquasso/instructions/gates.py
@@ -14,33 +14,32 @@
 # limitations under the License.
 
 r"""
-Gates can be characterized by a unitary operator :math:`\hat{U}`, which evolves the
+Gates can be characterized by a unitary operator :math:`U`, which evolves the
 quantum state in the following manner
 
 .. math::
-    \rho' = \hat{U} \rho \hat{U}^\dagger
+    \rho' = U \rho U^\dagger
 
 Gates with at most quadratic Hamiltonians are called linear gates. Evolution of the
 ladder operators by linear gates could be expressed in the form
 
 .. math::
 
-    \hat{U} \hat{\xi} \hat{U}^\dagger = S_{(c)} \hat{\xi} + \vec{d},
+    U \xi U^\dagger = S_{(c)} \xi + d,
 
 where :math:`S_{(c)} \in \operatorname{Sp}(2d, \mathbb{R})`,
-:math:`\vec{d} \in \mathbb{C}^{2d}`,
+:math:`d \in \mathbb{C}^{2d}`,
 
 .. math::
-    \hat{\xi} = \begin{bmatrix}
-        \hat{a} \\
-        \hat{a}^\dagger
-    \end{bmatrix},
+    \xi = \begin{bmatrix}
+        a_1, \dots, a_d, a_1^\dagger, \dots, a_d^\dagger
+    \end{bmatrix}^T,
 
-where :math:`\hat{a}^\dagger` and :math:`\hat{a}` are the multimode creation and
-annihilation operators, respectively.
+where :math:`a_1^\dagger, ..., a_d^\dagger` and :math:`a_1, \dots, a_d` are the
+creation and annihilation operators, respectively.
 
 Most of the gates defined here are linear gates, which can be characterized by
-:math:`S_{(c)}` and :math:`\vec{d}`.
+:math:`S_{(c)}` and :math:`d`.
 """
 
 import numpy as np
@@ -132,12 +131,16 @@ class Interferometer(_BogoliubovTransformation):
     The general unitary operator can be written as
 
     .. math::
-        \hat{U} = \exp ( i \hat{a}^dagger H \hat{a} ),
+        U = \exp \left (
+            i \sum_{i, j = 1}^d H_{i j} a_i^\dagger a_j
+        \right ),
 
     where the parameter `U` and :math:`H` is related by
 
     .. math::
-        U = \exp ( i H ).
+        U = \exp \left (
+            i H \right
+        ).
 
     The evolution of the ladder operators can be described by
 
@@ -172,10 +175,10 @@ class Beamsplitter(_BogoliubovTransformation):
     The general unitary operator can be written as
 
     .. math::
-        \hat{U} = \exp (
-            \theta e^{i \phi} \hat{a}^\dagger_i \hat{a}_j
-            - \theta e^{- i \phi} \hat{a}^\dagger_j \hat{a}_i
-        ).
+        BS_{ij} (\theta, \phi) = \exp \left (
+            \theta e^{i \phi} a^\dagger_i a_j
+            - \theta e^{- i \phi} a^\dagger_j a_i
+        \right ).
 
     The symplectic representation of the beamsplitter gate is
 
@@ -217,10 +220,13 @@ class Beamsplitter(_BogoliubovTransformation):
 class Phaseshifter(_ScalableBogoliubovTransformation):
     r"""Applies a rotation or phaseshifter gate.
 
-    The unitary operator corresponding to the phaseshifter gate is
+    The unitary operator corresponding to the phaseshifter gate on the :math:`i`-th mode
+    is
 
     .. math::
-        \hat{U} = \exp ( i \phi \hat{a}^\dagger \hat{a} ).
+        R_i (\phi) = \exp \left (
+            i \phi a_i^\dagger a_i
+        \right ).
 
     The symplectic representation of the phaseshifter gate is
 
@@ -287,10 +293,12 @@ class MachZehnder(_BogoliubovTransformation):
 class Fourier(_ScalableBogoliubovTransformation):
     r"""Applies a Fourier gate.
 
-    The unitary operator corresponding to the Fourier gate is
+    The unitary operator corresponding to the Fourier gate on the :math:`i`-th mode is
 
     .. math::
-        \hat{U} = \exp ( i \frac{\pi}{2} \hat{a}^\dagger \hat{a} ).
+        F_{i} = \exp \left (
+            i \frac{\pi}{2} a_i^\dagger a_i
+        \right ).
 
     The symplectic representation of the Fourier gate is
 
@@ -361,7 +369,9 @@ class Squeezing(_ScalableBogoliubovTransformation):
     The unitary operator corresponding to the squeezing gate is
 
     .. math::
-        \hat{U} = \exp ( \frac{1}{2}(z^* \hat{a}^2 - z \hat{a}^{\dagger 2} ).
+        S_{i} (z) = \exp \left (
+            \frac{1}{2}(z^* a_i^2 - z a_i^{\dagger 2} )
+        \right ).
 
     The symplectic representation of the squeezing gate is
 
@@ -374,7 +384,9 @@ class Squeezing(_ScalableBogoliubovTransformation):
     The unitary squeezing operator is
 
     .. math::
-        S(z) = \exp ( \frac{1}{2}(z^* a^2 -z a^{\dagger 2} ),
+        S(z) = \exp \left (
+            \frac{1}{2}(z^* a_i^2 - z a_i^{\dagger 2})
+        \right ),
 
     where :math:`z \in \mathbb{C}^{d \times d}` is a symmetric matrix.
 
@@ -402,9 +414,9 @@ class QuadraticPhase(_ScalableBogoliubovTransformation):
     The unitary operator corresponding to the Fourier gate is
 
     .. math::
-        \hat{U} = \exp (
-            i \frac{s}{2 \hbar} \hat{x}^2
-        ).
+        QP_{i} (s) = \exp \left (
+            i \frac{s}{2 \hbar} x_i^2
+        \right ).
 
     The symplectic representation of the quadratic phase gate is
 
@@ -430,8 +442,10 @@ class Squeezing2(_BogoliubovTransformation):
 
     The unitary operator corresponding to the two-mode squeezing gate is
 
-      .. math::
-        \hat{U} = \exp ( \frac{1}{2}(z^* \hat{a}^2 - z \hat{a}^{\dagger 2} ).
+    .. math::
+        S_{ij} (z) = \exp \left (
+            \frac{1}{2}(z^* a_i a_j - z a_i^\dagger a_j^\dagger )
+        \right ).
 
     The symplectic representation of the two-mode squeezing gate is
 
@@ -473,7 +487,9 @@ class ControlledX(_BogoliubovTransformation):
     The unitary operator corresponding to the controlled X gate is
 
     .. math::
-        \hat{U} = \exp ( -i \frac{s}{\hbar} \hat{x}_i \hat{p}_j ).
+        CX_{ij} (s) = \exp \left (
+            -i \frac{s}{\hbar} x_i p_j
+        \right ).
 
     The symplectic representation of the controlled X gate is
 
@@ -511,7 +527,9 @@ class ControlledZ(_BogoliubovTransformation):
     The unitary operator corresponding to the controlled Z gate is
 
     .. math::
-        \hat{U} = \exp ( -i \frac{s}{\hbar} \hat{x}_i \hat{x}_j ).
+        CZ_{ij} (s) = \exp \left (
+            -i \frac{s}{\hbar} x_i x_j
+        \right ).
 
     The symplectic representation of the controlled Z gate is
 
@@ -548,7 +566,10 @@ class Displacement(_ScalableBogoliubovTransformation):
     Evolves the ladder operators by
 
     .. math::
-        \hat{\xi} \mapsto \hat{\xi} + \begin{bmatrix} \alpha \\ \alpha^* \end{bmatrix},
+        \xi \mapsto \xi + \begin{bmatrix}
+            \alpha \\
+            \alpha^*
+        \end{bmatrix},
 
     where :math:`\alpha \in \mathbb{C}^{d \times d}`.
 
@@ -556,7 +577,9 @@ class Displacement(_ScalableBogoliubovTransformation):
     When `r` and `phi` are the given parameters, `alpha` is calculated via:
 
     .. math:
-        \alpha = r \exp(i \phi).
+        \alpha = r \exp \left (
+            i \phi
+        \right ).
 
     Args:
         alpha (complex): The displacement.
@@ -611,7 +634,9 @@ class Kerr(Instruction):
         :class:`~piquasso._backends.gaussian.state.GaussianState`.
 
     .. math::
-        K(\xi) = \exp(i \xi \hat{n} \hat{n})
+        K_i (\xi) = \exp \left (
+            i \xi n_i n_i
+        \right )
 
     .. math::
         K(\xi) a K(\xi) = a \exp(- i \xi (1 + 2 n))
@@ -632,11 +657,13 @@ class CrossKerr(Instruction):
         :class:`~piquasso._backends.gaussian.state.GaussianState`.
 
     .. math::
-        CK(\xi) = \exp(i \xi \hat{n}_i \hat{n}_j)
+        CK_{ij} (\xi) = \exp \left (
+            i \xi n_i n_j
+        \right )
 
     .. math::
-        CK(\xi) a_i CK(\xi) &= a_i \exp(- i \xi n_j) \\
-        CK(\xi) a_j CK(\xi) &= a_j \exp(- i \xi n_i)
+        CK_{ij} (\xi) a_i CK_{ij} (\xi) &= a_i \exp(- i \xi n_j) \\
+        CK_{ij} (\xi) a_j CK_{ij} (\xi) &= a_j \exp(- i \xi n_i)
 
     Args:
         xi (float): The magnitude of the Cross-Kerr nonlinear term.
@@ -707,7 +734,7 @@ class Graph(Instruction):
         For a squeezed state :math:`rho` the mean photon number is calculated by
 
         .. math::
-            \langle \hat{n} \rangle_\rho = \sum_{i = 0}^d \mathrm{sinh}(r_i)^2
+            \langle n \rangle_\rho = \sum_{i = 0}^d \mathrm{sinh}(r_i)^2
 
         where :math:`r_i = \mathrm{arctan}(s_i)`, where :math:`s_i` are the singular
         values of the adjacency matrix.

--- a/piquasso/instructions/measurements.py
+++ b/piquasso/instructions/measurements.py
@@ -13,34 +13,126 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""
+.. note::
+
+   When multiple shots are specified and the evolution of the choses simulated state is
+   possible, the measurement outcome corresponding to the last shot is used to evolve
+   the state.
+
+"""
+
 import numpy as np
 
 from piquasso.api.instruction import Instruction
 
 
 class ParticleNumberMeasurement(Instruction):
-    """Particle number measurement."""
+    r"""Particle number measurement.
+
+    A non-Gaussian projective measurement with the probability density given by
+
+    .. math::
+        p(n) = \operatorname{Tr} \left [ \rho | n \rangle \langle n | \right ]
+
+
+    The generated samples are non-negative integer values corresponding to the detected
+    photon number.
+
+    .. note::
+
+        When used with :class:`~piquasso._backends.gaussian.state.GaussianState`, the
+        state is not evolved, since that would be non-Gaussian.
+
+    Args:
+        cutoff (int): The Fock space cutoff.
+        shots (int): The number of samples to generate.
+    """
 
     def __init__(self, cutoff=5, shots=1):
         super().__init__(cutoff=cutoff, shots=shots)
 
 
 class ThresholdMeasurement(Instruction):
-    """Threshold measurement."""
+    """Threshold measurement.
+
+    Similar to :class:`ParticleNumberMeasurement`, but only measuring whether or not
+    the measured mode contains any photon.
+
+    The generated samples contain :math:`0` or :math:`1`, where :math:`0` corresponds to
+    no photon being detected, and :math:`1` corresponds to detection of at least one
+    photon.
+
+    Args:
+        shots (int): The number of samples to generate.
+    """
 
     def __init__(self, shots=1):
         super().__init__(shots=shots)
 
 
 class GeneraldyneMeasurement(Instruction):
-    """General-dyne measurement."""
+    r"""General-dyne measurement.
 
-    def __init__(self, detection_covariance, *, shots=1):
+    The probability density is given by
+
+    .. math::
+        p(r_m) = \frac{
+            \exp \left (
+                (r_m - r)^T
+                \frac{1}{\sigma + \sigma_m}
+                (r_m - r)
+            \right )
+        }{
+            \pi^d \sqrt{ \operatorname{det} (\sigma + \sigma_m) }
+        },
+
+    where :math:`r_m \in \mathbb{C}^d`, :math:`\sigma` is the covariance matrix of the
+    current state, :math:`r \in \mathbb{C}^d` is the first moment of the current state,
+    and :math:`\sigma_m` is the covariance corresponding to a non-displaced Gaussian
+    state characterizing the general-dyne detection. Notably, the heterodyne detection
+    would correspond to a non-displaced Gaussian state with covariance
+    :math:`\sigma_m = I_{d \times d}`.
+
+    Args:
+        detection_covariance (numpy.ndarray):
+            A 2-by-2 symplectic matrix corresponding to a purely quadratic Hamiltonian.
+        shots (int): The number of samples to generate.
+    """
+
+    def __init__(self, detection_covariance, shots=1):
         super().__init__(detection_covariance=detection_covariance, shots=shots)
 
 
 class HomodyneMeasurement(Instruction):
-    """Homodyne measurement."""
+    r"""Homodyne measurement.
+
+    Corresponds to measurement of the quadrature operator
+
+    .. math::
+        \hat{x}_{\phi} = \cos \phi \hat{x} + \sin \phi \hat{p}
+
+    with outcome probability density given by
+
+    .. math::
+        p(x_{\phi}) = \langle x_{\phi} | \rho | x_{\phi} \rangle,
+
+    where :math:`x_{\phi}` correspond to the eigenvalues of :math:`\hat{x}_{\phi}`.
+
+    In optical setups, the measurement is performed by mixing the state :math:`\rho`
+    with a strong coherent state :math:`| \alpha \rangle`, where :math:`\alpha >> 1`,
+    then subtracting the detected intensities of the two outputs.
+    The mixing is performed with a 50:50 beamsplitter.
+
+    Args:
+        phi (float): Phase space rotation angle.
+        z (float):
+            Squeezing amplitude. In the limit of `z` going to infinity one would recover
+            the pure homodyne measurement in the so-called strong oscillator limit.
+            Conversely, setting `z = 1` would correspond to
+            :class:`HeterodyneMeasurement`.
+        shots (int): The number of samples to generate.
+    """
 
     def __init__(self, phi=0.0, z=1e-4, shots=1):
         super().__init__(
@@ -56,7 +148,23 @@ class HomodyneMeasurement(Instruction):
 
 
 class HeterodyneMeasurement(GeneraldyneMeasurement):
-    """Heterodyne measurement."""
+    r"""Heterodyne measurement.
+
+    The probability density is given by
+
+    .. math::
+        p(x_{\phi}) = \frac{1}{\pi} \operatorname{Tr} (
+            \rho | \alpha \rangle \langle \alpha |
+        ).
+
+    In optical setups, the measurement is performed by mixing the state :math:`\rho`
+    with a vacuum state :math:`| 0 \rangle`, then subtracting the detected intensities
+    of the two outputs.
+    The mixing is performed with a 50:50 beamsplitter.
+
+    Args:
+        shots (int): The number of samples to generate.
+    """
 
     def __init__(self, shots=1):
         super().__init__(


### PR DESCRIPTION
The LaTeX `\hat{}` commands were omitted in `gates.py` where possible to
improve readability, and some smaller fixes got included.

Docstrings in `measurements.py` also got written.

In `GeneraldyneMeasurement` the enforcing of keyword arguments got
deleted, since we don't want to force the users to use them.