### PR TITLE
feat(constants): `cache_size`

### DIFF
--- a/piquasso/_backends/gaussian/state.py
+++ b/piquasso/_backends/gaussian/state.py
@@ -840,7 +840,7 @@ class GaussianState(State):
         shots,
         calculation,
     ):
-        @lru_cache(maxsize=None)
+        @lru_cache(constants.cache_size)
         def get_probability(*, subspace_modes, occupation_numbers):
             reduced_state = self.reduced(subspace_modes)
             probability = calculation(

--- a/piquasso/_math/fock.py
+++ b/piquasso/_math/fock.py
@@ -21,6 +21,7 @@ from operator import add
 from scipy.special import factorial, comb
 from scipy.linalg import block_diag
 
+from piquasso.api import constants
 from piquasso._math.combinatorics import partitions
 
 from scipy.linalg import polar, logm, funm
@@ -247,7 +248,7 @@ class FockSpace(tuple):
 
             return elements
 
-        @functools.lru_cache(maxsize=None)
+        @functools.lru_cache(constants.cache_size)
         def calculate_left(upper_bound):
             return get_f_vector(
                 upper_bound=upper_bound,
@@ -255,7 +256,7 @@ class FockSpace(tuple):
                 vector=left_vector,
             )
 
-        @functools.lru_cache(maxsize=None)
+        @functools.lru_cache(constants.cache_size)
         def calculate_right(upper_bound):
             return get_f_vector(
                 upper_bound=upper_bound,

--- a/piquasso/api/constants.py
+++ b/piquasso/api/constants.py
@@ -23,6 +23,8 @@ class _Constants:
 
     _HBAR_DEFAULT = 2
 
+    cache_size = 32
+
     def __init__(self):
         self.reset_hbar()
         self.seed()


### PR DESCRIPTION
Instead of using `maxsize=None` in `lru_cache`, the size of the cache is
inserted from `constants`.

Resolves #28