### PR TITLE
feat: `get_density_matrix`

### DIFF
--- a/piquasso/_backends/fock/general/state.py
+++ b/piquasso/_backends/fock/general/state.py
@@ -207,14 +207,17 @@ class FockState(BaseFockState):
     def __eq__(self, other):
         return np.allclose(self._density_matrix, other._density_matrix)
 
-    @property
-    def density_matrix(self):
-        return self._density_matrix
+    def get_density_matrix(self, cutoff=None):
+        cutoff = cutoff or self.cutoff
+
+        cardinality = cutoff_cardinality(d=self.d, cutoff=cutoff)
+
+        return self._density_matrix[:cardinality, :cardinality]
 
     def get_fock_probabilities(self, cutoff=None):
-        cutoff = cutoff or self._space.cutoff
+        cutoff = cutoff or self.cutoff
 
-        cardinality = cutoff_cardinality(d=self._space.d, cutoff=cutoff)
+        cardinality = cutoff_cardinality(d=self.d, cutoff=cutoff)
 
         return np.diag(self._density_matrix).real[:cardinality]
 

--- a/piquasso/_backends/fock/pnc/state.py
+++ b/piquasso/_backends/fock/pnc/state.py
@@ -239,9 +239,10 @@ class PNCFockState(BaseFockState):
             for n, subrep in enumerate(self._representation)
         ])
 
-    @property
-    def density_matrix(self):
-        return block_diag(*self._representation)
+    def get_density_matrix(self, cutoff=None):
+        cutoff = cutoff or self.cutoff
+
+        return block_diag(*self._representation[:cutoff])
 
     def _as_mixed(self):
         return FockState.from_fock_state(self)
@@ -250,7 +251,7 @@ class PNCFockState(BaseFockState):
         return self._as_mixed().reduced(modes)
 
     def get_fock_probabilities(self, cutoff=None):
-        cutoff = cutoff or self._space.cutoff
+        cutoff = cutoff or self.cutoff
 
         ret = []
 

--- a/piquasso/_backends/fock/pure/state.py
+++ b/piquasso/_backends/fock/pure/state.py
@@ -177,9 +177,13 @@ class PureFockState(BaseFockState):
     def __eq__(self, other):
         return np.allclose(self._state_vector, other._state_vector)
 
-    @property
-    def density_matrix(self):
-        state_vector = self._state_vector
+    def get_density_matrix(self, cutoff):
+        cutoff = cutoff or self.cutoff
+
+        cardinality = cutoff_cardinality(d=self.d, cutoff=cutoff)
+
+        state_vector = self._state_vector[:cardinality]
+
         return np.outer(state_vector, state_vector)
 
     def _as_mixed(self):

--- a/piquasso/_backends/fock/state.py
+++ b/piquasso/_backends/fock/state.py
@@ -141,11 +141,15 @@ class BaseFockState(State, abc.ABC):
     def nonzero_elements(self):
         pass
 
-    @property
     @abc.abstractmethod
-    def density_matrix(self):
+    def get_density_matrix(self, cutoff):
         """The density matrix of the state in terms of Fock basis vectors."""
         pass
+
+    @property
+    def density_matrix(self):
+        """The density matrix of the state in terms of Fock basis vectors."""
+        return self.get_density_matrix(cutoff=self.cutoff)
 
     @property
     @abc.abstractmethod

--- a/piquasso/_backends/gaussian/probabilities.py
+++ b/piquasso/_backends/gaussian/probabilities.py
@@ -18,53 +18,90 @@ import numpy as np
 from scipy.special import factorial
 
 from piquasso import constants
-from piquasso._math.linalg import block_reduce
+from piquasso._math.linalg import block_reduce, reduce_
 from piquasso._math.hafnian import loop_hafnian
 from piquasso._math.torontonian import torontonian
 
 
-def calculate_particle_number_detection_probability(
-    state,
-    occupation_numbers: tuple,
-):
-    d = state.d
-    Q = (state.complex_covariance + np.identity(2 * d)) / 2
-    Qinv = np.linalg.inv(Q)
+class DensityMatrixCalculation:
+    def __init__(self, complex_displacement, complex_covariance) -> None:
+        d = len(complex_displacement) // 2
+        Q = (complex_covariance + np.identity(2 * d)) / 2
 
-    identity = np.identity(d)
-    zeros = np.zeros_like(identity)
+        Qinv = np.linalg.inv(Q)
+        identity = np.identity(d)
+        zeros = np.zeros_like(identity)
 
-    X = np.block(
-        [
-            [zeros, identity],
-            [identity, zeros],
-        ],
-    )
-
-    A = X @ (np.identity(2 * d, dtype=complex) - Qinv)
-
-    alpha = state.complex_displacement
-    gamma = alpha.conj() @ Qinv
-
-    A_reduced = block_reduce(A, reduce_on=occupation_numbers)
-
-    np.fill_diagonal(
-        A_reduced,
-        block_reduce(
-            gamma, reduce_on=occupation_numbers
+        X = np.block(
+            [
+                [zeros, identity],
+                [identity, zeros],
+            ],
         )
-    )
 
-    return (
-        loop_hafnian(A_reduced) * np.exp(-0.5 * gamma @ alpha)
-        / (np.prod(factorial(occupation_numbers)) * np.sqrt(np.linalg.det(Q)))
-    ).real
+        self._A = X @ (np.identity(2 * d, dtype=complex) - Qinv)
+
+        self._gamma = complex_displacement.conj() @ Qinv
+
+        self._normalization = (
+            np.exp(-0.5 * self._gamma @ complex_displacement)
+            / np.sqrt(np.linalg.det(Q))
+        )
+
+    def _get_A_reduced(self, reduce_on: tuple):
+        A_reduced = reduce_(self._A, reduce_on=reduce_on)
+
+        np.fill_diagonal(
+            A_reduced,
+            reduce_(
+                self._gamma, reduce_on=reduce_on
+            )
+        )
+
+        return A_reduced
+
+    def get_density_matrix_element(self, bra: tuple, ket: tuple) -> float:
+        reduce_on = ket + bra
+
+        A_reduced = self._get_A_reduced(reduce_on=reduce_on)
+
+        return (
+            self._normalization * loop_hafnian(A_reduced)
+            / np.sqrt(np.prod(factorial(reduce_on)))
+        )
+
+    def get_density_matrix(self, occupation_numbers):
+        n = len(occupation_numbers)
+
+        density_matrix = np.empty(shape=(n, n), dtype=complex)
+
+        for i, bra in enumerate(occupation_numbers):
+            for j, ket in enumerate(occupation_numbers):
+                density_matrix[i, j] = self.get_density_matrix_element(bra, ket)
+
+        return density_matrix
+
+    def get_particle_number_detection_probabilities(
+        self,
+        occupation_numbers: list
+    ) -> list:
+        ret = []
+
+        for occupation_number in occupation_numbers:
+            probability = self.get_density_matrix_element(
+                bra=occupation_number,
+                ket=occupation_number,
+            )
+            ret.append(probability)
+
+        ret = np.array(ret)
+
+        ret[abs(ret) < 1e-10] = 0.0
+
+        return ret
 
 
-def calculate_threshold_detection_probability(
-    state,
-    occupation_numbers: tuple,
-):
+class ThresholdCalculation:
     r"""
     Calculates the threshold detection probability with the equation
 
@@ -75,7 +112,8 @@ def calculate_threshold_detection_probability(
             \sqrt{\operatorname{det}(\Sigma)}
         },
 
-    where :math:`\Sigma \in \mathbb{R}^{2d \times 2d}` is a symmetric matrix defined by
+    where :math:`\Sigma \in \mathbb{R}^{2d \times 2d}` is a symmetric matrix
+    defined by
 
     .. math::
         \Sigma = \frac{1}{2} \left (
@@ -83,17 +121,25 @@ def calculate_threshold_detection_probability(
                 + I
             \right ).
     """
-    d = state.d
 
-    sigma = (state.xp_cov / constants.HBAR + np.identity(2 * d)) / 2
+    def __init__(self, xp_covariance) -> None:
+        d = len(xp_covariance) // 2
 
-    sigma_inv_reduced = (
-        block_reduce(
-            np.linalg.inv(sigma),
-            reduce_on=occupation_numbers,
+        self._sigma = (xp_covariance / constants.HBAR + np.identity(2 * d)) / 2
+
+        self._normalization = 1 / np.sqrt(np.linalg.det(self._sigma))
+
+    def _get_sigma_inv_reduced(self, reduce_on: tuple):
+        return (
+            block_reduce(
+                np.linalg.inv(self._sigma),
+                reduce_on=reduce_on,
+            )
         )
-    )
 
-    return torontonian(
-        np.identity(len(sigma_inv_reduced)) - sigma_inv_reduced
-    ) / np.sqrt(np.linalg.det(sigma))
+    def calculate_click_probability(self, occupation_number):
+        sigma_inv_reduced = self._get_sigma_inv_reduced(reduce_on=occupation_number)
+
+        return self._normalization * torontonian(
+            np.identity(len(sigma_inv_reduced)) - sigma_inv_reduced
+        )

--- a/piquasso/_math/combinatorics.py
+++ b/piquasso/_math/combinatorics.py
@@ -32,3 +32,13 @@ def partitions(boxes, particles, class_=tuple):
     return sorted(
         class_(sum(c)) for c in combinations_with_replacement(masks, particles)
     )
+
+
+def get_occupation_numbers(d, cutoff):
+    occupation_numbers = []
+
+    for particle_number in range(cutoff):
+        for occupation_number in partitions(d, particle_number):
+            occupation_numbers.append(tuple(occupation_number))
+
+    return occupation_numbers

--- a/piquasso/_math/hafnian.py
+++ b/piquasso/_math/hafnian.py
@@ -67,6 +67,14 @@ def fG(polynom_coefficients, degree):
 
 
 def _hafnian(A, polynom_function):
+    """
+    NOTE: If the input matrix `A` has an odd dimension, e.g. 7x7, then the matrix
+    should be padded to an even dimension, to e.g. 8x8.
+    """
+    if len(A) % 2 == 1:
+        A = np.pad(A, pad_width=((1, 0), (1, 0)))
+        A[0, 0] = 1.0
+
     degree = A.shape[0] // 2
 
     if degree == 0:

--- a/piquasso/_math/linalg.py
+++ b/piquasso/_math/linalg.py
@@ -83,15 +83,17 @@ def symplectic_form(d):
     return symplectic_form
 
 
-def block_reduce(array, reduce_on):
-    reduction_indices = reduce_on * 2
-
+def reduce_(array, reduce_on):
     proper_index = []
 
-    for index, multiplier in enumerate(reduction_indices):
+    for index, multiplier in enumerate(reduce_on):
         proper_index.extend([index] * multiplier)
 
     if array.ndim == 1:
         return array[proper_index]
 
     return array[np.ix_(proper_index, proper_index)]
+
+
+def block_reduce(array, reduce_on):
+    return reduce_(array, reduce_on=(reduce_on * 2))


### PR DESCRIPTION
The `get_density_matrix` method got implemented in the `gaussian` and
`fock` backends.

To achieve this, the following has been done:
- The calculations in `gaussian.probabilities` have been refactored to
  classes to enable calculation of the density matrix;
- The probability calculation at GBS has been rewritten to enable for
  calculation general density matrix elements;
- The complexity of the density matrix element calculation has been
  enabled by deleting explicit casting to a real value;
- The hafnian calculation has been rewritten to handle matrices with odd
  dimensions by padding;
- The `density_matrix` properties in the `*FockState` classes has been
  rewritten to use a more general `get_density_matrix` class.
- Tests have been written accordinly.

References:

- [Simulating realistic non-Gaussian state preparation](https://arxiv.org/abs/1905.07011)