### PR TITLE
feat(sampling): Uniform loss strategy

### DIFF
--- a/tests/backends/test_sampling.py
+++ b/tests/backends/test_sampling.py
@@ -102,7 +102,7 @@ class TestSampling:
 
         self.program.execute(shots=1)
 
-    def test_loss(self):
+    def test_uniform_loss(self):
         with self.program:
             pq.Q(all) | pq.Loss(transmissivity=0.9)
 
@@ -111,3 +111,12 @@ class TestSampling:
         self.program.execute(shots=1)
 
         assert self.program.state.is_lossy
+
+    def test_general_loss(self):
+        with self.program:
+            pq.Q(0) | pq.Loss(transmissivity=0.4)
+            pq.Q(1) | pq.Loss(transmissivity=0.5)
+
+            pq.Q() | pq.Sampling()
+
+        self.program.execute(shots=1)


### PR DESCRIPTION
A separate simulation strategy has been created in BoSS for uniform
losses, which is being utilized in this patch. The instantiation of the
`*Strategy` classes has been put into a separate static method.

Resolves #38