### PR TITLE
fix(gaussian): Improve numerical stability

### DIFF
--- a/piquasso/_backends/gaussian/state.py
+++ b/piquasso/_backends/gaussian/state.py
@@ -687,11 +687,13 @@ class GaussianState(State):
         @lru_cache(maxsize=None)
         def get_probability(*, subspace_modes, occupation_numbers):
             reduced_state = self.reduced(subspace_modes)
-            return calculation(
+            probability = calculation(
                 reduced_state,
                 subspace_modes,
                 occupation_numbers,
             )
+
+            return max(probability, 0.0)
 
         samples = []
 


### PR DESCRIPTION
The `ParticleNumberMeasurement` instruction had issues, since the
probability could turn out to be *slightly* less than 0.0 due to
numerical inaccuracies. The following calculations expect the
probabilities to be positive. Getting some negative probabilities could
result in errors rarely, when the `choice` turned out to be `None` due
to the fact that a non-increasing sequence of numbers are passed as
cumulative distribution to `choose_from_cumulated_probabilities`.

To resolve this issue, the positivity of probabilities are enforced in
`get_probability`.