### PR TITLE
fix(api): Generating numpy array parameter

### DIFF
--- a/piquasso/api/instruction.py
+++ b/piquasso/api/instruction.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import numpy as np
+
 from piquasso.core import _mixins
 
 
@@ -44,13 +46,24 @@ class Instruction(_mixins.PropertyMixin, _mixins.RegisterMixin, _mixins.CodeMixi
         if hasattr(self, "params"):
             params_string = "{}".format(
                 ", ".join(
-                    [f"{key}={value}" for key, value in self.params.items()]
+                    [
+                        f"{key}={self._param_repr(value)}"
+                        for key, value
+                        in self.params.items()
+                    ]
                 )
             )
         else:
             params_string = ""
 
         return f"pq.Q({mode_string}) | pq.{self.__class__.__name__}({params_string})"
+
+    @staticmethod
+    def _param_repr(value):
+        if isinstance(value, np.ndarray):
+            return "np." + repr(value)
+
+        return value
 
     def on_modes(self, *modes):
         self.modes = modes

--- a/piquasso/api/program.py
+++ b/piquasso/api/program.py
@@ -220,7 +220,7 @@ class Program(_mixins.RegisterMixin):
         with_statement = f"with pq.{self.__class__.__name__}() as program:"
 
         script = (
-            f"import piquasso as pq\n\n\n{with_statement}\n"
+            f"import numpy as np\nimport piquasso as pq\n\n\n{with_statement}\n"
         )
 
         four_space = " " * 4

--- a/tests/api/test_code_generation.py
+++ b/tests/api/test_code_generation.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import numpy as np
+
 import piquasso as pq
 
 
@@ -29,6 +31,7 @@ def test_code_generation():
 
     assert code == (
         """\
+import numpy as np
 import piquasso as pq
 
 
@@ -38,6 +41,39 @@ with pq.Program() as program:
     pq.Q(0) | pq.Fourier()
     pq.Q(0, 1) | pq.Beamsplitter(theta=0.1, phi=0.3)
     pq.Q() | pq.Fourier()
+"""
+    )
+
+    exec(code)
+
+
+def test_Program_as_code_with_numpy_ndarray_parameter():
+    with pq.Program() as program:
+        pq.Q() | pq.GaussianState(d=3) | pq.Vacuum()
+
+        pq.Q(0, 1) | pq.GeneraldyneMeasurement(
+            detection_covariance=np.array(
+                [
+                    [1.0, 0.0],
+                    [0.0, 1.0],
+                ],
+            ),
+        )
+
+    code = program.as_code()
+
+    assert code == (
+        """\
+import numpy as np
+import piquasso as pq
+
+
+with pq.Program() as program:
+    pq.Q() | pq.GaussianState(d=3)
+
+    pq.Q() | pq.Vacuum()
+    pq.Q(0, 1) | pq.GeneraldyneMeasurement(detection_covariance=np.array([[1., 0.],
+       [0., 1.]]))
 """
     )
 


### PR DESCRIPTION
The code generation where a parameter was a numpy array didn't work,
since the `__str__` method of `numpy.ndarray` didn't result in
executable code. The `__repr__` returns regular executable code, one
only has to prepend the generated string with `"np."`, and include
`"import numpy as np"` in the beginning of the script.

Resolves #23