### PR TITLE
feat(State): `get_particle_detection_probability`

### DIFF
--- a/piquasso/_backends/fock/general/state.py
+++ b/piquasso/_backends/fock/general/state.py
@@ -214,6 +214,10 @@ class FockState(BaseFockState):
 
         return self._density_matrix[:cardinality, :cardinality]
 
+    def get_particle_detection_probability(self, occupation_number: tuple) -> float:
+        index = self._space.index(occupation_number)
+        return np.diag(self._density_matrix)[index].real
+
     def get_fock_probabilities(self, cutoff=None):
         cutoff = cutoff or self.cutoff
 

--- a/piquasso/_backends/fock/pnc/state.py
+++ b/piquasso/_backends/fock/pnc/state.py
@@ -16,6 +16,7 @@
 import numpy as np
 
 from piquasso.api.errors import InvalidState
+from piquasso._math.combinatorics import partitions
 
 from ..state import BaseFockState
 from ..general.state import FockState
@@ -249,6 +250,17 @@ class PNCFockState(BaseFockState):
 
     def reduced(self, modes):
         return self._as_mixed().reduced(modes)
+
+    def get_particle_detection_probability(self, occupation_number: tuple) -> float:
+        number_of_particles = sum(occupation_number)
+
+        subrep_probabilities = np.diag(self._representation[number_of_particles])
+
+        basis = partitions(self.d, number_of_particles)
+
+        index = basis.index(occupation_number)
+
+        return subrep_probabilities[index].real
 
     def get_fock_probabilities(self, cutoff=None):
         cutoff = cutoff or self.cutoff

--- a/piquasso/_backends/fock/pure/state.py
+++ b/piquasso/_backends/fock/pure/state.py
@@ -192,6 +192,13 @@ class PureFockState(BaseFockState):
     def reduced(self, modes):
         return self._as_mixed().reduced(modes)
 
+    def get_particle_detection_probability(self, occupation_number):
+        index = self._space.index(occupation_number)
+
+        return np.real(
+            self._state_vector[index].conjugate() * self._state_vector[index]
+        )
+
     def get_fock_probabilities(self, cutoff=None):
         cutoff = cutoff or self._space.cutoff
 

--- a/piquasso/_backends/gaussian/state.py
+++ b/piquasso/_backends/gaussian/state.py
@@ -929,6 +929,17 @@ class GaussianState(State):
 
         return samples
 
+    def get_particle_detection_probability(self, occupation_number: tuple) -> float:
+        calculation = DensityMatrixCalculation(
+            self.complex_displacement,
+            self.complex_covariance,
+        )
+
+        return calculation.get_density_matrix_element(
+            bra=occupation_number,
+            ket=occupation_number,
+        )
+
     def get_fock_probabilities(self, cutoff):
         calculation = DensityMatrixCalculation(
             complex_displacement=self.complex_displacement,

--- a/piquasso/_backends/sampling/state.py
+++ b/piquasso/_backends/sampling/state.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from piquasso._math.combinatorics import partitions
 import numpy as np
 
 from piquasso.api.state import State
@@ -99,6 +100,20 @@ class SamplingState(State):
         """
 
         return sum(self.initial_state)
+
+    def get_particle_detection_probability(self, occupation_number):
+        number_of_particles = sum(occupation_number)
+
+        if number_of_particles != self.particle_number:
+            return 0.0
+
+        basis = partitions(self.d, number_of_particles)
+
+        index = basis.index(occupation_number)
+
+        subspace_probabilities = self._get_fock_probabilities_on_subspace()
+
+        return subspace_probabilities[index]
 
     def get_fock_probabilities(self, cutoff: int = None) -> list:
         cutoff = cutoff or self.particle_number + 1

--- a/piquasso/api/state.py
+++ b/piquasso/api/state.py
@@ -64,3 +64,19 @@ class State(_mixins.PropertyMixin, _mixins.RegisterMixin, _mixins.CodeMixin, abc
         auxiliary_rows = np.array([modes] * len(auxiliary_modes)).transpose()
 
         return auxiliary_rows, auxiliary_modes
+
+    @abc.abstractmethod
+    def get_particle_detection_probability(self, occupation_number: tuple) -> float:
+        """
+        Returns the particle number detection probability using the occupation number
+        specified as a parameter.
+
+        Args:
+            occupation_number (tuple):
+                List of natural numbers representing the number of particles in each
+                mode.
+
+        Returns:
+            float: The probability of detection.
+        """
+        pass

--- a/tests/api/program/conftest.py
+++ b/tests/api/program/conftest.py
@@ -37,6 +37,9 @@ def setup_plugin():
         circuit_class = FakeCircuit
         d = 42
 
+        def get_particle_detection_probability(self, occupation_number: tuple) -> float:
+            raise NotImplementedError
+
     class FakePlugin(pq.Plugin):
         classes = {
             "FakeState": FakeState,

--- a/tests/api/test_parsing.py
+++ b/tests/api/test_parsing.py
@@ -58,6 +58,12 @@ class TestProgramJSONParsing:
                 self.bar = bar
                 self.d = d
 
+            def get_particle_detection_probability(
+                self,
+                occupation_number: tuple
+            ) -> float:
+                raise NotImplementedError
+
         return FakeState
 
     @pytest.fixture(autouse=True)

--- a/tests/backends/fock/test_state.py
+++ b/tests/backends/fock/test_state.py
@@ -1,0 +1,42 @@
+#
+# Copyright 2021 Budapest Quantum Computing Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+import numpy as np
+
+import piquasso as pq
+
+
+@pytest.mark.filterwarnings("ignore:.*may not result in the desired state.*")
+@pytest.mark.parametrize(
+    "StateClass",
+    (pq.FockState, pq.PNCFockState, pq.PureFockState)
+)
+def test_FockState_get_particle_detection_probability(StateClass):
+    with pq.Program() as program:
+        pq.Q() | StateClass(d=2, cutoff=4) | pq.Vacuum()
+
+        pq.Q(0) | pq.Squeezing(r=0.1, phi=np.pi / 3)
+
+        pq.Q(0, 1) | pq.Beamsplitter(theta=np.pi / 4)
+
+    program.execute()
+
+    probability = program.state.get_particle_detection_probability(
+        occupation_number=(0, 2)
+    )
+
+    assert np.isclose(probability, 0.0012355767142126952)

--- a/tests/backends/gaussian/test_state.py
+++ b/tests/backends/gaussian/test_state.py
@@ -379,3 +379,20 @@ def test_mean_photon_number():
     assert np.isclose(mean_photon_number_first_mode, state.mean_photon_number((0,)))
     assert np.isclose(mean_photon_number_second_mode, state.mean_photon_number((1,)))
     assert np.isclose(total_mean_photon_number, state.mean_photon_number((0, 1, 2)))
+
+
+def test_GaussianState_get_particle_detection_probability():
+    with pq.Program() as program:
+        pq.Q() | pq.GaussianState(d=2) | pq.Vacuum()
+
+        pq.Q(0) | pq.Squeezing(r=0.1, phi=np.pi / 3)
+
+        pq.Q(0, 1) | pq.Beamsplitter(theta=np.pi / 4)
+
+    program.execute()
+
+    probability = program.state.get_particle_detection_probability(
+        occupation_number=(0, 2)
+    )
+
+    assert np.isclose(probability, 0.0012355308401079989)

--- a/tests/backends/sampling/test_state.py
+++ b/tests/backends/sampling/test_state.py
@@ -149,3 +149,49 @@ class TestSamplingState:
                 0.0, 0.0, 0.0, 0.6945423895038292, 0.30545762086020883, 0.0
             ],
         )
+
+    def test_get_particle_detection_probability(self):
+        U = np.array(
+            [
+                [1, 0, 0],
+                [0, -0.54687158 + 0.07993182j, 0.32028583 - 0.76938896j],
+                [0, 0.78696803 + 0.27426941j, 0.42419041 - 0.35428818j]
+            ],
+        )
+
+        with pq.Program() as program:
+            pq.Q() | pq.SamplingState(1, 1, 0)
+
+            pq.Q(all) | pq.Interferometer(U)
+
+        program.execute()
+
+        probability = program.state.get_particle_detection_probability(
+            occupation_number=(1, 1, 0)
+        )
+
+        assert np.allclose(probability, 0.30545762086020883)
+
+    def test_get_particle_detection_probability_on_different_subspace(self):
+        U = np.array(
+            [
+                [1, 0, 0],
+                [0, -0.54687158 + 0.07993182j, 0.32028583 - 0.76938896j],
+                [0, 0.78696803 + 0.27426941j, 0.42419041 - 0.35428818j]
+            ],
+        )
+
+        with pq.Program() as program:
+            pq.Q() | pq.SamplingState(1, 1, 0)
+
+            pq.Q(all) | pq.Interferometer(U)
+
+        program.execute()
+
+        different_particle_subspace_occupation_number = (3, 1, 0)
+
+        probability = program.state.get_particle_detection_probability(
+            occupation_number=different_particle_subspace_occupation_number
+        )
+
+        assert np.allclose(probability, 0.0)


### PR DESCRIPTION
A method called `get_particle_detection_probability` has been
implemented which returns the particle number detection probability
using the occupation number specified as a parameter.

Since this method can be implemented in **all** backends, this method
has been specified in the abstract `State` class. By doing this, several
`FakeState` subclasses also have to be extended with this method in
several tests.

Resolves #30