### PR TITLE
fix: Allow only one measurement

### DIFF
--- a/docs/api/measurement.rst
+++ b/docs/api/measurement.rst
@@ -1,0 +1,5 @@
+Measurement
+-----------
+
+.. automodule:: piquasso.api.measurement
+   :members:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -79,6 +79,7 @@ C++.
    api/mode
    api/state
    api/instruction
+   api/measurement
    api/result
    api/circuit
    api/errors

--- a/docs/tutorials/boson-sampling.ipynb
+++ b/docs/tutorials/boson-sampling.ipynb
@@ -18,7 +18,7 @@
      "output_type": "stream",
      "name": "stdout",
      "text": [
-      "[<Result instruction=<pq.Sampling(modes=(0, 1, 2, 3))> samples=[array([1, 0, 0, 1]), array([0, 1, 0, 1]), array([1, 0, 0, 1]), array([0, 1, 0, 1]), array([1, 0, 0, 1])]>]\n"
+      "<Result instruction=<pq.Sampling(modes=(0, 1, 2, 3))> samples=[array([1, 0, 0, 1]), array([1, 0, 0, 1]), array([1, 0, 0, 1]), array([1, 0, 0, 1]), array([0, 1, 0, 1])]>\n"
      ]
     }
    ],
@@ -36,9 +36,9 @@
     "\n",
     "    pq.Q() | pq.Sampling()\n",
     "\n",
-    "results = program.execute(shots=5)\n",
+    "result = program.execute(shots=5)\n",
     "\n",
-    "print(results)"
+    "print(result)"
    ]
   },
   {
@@ -52,7 +52,7 @@
  "metadata": {
   "kernelspec": {
    "name": "python3",
-   "display_name": "Python 3.8.10 64-bit"
+   "display_name": "Python 3.8.10 64-bit ('.venv': venv)"
   },
   "language_info": {
    "codemirror_mode": {

--- a/docs/tutorials/gaussian-boson-sampling.ipynb
+++ b/docs/tutorials/gaussian-boson-sampling.ipynb
@@ -48,9 +48,9 @@
     "    \n",
     "    pq.Q(all) | pq.ParticleNumberMeasurement()\n",
     "\n",
-    "results = gaussian_boson_sampling.execute(shots=shots)\n",
+    "result = gaussian_boson_sampling.execute(shots=shots)\n",
     "\n",
-    "print(\"Samples:\", results[0].samples)"
+    "print(\"Samples:\", result.samples)"
    ]
   },
   {
@@ -76,7 +76,7 @@
     }
    ],
    "source": [
-    "print(\"Subgraphs:\", results[0].to_subgraph_nodes())"
+    "print(\"Subgraphs:\", result.to_subgraph_nodes())"
    ]
   }
  ],

--- a/docs/tutorials/getting-started.ipynb
+++ b/docs/tutorials/getting-started.ipynb
@@ -11,7 +11,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "id": "rational-romantic",
    "metadata": {},
    "outputs": [],
@@ -49,7 +49,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 5,
    "id": "african-george",
    "metadata": {},
    "outputs": [
@@ -57,18 +57,18 @@
      "output_type": "execute_result",
      "data": {
       "text/plain": [
-       "[<Result instruction=<pq.HomodyneMeasurement(phi=0.0, z=0.0001, modes=(0,))> samples=[[ 2.60779043e+00  1.11035996e+04]\n",
-       "  [ 2.17113776e+00  2.23263914e+04]\n",
-       "  [ 4.34079919e+00 -8.33029381e+03]]>]"
+       "<Result instruction=<pq.HomodyneMeasurement(phi=0.0, z=0.0001, modes=(0,))> samples=[[ 2.10951348e+00 -4.78395147e+03]\n",
+       " [ 4.84936559e+00  6.14811615e+03]\n",
+       " [ 3.41665880e+00  7.96599665e+03]]>"
       ]
      },
      "metadata": {},
-     "execution_count": 2
+     "execution_count": 5
     }
    ],
    "source": [
-    "results = program.execute(shots=3)\n",
-    "results"
+    "result = program.execute(shots=3)\n",
+    "result"
    ]
   },
   {
@@ -81,38 +81,31 @@
   },
   {
    "source": [
-    "results[0].samples"
+    "result.samples"
    ],
    "cell_type": "code",
    "metadata": {},
-   "execution_count": 3,
+   "execution_count": 6,
    "outputs": [
     {
      "output_type": "execute_result",
      "data": {
       "text/plain": [
-       "array([[ 2.60779043e+00,  1.11035996e+04],\n",
-       "       [ 2.17113776e+00,  2.23263914e+04],\n",
-       "       [ 4.34079919e+00, -8.33029381e+03]])"
+       "array([[ 2.10951348e+00, -4.78395147e+03],\n",
+       "       [ 4.84936559e+00,  6.14811615e+03],\n",
+       "       [ 3.41665880e+00,  7.96599665e+03]])"
       ]
      },
      "metadata": {},
-     "execution_count": 3
+     "execution_count": 6
     }
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
    "name": "python3",
-   "display_name": "Python 3.8.10 64-bit"
+   "display_name": "Python 3.8.10 64-bit ('.venv': venv)"
   },
   "language_info": {
    "codemirror_mode": {

--- a/docs/tutorials/separating-programs.ipynb
+++ b/docs/tutorials/separating-programs.ipynb
@@ -20,7 +20,7 @@
      "output_type": "execute_result",
      "data": {
       "text/plain": [
-       "[<Result instruction=<pq.HeterodyneMeasurement(, modes=(3,))> samples=[[ 3.73527061 -3.5817742 ]]>]"
+       "<Result instruction=<pq.HeterodyneMeasurement(modes=(3,))> samples=[[-0.14978644  1.49395304]]>"
       ]
      },
      "metadata": {},
@@ -65,7 +65,7 @@
  "metadata": {
   "kernelspec": {
    "name": "python3",
-   "display_name": "Python 3.8.10 64-bit"
+   "display_name": "Python 3.8.10 64-bit ('.venv': venv)"
   },
   "language_info": {
    "codemirror_mode": {

--- a/piquasso/__init__.py
+++ b/piquasso/__init__.py
@@ -65,7 +65,6 @@ from .instructions.gates import (
     ControlledX,
     ControlledZ,
     Interferometer,
-    Sampling,
     Graph,
 )
 
@@ -75,6 +74,7 @@ from .instructions.measurements import (
     HomodyneMeasurement,
     HeterodyneMeasurement,
     GeneraldyneMeasurement,
+    Sampling,
 )
 
 from .instructions.channels import (

--- a/piquasso/_backends/fock/circuit.py
+++ b/piquasso/_backends/fock/circuit.py
@@ -54,8 +54,7 @@ class BaseFockCircuit(Circuit, abc.ABC):
             shots=self.shots,
         )
 
-        self.update_measured_modes(instruction.modes)
-        self.results.append(Result(instruction=instruction, samples=samples))
+        self.result = Result(instruction=instruction, samples=samples)
 
     def _vacuum(self, instruction, state):
         state._apply_vacuum()

--- a/piquasso/_backends/gaussian/circuit.py
+++ b/piquasso/_backends/gaussian/circuit.py
@@ -83,8 +83,7 @@ class GaussianCircuit(Circuit):
             modes=modes,
         )
 
-        self.update_measured_modes(instruction.modes)
-        self.results.append(Result(instruction=instruction, samples=samples))
+        self.result = Result(instruction=instruction, samples=samples)
 
     def _generaldyne_measurement(self, instruction, state):
         samples = state._apply_generaldyne_measurement(
@@ -93,8 +92,7 @@ class GaussianCircuit(Circuit):
             modes=instruction.modes,
         )
 
-        self.update_measured_modes(instruction.modes)
-        self.results.append(Result(instruction=instruction, samples=samples))
+        self.result = Result(instruction=instruction, samples=samples)
 
     def _vacuum(self, instruction, state):
         state.reset()
@@ -112,8 +110,7 @@ class GaussianCircuit(Circuit):
             modes=instruction.modes,
         )
 
-        self.update_measured_modes(instruction.modes)
-        self.results.append(Result(instruction=instruction, samples=samples))
+        self.result = Result(instruction=instruction, samples=samples)
 
     def _threshold_measurement(self, instruction, state):
         samples = state._apply_threshold_measurement(
@@ -121,8 +118,7 @@ class GaussianCircuit(Circuit):
             modes=instruction.modes,
         )
 
-        self.update_measured_modes(instruction.modes)
-        self.results.append(Result(instruction=instruction, samples=samples))
+        self.result = Result(instruction=instruction, samples=samples)
 
     def _graph(self, instruction, state):
         """

--- a/piquasso/_backends/sampling/circuit.py
+++ b/piquasso/_backends/sampling/circuit.py
@@ -77,9 +77,7 @@ class SamplingCircuit(Circuit):
             samples_number=self.shots
         )
 
-        self.results.append(
-            Result(instruction=instruction, samples=samples)
-        )
+        self.result = Result(instruction=instruction, samples=samples)
 
     def _loss(self, instruction, state):
         state._apply_loss(

--- a/piquasso/_backends/sampling/state.py
+++ b/piquasso/_backends/sampling/state.py
@@ -35,7 +35,6 @@ class SamplingState(State):
     def __init__(self, *initial_state):
         self.initial_state = initial_state
         self.interferometer = np.diag(np.ones(self.d, dtype=complex))
-        self.results = None
 
         self.is_lossy = False
 

--- a/piquasso/api/circuit.py
+++ b/piquasso/api/circuit.py
@@ -17,27 +17,14 @@
 
 import abc
 
-from piquasso.api.errors import InvalidModes
-
 
 class Circuit(abc.ABC):
     instruction_map: dict
 
     def __init__(self, program):
         self.program = program
-        self.results = []
-        self._measured_modes = set()
+        self.result = None
         self.shots = None
-
-    def update_measured_modes(self, modes):
-        self._measured_modes.update(set(modes))
-
-    def validate_modes(self, modes):
-        if any(mode in self._measured_modes for mode in modes):
-            raise InvalidModes(
-                f"The modes {modes} contains a mode which is already measured.\n"
-                f"Already mesured modes: {list(self._measured_modes)}"
-            )
 
     def execute_instructions(self, instructions, state, shots):
         """Executes the collected instructions in order.
@@ -57,8 +44,6 @@ class Circuit(abc.ABC):
             if instruction.modes is tuple():
                 instruction.modes = tuple(range(state.d))
 
-            self.validate_modes(instruction.modes)
-
             if hasattr(instruction, "_autoscale"):
                 instruction._autoscale()
 
@@ -77,4 +62,4 @@ class Circuit(abc.ABC):
 
             getattr(self, method_name)(instruction, state)
 
-        return self.results
+        return self.result

--- a/piquasso/api/measurement.py
+++ b/piquasso/api/measurement.py
@@ -1,0 +1,28 @@
+#
+# Copyright 2021 Budapest Quantum Computing Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from piquasso.api.errors import InvalidProgram
+from piquasso.api.instruction import Instruction
+
+
+class Measurement(Instruction):
+    def _apply_to_program_on_register(self, program, register):
+        if any(
+            isinstance(instruction, type(self))
+            for instruction in program.instructions
+        ):
+            raise InvalidProgram("Measurement already registered.")
+
+        super()._apply_to_program_on_register(program, register)

--- a/piquasso/api/mode.py
+++ b/piquasso/api/mode.py
@@ -35,7 +35,7 @@ class Q:
 
             pq.Q(0, 1) | pq.Squeezing(r=0.5)
 
-        results = program.execute()
+        result = program.execute()
 
     In the above example, the :class:`~piquasso.instructions.gates.Beamsplitter` gate
     is applied to modes `0, 1`.

--- a/piquasso/api/program.py
+++ b/piquasso/api/program.py
@@ -40,7 +40,7 @@ class Program(_mixins.RegisterMixin):
 
             pq.Q(0, 1) | pq.Squeezing(r=0.5)
 
-        results = program.execute()
+        result = program.execute()
 
     Args:
         state (State): The initial quantum state.
@@ -123,8 +123,8 @@ class Program(_mixins.RegisterMixin):
         )
 
     @property
-    def results(self) -> list:
-        return self._circuit.results
+    def result(self) -> list:
+        return self._circuit.result
 
     @classmethod
     def from_properties(cls, properties: dict):

--- a/piquasso/instructions/gates.py
+++ b/piquasso/instructions/gates.py
@@ -677,25 +677,6 @@ class CrossKerr(Instruction):
         super().__init__(params=dict(xi=xi))
 
 
-class Sampling(Instruction):
-    r"""Boson Sampling.
-
-    Simulates a boson sampling using generalized Clifford&Clifford algorithm
-    from [Brod, Oszmaniec 2020].
-
-    This method assumes that initial_state is given in the second quantization
-    description (mode occupation). BoSS requires input states as numpy arrays,
-    therefore the state is prepared as such structure.
-
-    Generalized Cliffords simulation strategy form [Brod, Oszmaniec 2020] was used
-    as it allows effective simulation of broader range of input states than original
-    algorithm.
-    """
-
-    def __init__(self):
-        super().__init__()
-
-
 class Graph(Instruction):
     r"""Applies a graph given its adjacency matrix, see
     https://arxiv.org/pdf/1612.01199.pdf

--- a/piquasso/instructions/measurements.py
+++ b/piquasso/instructions/measurements.py
@@ -24,12 +24,12 @@
 
 import numpy as np
 
-from piquasso.api.instruction import Instruction
 from piquasso.api.errors import InvalidParameter
+from piquasso.api.measurement import Measurement
 from piquasso._math.linalg import is_positive_semidefinite, symplectic_form
 
 
-class ParticleNumberMeasurement(Instruction):
+class ParticleNumberMeasurement(Measurement):
     r"""Particle number measurement.
 
     A non-Gaussian projective measurement with the probability density given by
@@ -54,7 +54,7 @@ class ParticleNumberMeasurement(Instruction):
         super().__init__(params=dict(cutoff=cutoff))
 
 
-class ThresholdMeasurement(Instruction):
+class ThresholdMeasurement(Measurement):
     """Threshold measurement.
 
     Similar to :class:`ParticleNumberMeasurement`, but only measuring whether or not
@@ -69,7 +69,7 @@ class ThresholdMeasurement(Instruction):
         super().__init__()
 
 
-class GeneraldyneMeasurement(Instruction):
+class GeneraldyneMeasurement(Measurement):
     r"""General-dyne measurement.
 
     The probability density is given by
@@ -111,7 +111,7 @@ class GeneraldyneMeasurement(Instruction):
         )
 
 
-class HomodyneMeasurement(Instruction):
+class HomodyneMeasurement(Measurement):
     r"""Homodyne measurement.
 
     Corresponds to measurement of the quadrature operator
@@ -157,7 +157,7 @@ class HomodyneMeasurement(Instruction):
         )
 
 
-class HeterodyneMeasurement(Instruction):
+class HeterodyneMeasurement(Measurement):
     r"""Heterodyne measurement.
 
     The probability density is given by
@@ -179,3 +179,22 @@ class HeterodyneMeasurement(Instruction):
                 detection_covariance=np.identity(2),
             ),
         )
+
+
+class Sampling(Measurement):
+    r"""Boson Sampling.
+
+    Simulates a boson sampling using generalized Clifford&Clifford algorithm
+    from [Brod, Oszmaniec 2020].
+
+    This method assumes that initial_state is given in the second quantization
+    description (mode occupation). BoSS requires input states as numpy arrays,
+    therefore the state is prepared as such structure.
+
+    Generalized Cliffords simulation strategy form [Brod, Oszmaniec 2020] was used
+    as it allows effective simulation of broader range of input states than original
+    algorithm.
+    """
+
+    def __init__(self):
+        super().__init__()

--- a/scripts/gbs_cramer.py
+++ b/scripts/gbs_cramer.py
@@ -73,7 +73,7 @@ with sf_program.context as q:
 
 if __name__ == "__main__":
 
-    pq_results = np.array(pq_program.execute(shots=shots)[0])
+    pq_results = np.array(pq_program.execute(shots=shots))
     sf_results = sf_engine.run(sf_program, shots=shots).samples
 
     result = cramer_multidim_test(pq_results, sf_results)

--- a/scripts/gbs_graph_histogram.py
+++ b/scripts/gbs_graph_histogram.py
@@ -61,7 +61,7 @@ with sf_program.context as q:
 
 
 if __name__ == "__main__":
-    pq_results = np.array(pq_program.execute(shots=shots)[0].samples)
+    pq_results = np.array(pq_program.execute(shots=shots).samples)
     sf_results = sf_engine.run(sf_program, shots=shots).samples
 
     N_points = 100000

--- a/scripts/gbs_histogram.py
+++ b/scripts/gbs_histogram.py
@@ -74,7 +74,7 @@ with sf_program.context as q:
 
 
 if __name__ == "__main__":
-    pq_results = np.array(pq_program.execute(shots=shots)[0].samples)
+    pq_results = np.array(pq_program.execute(shots=shots).samples)
     sf_results = sf_engine.run(sf_program, shots=shots).samples
 
     N_points = 100000

--- a/scripts/threshold_cramer.py
+++ b/scripts/threshold_cramer.py
@@ -70,7 +70,7 @@ with sf_program.context as q:
 
 if __name__ == "__main__":
 
-    pq_results = np.array(pq_program.execute(shots=shots)[0].samples)
+    pq_results = np.array(pq_program.execute(shots=shots).samples)
     sf_results = sf_engine.run(sf_program, shots=shots).samples
 
     result = cramer_multidim_test(pq_results, sf_results)

--- a/scripts/threshold_histogram.py
+++ b/scripts/threshold_histogram.py
@@ -71,7 +71,7 @@ with sf_program.context as q:
 
 
 if __name__ == "__main__":
-    pq_results = np.array(pq_program.execute(shots=shots)[0].samples)
+    pq_results = np.array(pq_program.execute(shots=shots).samples)
     sf_results = sf_engine.run(sf_program, shots=shots).samples
 
     N_points = 100000

--- a/tests/backends/fock/general_and_pnc/test_measurements.py
+++ b/tests/backends/fock/general_and_pnc/test_measurements.py
@@ -40,12 +40,11 @@ def test_measure_particle_number_on_one_mode(StateClass):
 
         pq.Q(2) | pq.ParticleNumberMeasurement()
 
-    results = program.execute()
+    result = program.execute()
 
     assert np.isclose(sum(program.state.fock_probabilities), 1)
-    assert len(results) == 1
 
-    sample = results[0].samples[0]
+    sample = result.samples[0]
     assert sample == (1, ) or sample == (2, )
 
     if sample == (1, ):
@@ -92,12 +91,11 @@ def test_measure_particle_number_on_two_modes(StateClass):
 
         pq.Q(1, 2) | pq.ParticleNumberMeasurement()
 
-    results = program.execute()
+    result = program.execute()
 
     assert np.isclose(sum(program.state.fock_probabilities), 1)
-    assert len(results) == 1
 
-    sample = results[0].samples[0]
+    sample = result.samples[0]
     assert sample == (0, 1) or sample == (1, 1) or sample == (0, 2)
 
     if sample == (0, 1):
@@ -147,12 +145,11 @@ def test_measure_particle_number_on_all_modes(StateClass):
 
         pq.Q() | pq.ParticleNumberMeasurement()
 
-    results = program.execute()
+    result = program.execute()
 
     assert np.isclose(sum(program.state.fock_probabilities), 1)
-    assert len(results) == 1
 
-    sample = results[0].samples[0]
+    sample = result.samples[0]
     assert sample == (0, 0, 0) or sample == (0, 0, 1) or sample == (1, 0, 0)
 
     if sample == (0, 0, 0):
@@ -202,7 +199,7 @@ def test_measure_particle_number_with_multiple_shots(StateClass):
 
         pq.Q() | pq.ParticleNumberMeasurement()
 
-    results = program.execute(shots=shots)
+    result = program.execute(shots=shots)
 
     assert np.isclose(sum(program.state.fock_probabilities), 1)
-    assert len(results[0].samples) == shots
+    assert len(result.samples) == shots

--- a/tests/backends/fock/pure/test_measurements.py
+++ b/tests/backends/fock/pure/test_measurements.py
@@ -29,12 +29,11 @@ def test_measure_particle_number_on_one_mode():
 
         pq.Q(2) | pq.ParticleNumberMeasurement()
 
-    results = program.execute()
+    result = program.execute()
 
     assert np.isclose(sum(program.state.fock_probabilities), 1)
-    assert len(results) == 1
 
-    sample = results[0].samples[0]
+    sample = result.samples[0]
     assert sample == (1, ) or sample == (2, )
 
     if sample == (1, ):
@@ -67,12 +66,11 @@ def test_measure_particle_number_on_two_modes():
 
         pq.Q(1, 2) | pq.ParticleNumberMeasurement()
 
-    results = program.execute()
+    result = program.execute()
 
     assert np.isclose(sum(program.state.fock_probabilities), 1)
-    assert len(results) == 1
 
-    sample = results[0].samples[0]
+    sample = result.samples[0]
     assert sample == (0, 1) or sample == (1, 1) or sample == (0, 2)
 
     if sample == (0, 1):
@@ -117,12 +115,11 @@ def test_measure_particle_number_on_all_modes():
     with program:
         pq.Q() | pq.ParticleNumberMeasurement()
 
-    results = program.execute()
+    result = program.execute()
 
     assert np.isclose(sum(program.state.fock_probabilities), 1)
-    assert len(results) == 1
 
-    sample = results[0].samples[0]
+    sample = result.samples[0]
     assert sample == (0, 0, 0) or sample == (1, 0, 0) or sample == (0, 0, 1)
 
     if sample == (0, 0, 0):
@@ -169,7 +166,7 @@ def test_measure_particle_number_with_multiple_shots():
     with program:
         pq.Q() | pq.ParticleNumberMeasurement()
 
-    results = program.execute(shots=shots)
+    result = program.execute(shots=shots)
 
     assert np.isclose(sum(program.state.fock_probabilities), 1)
-    assert len(results[0].samples) == shots
+    assert len(result.samples) == shots

--- a/tests/backends/gaussian/test_instructions.py
+++ b/tests/backends/gaussian/test_instructions.py
@@ -512,10 +512,10 @@ def test_generate_subgraphs_from_adjacency_matrix(program, gaussian_state_assets
 
         pq.Q() | pq.ParticleNumberMeasurement()
 
-    results = program.execute(shots=shots)
+    result = program.execute(shots=shots)
     program.state.validate()
 
-    subgraphs = results[0].to_subgraph_nodes()
+    subgraphs = result.to_subgraph_nodes()
 
     assert len(subgraphs) == shots
     assert subgraphs == [[1, 2], [1, 2]]

--- a/tests/backends/gaussian/test_measurements.py
+++ b/tests/backends/gaussian/test_measurements.py
@@ -55,10 +55,9 @@ def test_measure_homodyne(program):
     with program:
         pq.Q(0) | pq.HomodyneMeasurement()
 
-    results = program.execute()
+    result = program.execute()
 
-    assert len(results) == 1
-    assert results[0].instruction.modes == (0, )
+    assert result.instruction.modes == (0, )
 
     program.state.validate()
 
@@ -80,10 +79,9 @@ def test_measure_homodyne_with_rotation(program):
     with program:
         pq.Q(0) | pq.HomodyneMeasurement(angle)
 
-    results = program.execute()
+    result = program.execute()
 
-    assert len(results) == 1
-    assert results[0].instruction.modes == (0, )
+    assert result.instruction.modes == (0, )
 
 
 def test_measure_homodyne_with_angle_does_not_alter_the_state(program):
@@ -110,10 +108,9 @@ def test_measure_homodyne_on_multiple_modes(program):
     with program:
         pq.Q(0, 1) | pq.HomodyneMeasurement()
 
-    results = program.execute()
+    result = program.execute()
 
-    assert len(results) == 1
-    assert results[0].instruction.modes == (0, 1)
+    assert result.instruction.modes == (0, 1)
 
     program.state.validate()
 
@@ -122,10 +119,9 @@ def test_measure_homodyne_on_all_modes(program, d):
     with program:
         pq.Q() | pq.HomodyneMeasurement()
 
-    results = program.execute()
+    result = program.execute()
 
-    assert len(results) == 1
-    assert results[0].instruction.modes == tuple(range(d))
+    assert result.instruction.modes == tuple(range(d))
 
     program.state.validate()
 
@@ -136,19 +132,18 @@ def test_measure_homodyne_with_multiple_shots(program):
     with program:
         pq.Q(0, 1) | pq.HomodyneMeasurement()
 
-    results = program.execute(shots=shots)
+    result = program.execute(shots=shots)
 
-    assert len(results[0].samples) == shots
+    assert len(result.samples) == shots
 
 
 def test_measure_heterodyne(program):
     with program:
         pq.Q(0) | pq.HeterodyneMeasurement()
 
-    results = program.execute()
+    result = program.execute()
 
-    assert len(results) == 1
-    assert results[0].instruction.modes == (0, )
+    assert result.instruction.modes == (0, )
 
     program.state.validate()
 
@@ -168,10 +163,9 @@ def test_measure_heterodyne_on_multiple_modes(program):
     with program:
         pq.Q(0, 1) | pq.HeterodyneMeasurement()
 
-    results = program.execute()
+    result = program.execute()
 
-    assert len(results) == 1
-    assert results[0].instruction.modes == (0, 1)
+    assert result.instruction.modes == (0, 1)
 
     program.state.validate()
 
@@ -180,10 +174,9 @@ def test_measure_heterodyne_on_all_modes(program, d):
     with program:
         pq.Q() | pq.HeterodyneMeasurement()
 
-    results = program.execute()
+    result = program.execute()
 
-    assert len(results) == 1
-    assert results[0].instruction.modes == tuple(range(d))
+    assert result.instruction.modes == tuple(range(d))
 
     program.state.validate()
 
@@ -194,9 +187,9 @@ def test_measure_heterodyne_with_multiple_shots(program):
     with program:
         pq.Q(0, 1) | pq.HeterodyneMeasurement()
 
-    results = program.execute(shots=shots)
+    result = program.execute(shots=shots)
 
-    assert len(results[0].samples) == shots
+    assert len(result.samples) == shots
 
 
 def test_measure_dyne(program):
@@ -210,10 +203,9 @@ def test_measure_dyne(program):
     with program:
         pq.Q(0) | pq.GeneraldyneMeasurement(detection_covariance)
 
-    results = program.execute()
+    result = program.execute()
 
-    assert len(results) == 1
-    assert results[0].instruction.modes == (0, )
+    assert result.instruction.modes == (0, )
 
     program.state.validate()
 
@@ -231,36 +223,36 @@ def test_measure_dyne_with_multiple_shots(program):
     with program:
         pq.Q(0) | pq.GeneraldyneMeasurement(detection_covariance)
 
-    results = program.execute(shots=shots)
+    result = program.execute(shots=shots)
 
-    assert len(results[0].samples) == shots
+    assert len(result.samples) == shots
 
 
 def test_measure_particle_number_on_one_modes(program):
     with program:
         pq.Q(0) | pq.ParticleNumberMeasurement(cutoff=4)
 
-    results = program.execute()
+    result = program.execute()
 
-    assert results
+    assert result
 
 
 def test_measure_particle_number_on_two_modes(program):
     with program:
         pq.Q(0, 1) | pq.ParticleNumberMeasurement(cutoff=4)
 
-    results = program.execute()
+    result = program.execute()
 
-    assert results
+    assert result
 
 
 def test_measure_particle_number_on_all_modes(program):
     with program:
         pq.Q() | pq.ParticleNumberMeasurement(cutoff=4)
 
-    results = program.execute()
+    result = program.execute()
 
-    assert results
+    assert result
 
 
 def test_measure_threshold_raises_NotImplementedError_for_nonzero_displacements(
@@ -279,54 +271,33 @@ def test_measure_threshold_on_one_modes(nondisplaced_program):
     with nondisplaced_program:
         pq.Q(0) | pq.ThresholdMeasurement()
 
-    results = nondisplaced_program.execute()
+    result = nondisplaced_program.execute()
 
-    assert results
+    assert result
 
 
 def test_measure_threshold_with_multiple_shots(nondisplaced_program):
     with nondisplaced_program:
         pq.Q(0) | pq.ThresholdMeasurement()
 
-    results = nondisplaced_program.execute(shots=20)
+    result = nondisplaced_program.execute(shots=20)
 
-    assert results
+    assert result
 
 
 def test_measure_threshold_on_two_modes(nondisplaced_program):
     with nondisplaced_program:
         pq.Q(0, 1) | pq.ThresholdMeasurement()
 
-    results = nondisplaced_program.execute()
+    result = nondisplaced_program.execute()
 
-    assert results
+    assert result
 
 
 def test_measure_threshold_on_all_modes(nondisplaced_program):
     with nondisplaced_program:
         pq.Q() | pq.ThresholdMeasurement()
 
-    results = nondisplaced_program.execute()
+    result = nondisplaced_program.execute()
 
-    assert results
-
-
-def test_multiple_particle_number_measurements_in_one_program():
-    shots = 3
-
-    with pq.Program() as program:
-        pq.Q() | pq.GaussianState(d=3)
-
-        pq.Q(0) | pq.Squeezing(r=1, phi=0)
-        pq.Q(0, 1) | pq.Beamsplitter(theta=1, phi=np.pi / 4)
-        pq.Q(1, 2) | pq.Beamsplitter(theta=1, phi=np.pi / 4)
-        pq.Q(0, 1) | pq.ParticleNumberMeasurement(cutoff=5)
-        # NOTE: We should forbid this program!
-        pq.Q(2) | pq.ParticleNumberMeasurement(cutoff=5)
-
-    results = program.execute(shots=3)
-
-    assert len(results) == 2
-
-    assert len(results[0].samples) == shots
-    assert len(results[1].samples) == shots
+    assert result

--- a/tests/backends/sampling/test_circuit.py
+++ b/tests/backends/sampling/test_circuit.py
@@ -39,10 +39,9 @@ class TestSampling:
             pq.Q(4) | pq.Phaseshifter(.5)
             pq.Q() | pq.Sampling()
 
-        results = self.program.execute(shots=10)
+        result = self.program.execute(shots=10)
 
-        assert len(results) == 1
-        assert len(results[0].samples) == 10
+        assert len(result.samples) == 10
 
     def test_interferometer(self):
         U = np.array([
@@ -120,6 +119,6 @@ class TestSampling:
             pq.Q(0, 1, 2, 3, 4) | pq.Interferometer(U)
             pq.Q() | pq.Sampling()
 
-        results = self.program.execute(shots=1)
-        sample = results[0].samples[0]
+        result = self.program.execute(shots=1)
+        sample = result.samples[0]
         assert sum(sample) < sum(self.program.state.initial_state)

--- a/tests/backends/sampling/test_state.py
+++ b/tests/backends/sampling/test_state.py
@@ -28,9 +28,6 @@ class TestSamplingState:
         expected_initial_state = [1, 1, 1, 0, 0]
         assert np.allclose(self.state.initial_state, expected_initial_state)
 
-    def test_results_init(self):
-        assert self.state.results is None
-
     def test_interferometer_init(self):
         expected_interferometer = np.diag(np.ones(self.state.d, dtype=complex))
         assert np.allclose(self.state.interferometer, expected_interferometer)

--- a/tests/backends/test_measurements.py
+++ b/tests/backends/test_measurements.py
@@ -33,12 +33,10 @@ CUTOFF = 4
 def test_InvalidModes_are_raised_if_modes_are_already_measured(StateClass):
     d = 3
 
-    with pq.Program() as program:
-        pq.Q() | StateClass(d=d) | pq.Vacuum()
+    with pytest.raises(pq.api.errors.InvalidProgram):
+        with pq.Program():
+            pq.Q() | StateClass(d=d) | pq.Vacuum()
 
-        pq.Q(0, 1) | pq.ParticleNumberMeasurement()
+            pq.Q(0, 1) | pq.ParticleNumberMeasurement()
 
-        pq.Q(0) | pq.Fourier()
-
-    with pytest.raises(pq.api.errors.InvalidModes):
-        program.execute()
+            pq.Q(2) | pq.ParticleNumberMeasurement()

--- a/tests/backends/test_sampling.py
+++ b/tests/backends/test_sampling.py
@@ -54,9 +54,10 @@ class TestSampling:
 
         self.program.execute(shots)
 
-        assert len(self.program.results[-1].samples) == shots,\
-            f'Expected {shots} samples, ' \
-            f'got: {len(self.program.state.results)}'
+        assert len(self.program.result.samples) == shots, (
+            f"Expected {shots} samples, "
+            f"got: {len(self.program.result)}"
+        )
 
     def test_sampling_mode_permutation(self):
         shots = 1
@@ -66,7 +67,7 @@ class TestSampling:
 
         self.program.execute(shots)
 
-        sample = self.program.results[-1].samples[0]
+        sample = self.program.result.samples[0]
         assert np.allclose(sample, [1, 0, 0, 1, 1]),\
             f'Expected [1, 0, 0, 1, 1], got: {sample}'
 
@@ -78,7 +79,7 @@ class TestSampling:
 
         self.program.execute(shots)
 
-        samples = self.program.results[-1].samples
+        samples = self.program.result.samples
         first_sample = samples[0]
         second_sample = samples[1]
 


### PR DESCRIPTION
`piquasso` got rewritten to allow for only one measurement by
introducing a new `Measurement` class which overrides the
`Instruction._apply_to_program_on_register`.

The variable names, tests, scripts got rewritten according to these
changes.

Resolves #19