### PR TITLE
fix(State): Probabilities are numpy array of float

### DIFF
--- a/piquasso/_backends/fock/pnc/state.py
+++ b/piquasso/_backends/fock/pnc/state.py
@@ -256,9 +256,10 @@ class PNCFockState(BaseFockState):
         ret = []
 
         for subrep in self._representation[:cutoff]:
-            ret.extend(np.diag(subrep))
+            probability = np.real(np.diag(subrep))
+            ret.extend(probability)
 
-        return ret
+        return np.array(ret, dtype=float)
 
     @property
     def fock_probabilities(self):

--- a/piquasso/_backends/gaussian/probabilities.py
+++ b/piquasso/_backends/gaussian/probabilities.py
@@ -88,13 +88,15 @@ class DensityMatrixCalculation:
         ret = []
 
         for occupation_number in occupation_numbers:
-            probability = self.get_density_matrix_element(
-                bra=occupation_number,
-                ket=occupation_number,
+            probability = np.real(
+                self.get_density_matrix_element(
+                    bra=occupation_number,
+                    ket=occupation_number,
+                )
             )
             ret.append(probability)
 
-        ret = np.array(ret)
+        ret = np.array(ret, dtype=float)
 
         ret[abs(ret) < 1e-10] = 0.0
 

--- a/tests/backends/test_backend_equivalence.py
+++ b/tests/backends/test_backend_equivalence.py
@@ -54,6 +54,29 @@ def is_proportional(first, second):
         partial(pq.PNCFockState, cutoff=CUTOFF),
     )
 )
+def test_get_fock_probabilities_should_be_numpy_array_of_floats(StateClass):
+    with pq.Program() as program:
+        pq.Q() | StateClass(d=3) | pq.Vacuum()
+
+        pq.Q(0) | pq.Squeezing(r=0.1, phi=0.6)
+
+    program.execute()
+
+    probabilities = program.state.get_fock_probabilities(cutoff=CUTOFF)
+
+    assert isinstance(probabilities, np.ndarray)
+    assert probabilities.dtype == np.float64
+
+
+@pytest.mark.parametrize(
+    "StateClass",
+    (
+        pq.GaussianState,
+        partial(pq.PureFockState, cutoff=CUTOFF),
+        partial(pq.FockState, cutoff=CUTOFF),
+        partial(pq.PNCFockState, cutoff=CUTOFF),
+    )
+)
 def test_get_fock_probabilities_with_squeezed_state(StateClass):
     with pq.Program() as program:
         pq.Q() | StateClass(d=3) | pq.Vacuum()


### PR DESCRIPTION
The type of the returned list of probabilities should be a numpy array
of floats, consistently. This has been fixed in `PNCFockState` and
`GaussianState`.

A test have been written accordingly.