### PR TITLE
fix(backend=sampling): BoSS update, gate fix

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,6 +1,6 @@
 [flake8]
 # Longer line-length is more convenient for math
 max-line-length = 88
-exclude = .tox,pennylane
+exclude = .tox,pennylane,.venv
 extend-ignore = W605,  # Ignoring latex syntax in docstrings
                 E201   # Ignoring whitespace after '(' or '[' for matrices

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     url="https://github.com/Budapest-Quantum-Computing-Group/piquasso",
     keywords=["python", "piquasso"],
     install_requires=[
-        'boss-tomev==1.0.2; python_version >= "3.6"',
+        'boss-tomev==1.0.4; python_version >= "3.6"',
         'numpy>=1.19.5; python_version >= "3.6"',
         'scipy>=1.5.4; python_version >= "3.6"',
         'quantum-blackbird==0.2.4',

--- a/tests/backends/sampling/test_state.py
+++ b/tests/backends/sampling/test_state.py
@@ -125,16 +125,27 @@ class TestSamplingState:
 
         assert np.allclose(program.state.interferometer, expected_interferometer)
 
-    def test_distribution(self):
-        input_state = pq.SamplingState(1, 1, 0)
+    def test_probability_distribution(self):
+        U = np.array(
+            [
+                [1, 0, 0],
+                [0, -0.54687158 + 0.07993182j, 0.32028583 - 0.76938896j],
+                [0, 0.78696803 + 0.27426941j, 0.42419041 - 0.35428818j]
+            ],
+        )
 
-        U = np.asarray([[1, 0, 0],
-                        [0, -0.54687158 + 0.07993182j, 0.32028583 - 0.76938896j],
-                        [0, 0.78696803 + 0.27426941j, 0.42419041 - 0.35428818j]])
+        with pq.Program() as program:
+            pq.Q() | pq.SamplingState(1, 1, 0)
 
-        input_state.interferometer = U
+            pq.Q(all) | pq.Interferometer(U)
 
-        probabilities = input_state.get_fock_probabilities()
-        expected_result = [0.0, 0.30545762086020883, 0.6945423895038292, 0.0, 0.0, 0.0]
+        program.execute()
 
-        assert np.allclose(probabilities, expected_result)
+        assert np.allclose(
+            program.state.get_fock_probabilities(),
+            [
+                0.0,
+                0.0, 0.0, 0.0,
+                0.0, 0.0, 0.0, 0.6945423895038292, 0.30545762086020883, 0.0
+            ],
+        )


### PR DESCRIPTION
There was an issue in BoSS, which got fixed in the `1.0.4` release, the
`setup.py` got updated accordingly.

There was an issue with the gate matrix application: one has to embed
the subspace of application in an identity and *then* apply it to the
whole interferometer, rather than just multiply the matrix on the
subspace. The two give different results, and the first is the good
solution.

The method `SamplingState.get_fock_probabilities()` got rewritten to
match the outputs of the other `*State.get_fock_probabilities()`
methods.

A bunch of tests have been written testing the equivalence of the
`SamplingState` and the `PureFockState`.

(+ Minor fix: `.venv` has been added to `.flake8`'s excluded
directories.)

Resolves #18