### PR TITLE
Remove py36 and add py39 support.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v1

--- a/README.md
+++ b/README.md
@@ -27,5 +27,5 @@ pip install -rrequirements.txt
 Testing can be done with `tox` as well. Install `tox` and run tests with the following commands:
 ```
 pip install tox
-tox -e py38
+tox -e py39
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ flake8==3.8.3
 strawberryfields==0.16.0
 recommonmark==0.6.0
 sphinx_rtd_theme==0.5.0
-llvmlite==0.33.0
+llvmlite>=0.36.0
 furo==2021.2.28-beta.28
 matplotlib==3.3.4
 nbsphinx==0.8.5

--- a/setup.py
+++ b/setup.py
@@ -31,9 +31,9 @@ setup(
     url="https://github.com/Budapest-Quantum-Computing-Group/piquasso",
     keywords=["python", "piquasso"],
     install_requires=[
-        'boss-tomev==1.0.4; python_version >= "3.6"',
-        'numpy>=1.19.5; python_version >= "3.6"',
-        'scipy>=1.5.4; python_version >= "3.6"',
+        'boss-tomev==1.0.4; python_version >= "3.7"',
+        'numpy>=1.19.5; python_version >= "3.7"',
+        'scipy>=1.5.4; python_version >= "3.7"',
         'quantum-blackbird==0.2.4',
     ],
     classifiers=[

--- a/tox.ini
+++ b/tox.ini
@@ -4,13 +4,13 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py36, py37, py38
+envlist = py37, py38, py39
 
 [gh-actions]
 python =
-    3.6: py36
     3.7: py37
     3.8: py38
+    3.9: py39
 
 [testenv]
 deps = -rrequirements.txt


### PR DESCRIPTION
Python 3.6 has been removed from the supported versions and python 3.9 has been added.

llvmlite>=0.36.0 is required for py39; therefore, it has been changed in requirements.txt.

README.md, setup.py, tests.yml, and tox.ini has been updated accordingly.