### PR TITLE
feat(GaussianState): Threshold using hafnian

### DIFF
--- a/piquasso/api/constants.py
+++ b/piquasso/api/constants.py
@@ -31,6 +31,8 @@ HBAR = _HBAR_DEFAULT
 
 RNG = np.random.default_rng(_SEED)
 
+use_torontonian = False
+
 
 def reset_hbar() -> None:
     global HBAR

--- a/piquasso/instructions/measurements.py
+++ b/piquasso/instructions/measurements.py
@@ -64,10 +64,13 @@ class ThresholdMeasurement(Measurement):
     The generated samples contain :math:`0` or :math:`1`, where :math:`0` corresponds to
     no photon being detected, and :math:`1` corresponds to detection of at least one
     photon.
+
+    Args:
+        cutoff (int): The Fock space cutoff.
     """
 
-    def __init__(self) -> None:
-        super().__init__()
+    def __init__(self, cutoff: int = 5) -> None:
+        super().__init__(params=dict(cutoff=cutoff))
 
 
 class GeneraldyneMeasurement(Measurement):

--- a/scripts/threshold_histogram_using_torontonian_script.py
+++ b/scripts/threshold_histogram_using_torontonian_script.py
@@ -13,15 +13,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import subprocess
+
 import numpy as np
+import matplotlib.pyplot as plt
 
 import piquasso as pq
+
 import strawberryfields as sf
 
 
-def threshold_hypothesis_test_script(cramer_hypothesis_test):
+def threshold_histogram_script():
     d = 5
     shots = 2000
+
+    pq.constants.use_torontonian = True
 
     pq_state = pq.GaussianState(d=d)
 
@@ -67,6 +73,13 @@ def threshold_hypothesis_test_script(cramer_hypothesis_test):
     pq_results = np.array(pq_state.apply(pq_program, shots=shots).samples)
     sf_results = sf_engine.run(sf_program, shots=shots).samples
 
-    accepted = cramer_hypothesis_test(pq_results, sf_results)
+    n_bins = 20
 
-    assert accepted, "The hypothesis is not accepted."
+    fig, axs = plt.subplots(1, 2, sharey=True, tight_layout=True)
+
+    axs[0].hist(pq_results, bins=n_bins)
+    axs[1].hist(sf_results, bins=n_bins)
+
+    fig.savefig("histogram.png")
+
+    subprocess.call(('xdg-open', "histogram.png"))

--- a/scripts/threshold_hypothesis_test_using_torontonian_script.py
+++ b/scripts/threshold_hypothesis_test_using_torontonian_script.py
@@ -1,0 +1,74 @@
+#
+# Copyright 2021 Budapest Quantum Computing Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+
+import piquasso as pq
+import strawberryfields as sf
+
+
+def threshold_hypothesis_test_script(cramer_hypothesis_test):
+    d = 5
+    shots = 2000
+
+    pq.constants.use_torontonian = True
+
+    pq_state = pq.GaussianState(d=d)
+
+    with pq.Program() as pq_program:
+        pq.Q(0) | pq.Squeezing(r=1.0, phi=np.pi/1)
+        pq.Q(1) | pq.Squeezing(r=0.2, phi=np.pi/2)
+        pq.Q(2) | pq.Squeezing(r=0.3, phi=np.pi/3)
+        pq.Q(3) | pq.Squeezing(r=0.4, phi=np.pi/4)
+        pq.Q(4) | pq.Squeezing(r=1.0, phi=np.pi/5)
+
+        pq.Q(0, 1) | pq.Beamsplitter(0.0959408065906761, 0.06786053071484363)
+        pq.Q(2, 3) | pq.Beamsplitter(0.7730047654405018, 1.453770233324797)
+        pq.Q(1, 2) | pq.Beamsplitter(1.0152680371119776, 1.2863559998816205)
+        pq.Q(3, 4) | pq.Beamsplitter(1.3205517879465705, 0.5236836466492961)
+        pq.Q(0, 1) | pq.Beamsplitter(4.394480318177715,  4.481575657714487)
+        pq.Q(2, 3) | pq.Beamsplitter(2.2300919706807534, 1.5073556513699888)
+        pq.Q(1, 2) | pq.Beamsplitter(2.2679037068773673, 1.9550229282085838)
+        pq.Q(3, 4) | pq.Beamsplitter(3.340269832485504,  3.289367083610399)
+
+        pq.Q(0, 1, 2) | pq.ThresholdMeasurement()
+
+    sf_program = sf.Program(d)
+    sf_engine = sf.Engine(backend="gaussian")
+
+    with sf_program.context as q:
+        sf.ops.Sgate(1.0, phi=np.pi/1) | q[0]
+        sf.ops.Sgate(0.2, phi=np.pi/2) | q[1]
+        sf.ops.Sgate(0.3, phi=np.pi/3) | q[2]
+        sf.ops.Sgate(0.4, phi=np.pi/4) | q[3]
+        sf.ops.Sgate(1.0, phi=np.pi/5) | q[4]
+
+        sf.ops.BSgate(0.0959408065906761, 0.06786053071484363) | (q[0], q[1])
+        sf.ops.BSgate(0.7730047654405018, 1.453770233324797) | (q[2], q[3])
+        sf.ops.BSgate(1.0152680371119776, 1.2863559998816205) | (q[1], q[2])
+        sf.ops.BSgate(1.3205517879465705, 0.5236836466492961) | (q[3], q[4])
+        sf.ops.BSgate(4.394480318177715, 4.481575657714487) | (q[0], q[1])
+        sf.ops.BSgate(2.2300919706807534, 1.5073556513699888) | (q[2], q[3])
+        sf.ops.BSgate(2.2679037068773673, 1.9550229282085838) | (q[1], q[2])
+        sf.ops.BSgate(3.340269832485504, 3.289367083610399) | (q[3], q[4])
+
+        sf.ops.MeasureThreshold() | (q[0], q[1], q[2])
+
+    pq_results = np.array(pq_state.apply(pq_program, shots=shots).samples)
+    sf_results = sf_engine.run(sf_program, shots=shots).samples
+
+    accepted = cramer_hypothesis_test(pq_results, sf_results)
+
+    assert accepted, "The hypothesis is not accepted."

--- a/tests/backends/gaussian/test_measurements.py
+++ b/tests/backends/gaussian/test_measurements.py
@@ -257,9 +257,11 @@ def test_measure_particle_number_on_all_modes(state):
     assert result
 
 
-def test_measure_threshold_raises_NotImplementedError_for_nonzero_displacements(
+def test_displaced_ThresholdMeasurement_raises_NotImplementedError_with_torontonian(
     state,
 ):
+    pq.constants.use_torontonian = True
+
     state_with_nonzero_displacements = state
 
     with pq.Program() as program:
@@ -267,6 +269,8 @@ def test_measure_threshold_raises_NotImplementedError_for_nonzero_displacements(
 
     with pytest.raises(NotImplementedError):
         state_with_nonzero_displacements.apply(program)
+
+    pq.constants.use_torontonian = False
 
 
 def test_measure_threshold_on_one_modes(nondisplaced_state):


### PR DESCRIPTION
The `ThresholdMeasurement` can be performed via the GBS algorithm using
the hafnian, too. This is beneficial, since the latter is faster
asymptotically than the algorithm with the torontonian. The algorithm
works by mapping the non-zero results from the GBS samples to 1.

Both calculations are enabled by the `use_torontonian` flag in
`constants`, defaulted to `False`. This is not specified in the
constructor parameter of `ThresholdMeasurement`, since it is specific to
the simulation, but (should be) irrelevant regarding the results.

The `cutoff` optional parameter is added to `ThresholdMeasurement`.

**Notes**:

- The `cutoff` parameter is odd in `ThresholdMeasurement`, while the
  `use_torontonian` is technically a global variable. We might want to
  rethink this.

- The simulation using the hafnian doesn't seem to give exactly the same
  results as with the torontonian, but the results seem to be improving
  by increasing the cutoff.