### PR TITLE
feat(GaussianState): mean photon number

### DIFF
--- a/piquasso/_backends/gaussian/state.py
+++ b/piquasso/_backends/gaussian/state.py
@@ -509,6 +509,36 @@ class GaussianState(State):
 
         return transformed_state.mean, transformed_state.cov
 
+    def mean_photon_number(self, mode):
+        r""" This method returns the mean photon number of the given modes.
+        The mean photon number :math:`\bar{n} = \langle \hat{n}
+        \rangle` can be calculated in terms of the ladder operators by the following
+        expression
+        .. math::
+            \sum_{i=1}^{d} \langle a_{i}^\dagger a_{i} \rangle =
+            \operatorname{Tr}(\rho \hat{n}),
+        where :math:`a`, :math:`a ^\dagger` are the annihilation and the creation
+        operators respectively, :math:`\rho` is the density operator of the
+        currently represented state and :math:`d` is the number of modes. For a general
+        displaced squeezed gaussian state, the mean photon number is
+        .. math::
+            \langle \hat{n} \rangle = \operatorname{Tr}(\langle a^\dagger a \rangle) +
+            \mu_{c}^ \dagger \cdot \mu_{c},
+        where :math:`\mu_{c}` is the :attr:`complex_displacement`.
+        .. note::
+            This method can also be used to return the summation of the mean photon
+            number for multiple modes if the mode parameter contains more than one
+            integer e.g :math:`(0,1,...)`.
+        Args:
+            mode (tuple[int]): The correspoding mode at which the mean photon number is
+                calculated.
+        Returns:
+            float: The expectation value of the photon number.
+        """
+
+        state = self.reduced(mode)
+        return (np.trace(state._C) + state._m.conjugate() @ state._m).real
+
     def quadratic_polynomial_expectation(self, A, b, c=0.0, phi=0.0):
         r"""The expectation value of the specified quadratic polynomial.
 

--- a/tests/backends/gaussian/test_state.py
+++ b/tests/backends/gaussian/test_state.py
@@ -348,3 +348,38 @@ def test_quadratic_expectation(state):
         expectation_value,
         97.78556059428445,
     )
+
+
+def test_mean_photon_number_vaccum():
+    with pq.Program() as program:
+        pq.Q() | pq.GaussianState(d=3)
+
+    program.execute()
+    state = program.state
+
+    assert np.isclose(0., state.mean_photon_number((0, 1, 2)))
+    assert np.isclose(0., state.mean_photon_number((0, 1)))
+    assert np.isclose(0., state.mean_photon_number((0,)))
+
+
+def test_mean_photon_number():
+    alpha = 0.5 + 1j
+    r = 1.
+    phi = 3.
+    with pq.Program() as program:
+        pq.Q() | pq.GaussianState(d=3)
+        pq.Q(0) | pq.Displacement(alpha=alpha)
+        pq.Q(1) | pq.Squeezing(r=r, phi=phi)
+        pq.Q(2) | pq.Squeezing(r=r, phi=phi)
+        pq.Q(2) | pq.Displacement(alpha=alpha)
+
+    program.execute()
+    state = program.state
+
+    mean_photon_number_first_mode = np.abs(alpha)**2
+    mean_photon_number_second_mode = np.sinh(r)**2
+    total_mean_photon_number = 2 * (np.abs(alpha)**2 + np.sinh(r)**2)
+
+    assert np.isclose(mean_photon_number_first_mode, state.mean_photon_number((0,)))
+    assert np.isclose(mean_photon_number_second_mode, state.mean_photon_number((1,)))
+    assert np.isclose(total_mean_photon_number, state.mean_photon_number((0, 1, 2)))


### PR DESCRIPTION
A new method called `mean_photon_number` has been
implemented in `gaussian/state.py`.

Test cases has been written accordingly.
This method is needed for the pennylane-piquasso plugin

Resolves #31