### PR TITLE
refact(*Circuit): Inject State into calculation

### DIFF
--- a/piquasso/_backends/fock/circuit.py
+++ b/piquasso/_backends/fock/circuit.py
@@ -21,36 +21,35 @@ from piquasso.api.circuit import Circuit
 
 class BaseFockCircuit(Circuit, abc.ABC):
 
-    def get_instruction_map(self):
-        return {
-            "Interferometer": self._passive_linear,
-            "Beamsplitter": self._passive_linear,
-            "Phaseshifter": self._passive_linear,
-            "MachZehnder": self._passive_linear,
-            "Fourier": self._passive_linear,
-            "Kerr": self._kerr,
-            "CrossKerr": self._cross_kerr,
-            "Squeezing": self._linear,
-            "QuadraticPhase": self._linear,
-            "Displacement": self._linear,
-            "PositionDisplacement": self._linear,
-            "MomentumDisplacement": self._linear,
-            "Squeezing2": self._linear,
-            "GaussianTransform": self._linear,
-            "ParticleNumberMeasurement": self._particle_number_measurement,
-            "Vacuum": self._vacuum,
-            "Create": self._create,
-            "Annihilate": self._annihilate,
-        }
+    instruction_map = {
+        "Interferometer": "_passive_linear",
+        "Beamsplitter": "_passive_linear",
+        "Phaseshifter": "_passive_linear",
+        "MachZehnder": "_passive_linear",
+        "Fourier": "_passive_linear",
+        "Kerr": "_kerr",
+        "CrossKerr": "_cross_kerr",
+        "Squeezing": "_linear",
+        "QuadraticPhase": "_linear",
+        "Displacement": "_linear",
+        "PositionDisplacement": "_linear",
+        "MomentumDisplacement": "_linear",
+        "Squeezing2": "_linear",
+        "GaussianTransform": "_linear",
+        "ParticleNumberMeasurement": "_particle_number_measurement",
+        "Vacuum": "_vacuum",
+        "Create": "_create",
+        "Annihilate": "_annihilate",
+    }
 
-    def _passive_linear(self, instruction):
-        self.state._apply_passive_linear(
+    def _passive_linear(self, instruction, state):
+        state._apply_passive_linear(
             operator=instruction._all_params["passive_block"],
             modes=instruction.modes
         )
 
-    def _particle_number_measurement(self, instruction):
-        samples = self.state._particle_number_measurement(
+    def _particle_number_measurement(self, instruction, state):
+        samples = state._particle_number_measurement(
             modes=instruction.modes,
             shots=instruction._all_params["shots"],
         )
@@ -58,29 +57,29 @@ class BaseFockCircuit(Circuit, abc.ABC):
         self.update_measured_modes(instruction.modes)
         self.results.append(Result(instruction=instruction, samples=samples))
 
-    def _vacuum(self, instruction):
-        self.state._apply_vacuum()
+    def _vacuum(self, instruction, state):
+        state._apply_vacuum()
 
-    def _create(self, instruction):
-        self.state._apply_creation_operator(instruction.modes)
+    def _create(self, instruction, state):
+        state._apply_creation_operator(instruction.modes)
 
-    def _annihilate(self, instruction):
-        self.state._apply_annihilation_operator(instruction.modes)
+    def _annihilate(self, instruction, state):
+        state._apply_annihilation_operator(instruction.modes)
 
-    def _kerr(self, instruction):
-        self.state._apply_kerr(
+    def _kerr(self, instruction, state):
+        state._apply_kerr(
             **instruction._all_params,
             mode=instruction.modes[0],
         )
 
-    def _cross_kerr(self, instruction):
-        self.state._apply_cross_kerr(
+    def _cross_kerr(self, instruction, state):
+        state._apply_cross_kerr(
             **instruction._all_params,
             modes=instruction.modes,
         )
 
-    def _linear(self, instruction):
-        self.state._apply_linear(
+    def _linear(self, instruction, state):
+        state._apply_linear(
             passive_block=instruction._all_params["passive_block"],
             active_block=instruction._all_params["active_block"],
             displacement=instruction._all_params["displacement_vector"],

--- a/piquasso/_backends/fock/general/circuit.py
+++ b/piquasso/_backends/fock/general/circuit.py
@@ -17,11 +17,11 @@ from ..circuit import BaseFockCircuit
 
 
 class FockCircuit(BaseFockCircuit):
-    def get_instruction_map(self):
-        return {
-            "DensityMatrix": self._density_matrix,
-            **super().get_instruction_map()
-        }
 
-    def _density_matrix(self, instruction):
-        self.state._add_occupation_number_basis(**instruction.params)
+    instruction_map = {
+        "DensityMatrix": "_density_matrix",
+        **BaseFockCircuit.instruction_map
+    }
+
+    def _density_matrix(self, instruction, state):
+        state._add_occupation_number_basis(**instruction.params)

--- a/piquasso/_backends/fock/pnc/circuit.py
+++ b/piquasso/_backends/fock/pnc/circuit.py
@@ -19,35 +19,34 @@ from ..circuit import BaseFockCircuit
 
 
 class PNCFockCircuit(BaseFockCircuit):
-    def get_instruction_map(self):
-        return {
-            "DensityMatrix": self._density_matrix,
-            **super().get_instruction_map()
-        }
+    instruction_map = {
+        "DensityMatrix": "_density_matrix",
+        **BaseFockCircuit.instruction_map
+    }
 
-    def _density_matrix(self, instruction):
-        self.state._add_occupation_number_basis(**instruction.params)
+    def _density_matrix(self, instruction, state):
+        state._add_occupation_number_basis(**instruction.params)
 
-    def _linear(self, instruction):
+    def _linear(self, instruction, state):
         warnings.warn(
             f"Gaussian evolution of the state with instruction {instruction} may not "
-            f"result in the desired state, since state {self.state.__class__} only "
+            f"result in the desired state, since state {state.__class__} only "
             "stores a limited amount of information to handle particle number "
             "conserving instructions.\n"
             "Consider using 'FockState' or 'PureFockState' instead!",
             UserWarning
         )
 
-        super()._linear(instruction)
+        super()._linear(instruction, state)
 
-    def _displacement(self, instruction):
+    def _displacement(self, instruction, state):
         warnings.warn(
             f"Displacing the state with instruction {instruction} may not result in "
-            f"the desired state, since state {self.state.__class__} only stores a "
+            f"the desired state, since state {state.__class__} only stores a "
             "limited amount of information to handle particle number conserving "
             "instructions.\n"
             "Consider using 'FockState' or 'PureFockState' instead!",
             UserWarning
         )
 
-        super()._displacement(instruction)
+        super()._displacement(instruction, state)

--- a/piquasso/_backends/fock/pure/circuit.py
+++ b/piquasso/_backends/fock/pure/circuit.py
@@ -17,14 +17,13 @@ from ..circuit import BaseFockCircuit
 
 
 class PureFockCircuit(BaseFockCircuit):
-    def get_instruction_map(self):
-        return {
-            "StateVector": self._state_vector,
-            **super().get_instruction_map()
-        }
+    instruction_map = {
+        "StateVector": "_state_vector",
+        **BaseFockCircuit.instruction_map
+    }
 
-    def _state_vector(self, instruction):
-        self.state._add_occupation_number_basis(
+    def _state_vector(self, instruction, state):
+        state._add_occupation_number_basis(
             **instruction._all_params,
             modes=instruction.modes,
         )

--- a/piquasso/api/program.py
+++ b/piquasso/api/program.py
@@ -67,7 +67,7 @@ class Program(_mixins.RegisterMixin):
         self._state = new_state
 
         self._circuit = (
-            new_state.circuit_class(new_state, program=self)
+            new_state.circuit_class(program=self)
             if new_state
             else None
         )
@@ -108,7 +108,7 @@ class Program(_mixins.RegisterMixin):
             list[Result]: A list of the execution results.
         """
 
-        return self._circuit.execute_instructions(self.instructions)
+        return self._circuit.execute_instructions(self.instructions, self.state)
 
     @property
     def results(self) -> list:

--- a/tests/api/program/conftest.py
+++ b/tests/api/program/conftest.py
@@ -29,10 +29,9 @@ def setup_plugin():
     class FakeCircuit(pq.Circuit):
         dummy_instruction = Mock(name="dummy_instruction")
 
-        def get_instruction_map(self):
-            return {
-                DummyInstruction.__name__: self.dummy_instruction,
-            }
+        instruction_map = {
+            "DummyInstruction": "dummy_instruction",
+        }
 
     class FakeState(pq.State):
         circuit_class = FakeCircuit

--- a/tests/api/program/test_execution.py
+++ b/tests/api/program/test_execution.py
@@ -23,7 +23,9 @@ def test_instruction_execution(program):
 
     program.execute()
 
-    program._circuit.dummy_instruction.assert_called_once_with(instruction)
+    program._circuit.dummy_instruction.assert_called_once_with(
+        instruction, program.state
+    )
 
 
 def test_register_instruction_from_left_hand_side(program):
@@ -33,4 +35,6 @@ def test_register_instruction_from_left_hand_side(program):
 
     program.execute()
 
-    program._circuit.dummy_instruction.assert_called_once_with(instruction)
+    program._circuit.dummy_instruction.assert_called_once_with(
+        instruction, program.state
+    )

--- a/tests/api/test_parsing.py
+++ b/tests/api/test_parsing.py
@@ -38,10 +38,12 @@ class TestProgramJSONParsing:
     def FakeCircuit(self, FakeInstruction):
 
         class FakeCircuit(pq.Circuit):
-            def get_instruction_map(self):
-                return {
-                    "FakeInstruction": FakeInstruction,
-                }
+            instruction_map = {
+                "FakeInstruction": "_fake_instruction",
+            }
+
+            def _fake_instruction(self, instruction, state):
+                pass
 
         return FakeCircuit
 
@@ -110,8 +112,6 @@ class TestProgramJSONParsing:
 
     def test_instantiation_using_mappings(
         self,
-        FakeState,
-        FakeInstruction,
         state_mapping,
         instructions_mapping,
         number_of_modes,
@@ -141,8 +141,6 @@ class TestProgramJSONParsing:
 
     def test_from_json(
         self,
-        FakeState,
-        FakeInstruction,
         state_mapping,
         instructions_mapping,
         number_of_modes,


### PR DESCRIPTION
**Disclaimer**: This is the first commit of a considerable amount of
refactor.

**Problem**

- The calculations are too tightly coupled to the `State` classes. It
  would be great to loosen the coupling for easier integration with
  `piquassoboost`.

- In `Circuit` methods, private methods are called on a `State` object.
  This violates that single underscore methods are only used in the same
  class. By violating this, refactoring code gets harder;

- The `*State` implementations are huge and difficult to understand;

- In the `*State` classes two fundamentally different things are
  defined: calculations (corresponding to instructions, like
  `_apply_linear()`) and public methods (like `validate()`,
  `normalize()`);

- `get_instruction_map()` is odd, since it is an instance method
  returning information which is available without an instance;

- Both `Program` and `Circuit` has a reference to the actual state,
  which is somewhat confusing and redundant.

**Solution**

The current `state` instance is injected in each method of `Circuit`
corresponding to an `Instruction`.

The `get_instruction_map` is removed in favour of a class attribute
called `instruction_map`, which only refers to the names of the methods
corresponding to instructions. `execute_instructions` is rewritten
accordingly.

To further enforce the state injection, the `state` attribute of
`Circuit` has been deleted. Instead, the `state` instance is passed from
`Program.execute()` to `Circuit.execute_instructions()`.

Some `api`-related tests have been rewritten accordingly.

The `.flake8` configuration has been extended to exclude the `.venv`
folder for convenience.