### PR TITLE
feat(backend=fock): Reduced states

### DIFF
--- a/piquasso/_backends/fock/pnc/state.py
+++ b/piquasso/_backends/fock/pnc/state.py
@@ -18,6 +18,7 @@ import numpy as np
 from piquasso.api.errors import InvalidState
 
 from ..state import BaseFockState
+from ..general.state import FockState
 
 from .circuit import PNCFockCircuit
 
@@ -237,6 +238,16 @@ class PNCFockState(BaseFockState):
             np.allclose(subrep, other._representation[n])
             for n, subrep in enumerate(self._representation)
         ])
+
+    @property
+    def density_matrix(self):
+        return block_diag(*self._representation)
+
+    def _as_mixed(self):
+        return FockState.from_fock_state(self)
+
+    def reduced(self, modes):
+        return self._as_mixed().reduced(modes)
 
     def get_fock_probabilities(self, cutoff=None):
         cutoff = cutoff or self._space.cutoff

--- a/piquasso/_backends/fock/pure/state.py
+++ b/piquasso/_backends/fock/pure/state.py
@@ -19,6 +19,7 @@ from piquasso.api.errors import InvalidState
 from piquasso._math.fock import cutoff_cardinality
 
 from ..state import BaseFockState
+from ..general.state import FockState
 
 from .circuit import PureFockCircuit
 
@@ -175,6 +176,17 @@ class PureFockState(BaseFockState):
 
     def __eq__(self, other):
         return np.allclose(self._state_vector, other._state_vector)
+
+    @property
+    def density_matrix(self):
+        state_vector = self._state_vector
+        return np.outer(state_vector, state_vector)
+
+    def _as_mixed(self):
+        return FockState.from_fock_state(self)
+
+    def reduced(self, modes):
+        return self._as_mixed().reduced(modes)
 
     def get_fock_probabilities(self, cutoff=None):
         cutoff = cutoff or self._space.cutoff

--- a/piquasso/_backends/fock/state.py
+++ b/piquasso/_backends/fock/state.py
@@ -141,6 +141,18 @@ class BaseFockState(State, abc.ABC):
     def nonzero_elements(self):
         pass
 
+    @property
+    @abc.abstractmethod
+    def density_matrix(self):
+        """The density matrix of the state in terms of Fock basis vectors."""
+        pass
+
+    @property
+    @abc.abstractmethod
+    def reduced(self, modes):
+        """Reduces the state to a subsystem corresponding to the specified modes."""
+        pass
+
     @abc.abstractmethod
     def get_fock_probabilities(self, cutoff):
         pass

--- a/tests/backends/fock/general_and_pnc/test_state.py
+++ b/tests/backends/fock/general_and_pnc/test_state.py
@@ -1,0 +1,52 @@
+#
+# Copyright 2021 Budapest Quantum Computing Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+import numpy as np
+
+import piquasso as pq
+
+
+@pytest.mark.parametrize("StateClass", (pq.FockState, pq.PNCFockState))
+def test_FockState_reduced(StateClass):
+    with pq.Program() as program:
+        pq.Q() | StateClass(d=2, cutoff=3)
+
+        pq.Q() | pq.DensityMatrix(ket=(0, 1), bra=(0, 1)) / 4
+
+        pq.Q() | pq.DensityMatrix(ket=(0, 2), bra=(0, 2)) / 4
+        pq.Q() | pq.DensityMatrix(ket=(2, 0), bra=(2, 0)) / 2
+
+        pq.Q() | pq.DensityMatrix(ket=(0, 2), bra=(2, 0)) * np.sqrt(1/8)
+        pq.Q() | pq.DensityMatrix(ket=(2, 0), bra=(0, 2)) * np.sqrt(1/8)
+
+    program.execute()
+
+    with pq.Program() as reduced_program:
+        pq.Q() | pq.FockState(d=1, cutoff=3)
+
+        pq.Q() | pq.DensityMatrix(ket=(1, ), bra=(1, )) / 4
+
+        pq.Q() | pq.DensityMatrix(ket=(2, ), bra=(2, )) / 4
+        pq.Q() | pq.DensityMatrix(ket=(0, ), bra=(0, )) / 2
+
+    reduced_program.execute()
+
+    expected_reduced_state = reduced_program.state
+
+    reduced_state = program.state.reduced(modes=(1, ))
+
+    assert expected_reduced_state == reduced_state

--- a/tests/backends/fock/pure/test_state.py
+++ b/tests/backends/fock/pure/test_state.py
@@ -1,0 +1,49 @@
+#
+# Copyright 2021 Budapest Quantum Computing Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+
+import piquasso as pq
+
+
+def test_PureFockState_reduced():
+    with pq.Program() as program:
+        pq.Q() | pq.PureFockState(d=2, cutoff=3)
+
+        pq.Q() | pq.StateVector(0, 1) / 2
+
+        pq.Q() | pq.StateVector(0, 2) / 2
+        pq.Q() | pq.StateVector(2, 0) / np.sqrt(2)
+
+    program.execute()
+
+    with pq.Program() as reduced_program:
+        pq.Q() | pq.FockState(d=1, cutoff=3)
+
+        pq.Q() | pq.DensityMatrix(ket=(0, ), bra=(0, )) / 2
+
+        pq.Q() | pq.DensityMatrix(ket=(1, ), bra=(1, )) / 4
+        pq.Q() | pq.DensityMatrix(ket=(2, ), bra=(2, )) / 4
+
+        pq.Q() | pq.DensityMatrix(ket=(1, ), bra=(2, )) / 4
+        pq.Q() | pq.DensityMatrix(ket=(2, ), bra=(1, )) / 4
+
+    reduced_program.execute()
+
+    expected_reduced_state = reduced_program.state
+
+    reduced_state = program.state.reduced(modes=(1, ))
+
+    assert expected_reduced_state == reduced_state

--- a/tests/backends/fock/test_preparations.py
+++ b/tests/backends/fock/test_preparations.py
@@ -18,7 +18,7 @@ import numpy as np
 import piquasso as pq
 
 
-def test_from_pure_preserves_fock_probabilities():
+def test_from_fock_state_preserves_fock_probabilities():
     with pq.Program() as pure_state_preparation:
         pq.Q() | pq.PureFockState(d=2, cutoff=4)
 
@@ -34,7 +34,7 @@ def test_from_pure_preserves_fock_probabilities():
         pq.Q(0, 1) | beamsplitter
 
     with pq.Program() as mixed_state_program:
-        pq.Q() | pq.FockState.from_pure(pure_state_preparation.state)
+        pq.Q() | pq.FockState.from_fock_state(pure_state_preparation.state)
 
         pq.Q(0, 1) | beamsplitter
 


### PR DESCRIPTION
The method `reduced` got implemented for the `*FockState` classes. The
reduction is implemented by partial tracing the density matrix in the
`FockState`.

Generally, when partial tracing a pure state, the resulting state is
mixed. Therefore, before reducing a `PureFockState`, one should convert
it to a `FockState`. The same could also be said about the
`PNCFockState`.

The `from_pure` has to be reimplemented to work with any `BaseFockState`
subclass instance. Thereby it got renamed to `from_fock_state`.