### PR TITLE
fix(gaussian): Convenient Wigner function inputs

### DIFF
--- a/piquasso/_backends/gaussian/state.py
+++ b/piquasso/_backends/gaussian/state.py
@@ -596,10 +596,10 @@ class GaussianState(State):
         # TODO: calculate the variance.
         return first_moment
 
-    def wigner_function(self, quadrature_matrix, modes=None):
+    def wigner_function(self, positions: list, momentums: list, modes=None):
         r"""
-        Calculates the Wigner function values at the specified `quadrature_matrix`,
-        according to the equation
+        Calculates the Wigner function values at the specified position and momentum
+        vectors, according to the equation
 
         .. math::
             W(r) = \frac{1}{\pi^d \sqrt{\mathrm{det} \sigma}}
@@ -610,26 +610,30 @@ class GaussianState(State):
                 \big ).
 
         Args:
-            quadrature_matrix (list[numpy.ndarray]):
-                List of canonical coordinate vectors.
+            positions (list[list[float]]): List of position vectors.
+            momentums (list[list[float]]): List of momentum vectors.
             modes (tuple[int], optional):
                 Modes where Wigner function should be calculcated.
 
         Returns:
-            list[float]: The Wigner function values in the shape of `quadrature_matrix`.
+            numpy.ndarray:
+                The Wigner function values in the shape of a grid specified by the
+                input.
         """
 
         if modes:
             reduced_state = self.reduced(modes)
             return gaussian_wigner_function(
-                quadrature_matrix,
+                positions,
+                momentums,
                 d=reduced_state.d,
                 mean=reduced_state.mean,
                 cov=reduced_state.cov
             )
 
         return gaussian_wigner_function(
-            quadrature_matrix,
+            positions,
+            momentums,
             d=self.d,
             mean=self.mean,
             cov=self.cov,

--- a/piquasso/_math/functions.py
+++ b/piquasso/_math/functions.py
@@ -16,16 +16,20 @@
 import numpy as np
 
 
-def gaussian_wigner_function(quadrature_matrix, *, d, mean, cov):
-    assert len(quadrature_matrix[0]) == len(mean), (
-        "'quadrature_matrix' elements should have the same dimension as 'mean': "
-        f"dim(quadrature_matrix[0])={len(quadrature_matrix[0])}, dim(mean)={len(mean)}."
-    )
+def gaussian_wigner_function(positions, momentums, *, d, mean, cov):
+    result = []
 
-    return [
-        gaussian_wigner_function_for_scalar(quadrature_array, d=d, mean=mean, cov=cov)
-        for quadrature_array in quadrature_matrix
-    ]
+    for position in positions:
+        result.append(
+            [
+                gaussian_wigner_function_for_scalar(
+                    [*position, *momentum], d=d, mean=mean, cov=cov
+                )
+                for momentum in momentums
+            ]
+        )
+
+    return np.array(result)
 
 
 def gaussian_wigner_function_for_scalar(X, *, d, mean, cov):

--- a/tests/_math/test_functions.py
+++ b/tests/_math/test_functions.py
@@ -55,24 +55,19 @@ def test_wigner_function_at_scalar(d, mean, cov):
 
 
 def test_gaussian_wigner_function_handles_vectors(d, mean, cov):
-    quadrature_matrix = np.array(
-        [
-            [1, 2],
-            [3, 4],
-            [5, 6],
-        ]
-    )
+    positions = [[1.0], [3.0], [5.0]]
+    momentums = [[2.0], [4.0], [6.0]]
 
     expected = np.array(
         [
-            0.10065842420897406,
-            0.009131526225575573,
-            6.81746788883418e-06,
-        ],
+            [0.10065842420897406, 0.0674733595496344, 0.020322585354620785],
+            [0.020322585354620785, 0.009131526225575573, 0.001843623348920587],
+            [0.00016724973685064803, 5.0374652683254064e-05, 6.81746788883418e-06]
+        ]
     )
 
     actual = gaussian_wigner_function(
-        quadrature_matrix, d=d, mean=mean, cov=cov
+        positions, momentums, d=d, mean=mean, cov=cov
     )
 
     assert np.allclose(expected, actual)

--- a/tests/backends/gaussian/test_state.py
+++ b/tests/backends/gaussian/test_state.py
@@ -87,14 +87,10 @@ def test_representation_roundtrip_at_different_HBAR(state):
 
 
 def test_wigner_function(state, assets):
-    quadrature_array = np.array(
-        [
-            [1, 2, 3, 4, 5, 6],
-            [5, 6, 7, 8, 9, 0],
-        ]
+    actual_result = state.wigner_function(
+        positions=[[1.0, 3.0, 5.0], [5.0, 7.0, 9.0]],
+        momentums=[[2.0, 4.0, 6.0], [6.0, 8.0, 0.0]],
     )
-
-    actual_result = state.wigner_function(quadrature_array)
 
     expected_result = assets.load("expected_wigner_function_result")
 


### PR DESCRIPTION
The inputs of the Wigner function in `GaussianState` should be specified as
separate position and momentum values instead of an array of (x,p) pairs. This
method is more logical, since the wigner function calculation is mostly needed
for plotting, where a grid spanned by the position and momentum values are displayed.

With this logic, less data processing is needed in `piquasso-ui`, and less
amount of data needs to be passed, rendering the calculation faster.

Since the Wigner function can have multidimensional inputs (x, p
coordinates), a list of list has to be specified as `positions` and
`momentums` arguments.