### PR TITLE
fix(GaussianState): GBS sampling is biased

### DIFF
--- a/scripts/gbs_hypothesis_test_script.py
+++ b/scripts/gbs_hypothesis_test_script.py
@@ -21,7 +21,7 @@ import strawberryfields as sf
 
 def gbs_hypothesis_test_script(cramer_hypothesis_test):
     d = 5
-    shots = 1000
+    shots = 5000
 
     pq_state = pq.GaussianState(d=d)
 


### PR DESCRIPTION
We tried to be too smart.

The previous calculation introduced a bias, since it divided the
currently calculated probability by the previously calculated one to
acquire conditional probabilities. This is wrong, since the previous
probability was conditioned on a different heterodyne measurement,
corresponding to a different quantum state.

It hasn't been noticed with the hypothesis test. The issue was noticed
by observing that the set of conditional probabilities didn't always sum
up to one.

The calculation was rewritten to omit the previous probability.
Additionally, the normalization and the previos samples from the
occupation number factorial in the denominator can be omitted, since it
is the same for every "probabilites". Omitting these factors, the
variables got renamed to "weight(s)" from "probabilit(y|ies)".

To make the hypothesis test more reliable, the shots got increased to
5000 from only 1000.

Additionally, the `Q` matrix has been refactored into the `Q_matrix`
property.