### PR TITLE
feat(GaussianState): Quadratic polynomial first moment

### DIFF
--- a/piquasso/_backends/gaussian/state.py
+++ b/piquasso/_backends/gaussian/state.py
@@ -23,7 +23,7 @@ from scipy.special import factorial
 
 from piquasso.api.state import State
 from piquasso.api import constants
-from piquasso.api.errors import InvalidState
+from piquasso.api.errors import InvalidState, InvalidParameter
 from piquasso._math.functions import gaussian_wigner_function
 from piquasso._math.linalg import (
     is_symmetric,
@@ -508,6 +508,57 @@ class GaussianState(State):
         transformed_state = self.reduced(modes).rotated(phi)
 
         return transformed_state.mean, transformed_state.cov
+
+    def quadratic_polynomial_expectation(self, A, b, c=0.0, phi=0.0):
+        r"""The expectation value of the specified quadratic polynomial.
+
+        A quadratic polynomial can be written as
+
+        .. math::
+            f(R) = R^T A R + R \cdot b + c,
+
+        where :math:`R = (x_1, p_1, \dots, x_d, p_d)^T` is the vector of the quadrature
+        operators where :math:`d` is the number of modes,
+        :math:`A \in \mathbb{R}^{2d \times 2d}` is a symmetric matrix,
+        :math:`b \in \mathbb{R}^{2d}`, and :math:`c\in\mathbb{R}`.
+
+        This method returns the expectation value :math:`E[f(R)]` using the following
+        equation:
+
+        .. math::
+            \operatorname{E}[f(R)]
+                = \operatorname{Tr}[ A\sigma ] + \mu^T A \mu + \mu^T b + c,
+
+        where :math:`\sigma` is the covariance matrix, :math:`\mu = E[R]` is the mean
+        of the quadrature operators and
+
+        .. math::
+            \operatorname{E}[\cdot] = \operatorname{Tr}[\cdot \rho],
+
+        where :math:`\rho` is the density matrix of the state.
+
+        Args:
+            A (numpy.ndarray):
+                A :math:`2d \times 2d` real symmetric matrix corresponding to the
+                quadratic coefficients, where :math:`d` is the number of modes.
+            b (numpy.ndarray):
+                A one-dimensional :math:`2d`-length real-valued vector that corresponds
+                to the first order terms of the quadratic polynomial.
+            c (float): The constant term in the quadratic polynomial. Defaults to `0`.
+            phi (float): Rotation angle, by which the state is rotated. Defaults to `0`.
+        Returns:
+            float: The expectation value of the quadratic polynomial.
+        """
+
+        if not is_symmetric(A):
+            raise InvalidParameter("The specified matrix is not symmetric.")
+
+        state = self.rotated(phi)
+        mean = state.mean
+        cov = state.cov
+        first_moment = np.trace(A @ cov) / 2 + mean @ A @ mean + mean @ b + c
+        # TODO: calculate the variance.
+        return first_moment
 
     def wigner_function(self, quadrature_matrix, modes=None):
         r"""

--- a/tests/backends/gaussian/test_state.py
+++ b/tests/backends/gaussian/test_state.py
@@ -18,6 +18,7 @@ import numpy as np
 
 import piquasso as pq
 from piquasso.api import constants
+from piquasso.api.errors import InvalidParameter
 
 
 @pytest.fixture
@@ -297,4 +298,53 @@ def test_complex_displacement_do_not_scale_with_HBAR(state):
     assert np.allclose(
         complex_displacement_default_hbar,
         complex_displacement_different_hbar,
+    )
+
+
+def test_quadratic_expectation_with_nonsymmetric_quadratic_coefficients(state):
+    nonsymmetric_quadratic_coefficients = np.array(
+        [
+            [0, 1, 1, 1, 1, 1],
+            [0, 0, 1, 1, 1, 1],
+            [0, 0, 0, 1, 1, 1],
+            [0, 0, 0, 0, 1, 1],
+            [0, 0, 0, 0, 0, 1],
+            [0, 0, 0, 0, 0, 0],
+        ]
+    )
+
+    any_vector = np.empty(2 * state.d)
+
+    with pytest.raises(InvalidParameter):
+        state.quadratic_polynomial_expectation(
+            A=nonsymmetric_quadratic_coefficients,
+            b=any_vector,
+        )
+
+
+def test_quadratic_expectation(state):
+    rotation_angle = np.pi / 3
+    constant_term = 100
+    quadratic_coefficients = np.array(
+        [
+            [0, 1, 2, 0, 2, 0],
+            [1, 0, 0, 1, 0, 1],
+            [2, 0, 0, 0, 0, 0],
+            [0, 1, 0, 0, 0, 0],
+            [2, 0, 0, 0, 0, 0],
+            [0, 1, 0, 0, 0, 0],
+        ]
+    )
+    linear_coefficients = np.ones(2 * state.d)
+
+    expectation_value = state.quadratic_polynomial_expectation(
+        A=quadratic_coefficients,
+        b=linear_coefficients,
+        c=constant_term,
+        phi=rotation_angle,
+    )
+
+    assert np.isclose(
+        expectation_value,
+        97.78556059428445,
     )


### PR DESCRIPTION
A new method called `quadratic_polynomial_expectation` has been
implemented in `gaussian/state.py`.

Test cases has been written accordingly.

Note: The equation for the first moment only works for a symmetric
matrix of the quadratic coefficient matrix. For non-symmetric ones, an
error is raised. One could calculate the expectation values in the 
non-symmetric case which would yield complex values generally, but the 
plugin `pennylane-piquasso` only requires real values.

Resolves #26 