### PR TITLE
refact(gaussian.probabilities): Remove `subspace_modes`

### DIFF
--- a/piquasso/_backends/gaussian/probabilities.py
+++ b/piquasso/_backends/gaussian/probabilities.py
@@ -25,10 +25,9 @@ from piquasso._math.torontonian import torontonian
 
 def calculate_particle_number_detection_probability(
     state,
-    subspace_modes: tuple,
     occupation_numbers: tuple,
 ):
-    d = len(subspace_modes)
+    d = state.d
     Q = (state.complex_covariance + np.identity(2 * d)) / 2
     Qinv = np.linalg.inv(Q)
 
@@ -64,8 +63,7 @@ def calculate_particle_number_detection_probability(
 
 def calculate_threshold_detection_probability(
     state,
-    subspace_modes,
-    occupation_numbers,
+    occupation_numbers: tuple,
 ):
     r"""
     Calculates the threshold detection probability with the equation
@@ -85,8 +83,7 @@ def calculate_threshold_detection_probability(
                 + I
             \right ).
     """
-
-    d = len(subspace_modes)
+    d = state.d
 
     sigma = (state.xp_cov / constants.HBAR + np.identity(2 * d)) / 2
 

--- a/piquasso/_backends/gaussian/state.py
+++ b/piquasso/_backends/gaussian/state.py
@@ -845,8 +845,7 @@ class GaussianState(State):
             reduced_state = self.reduced(subspace_modes)
             probability = calculation(
                 reduced_state,
-                subspace_modes,
-                occupation_numbers,
+                occupation_numbers=occupation_numbers,
             )
 
             return max(probability, 0.0)
@@ -899,15 +898,12 @@ class GaussianState(State):
         return samples
 
     def get_fock_probabilities(self, cutoff):
-        modes = tuple(range(self.d))
-
         ret = []
 
         for particle_number in range(cutoff):
             for occupation_numbers in partitions(self.d, particle_number):
                 probability = calculate_particle_number_detection_probability(
                     self.copy(),
-                    subspace_modes=modes,
                     occupation_numbers=tuple(occupation_numbers),
                 )
                 ret.append(probability)


### PR DESCRIPTION
The parameter `subspace_modes` got removed from
`calculate_particle_number_detection_probability` and
`calculate_threshold_detection_probability`, since it is not used.