### PR TITLE
feat(State): `apply_instructions`

### DIFF
--- a/piquasso/_backends/fock/state.py
+++ b/piquasso/_backends/fock/state.py
@@ -17,9 +17,8 @@ import numpy as np
 
 import abc
 import random
-from typing import Tuple, Generator, Any, Mapping, List
+from typing import Tuple, Generator, Any, Mapping
 
-from piquasso.instructions.preparations import StateVector
 from piquasso._math.fock import FockBasis
 from piquasso.api.config import Config
 from piquasso.api.instruction import Instruction
@@ -57,29 +56,6 @@ class BaseFockState(State, abc.ABC):
             d=d,
             cutoff=self._config.cutoff,
         )
-
-    @classmethod
-    def from_number_preparations(
-        cls,
-        *,
-        d: int,
-        number_preparations: List[StateVector],
-        config: Config = None,
-    ) -> "BaseFockState":
-        """
-        NOTE: Here is a small coupling between :class:`Instruction` and :class:`State`.
-        This is the only case (so far) where the user could specify instructions
-        directly.
-
-        Is this needed?
-        """
-
-        self = cls(d=d, config=config)
-
-        for number_preparation in number_preparations:
-            self._add_occupation_number_basis(**number_preparation.params)
-
-        return self
 
     @property
     def d(self) -> int:

--- a/tests/backends/fock/general/test_measurements.py
+++ b/tests/backends/fock/general/test_measurements.py
@@ -47,10 +47,12 @@ def test_measure_particle_number_on_one_mode():
     assert sample == (1, ) or sample == (2, )
 
     if sample == (1, ):
-        expected_state = pq.FockState.from_number_preparations(
+        expected_state = pq.FockState(
             d=3,
             config=config,
-            number_preparations=[
+        )
+        expected_state.apply_instructions(
+            instructions=[
                 1/3 * pq.DensityMatrix(ket=(0, 0, 1), bra=(0, 0, 1)),
                 4j * pq.DensityMatrix(ket=(0, 0, 1), bra=(0, 1, 1)),
                 -2j * pq.DensityMatrix(ket=(0, 0, 1), bra=(1, 0, 1)),
@@ -61,10 +63,12 @@ def test_measure_particle_number_on_one_mode():
         )
 
     elif sample == (2, ):
-        expected_state = pq.FockState.from_number_preparations(
+        expected_state = pq.FockState(
             d=3,
             config=config,
-            number_preparations=[
+        )
+        expected_state.apply_instructions(
+            instructions=[
                 pq.DensityMatrix(ket=(0, 0, 2), bra=(0, 0, 2))
             ]
         )
@@ -101,10 +105,9 @@ def test_measure_particle_number_on_two_modes():
     assert sample == (0, 1) or sample == (1, 1) or sample == (0, 2)
 
     if sample == (0, 1):
-        expected_state = pq.FockState.from_number_preparations(
-            d=3,
-            config=config,
-            number_preparations=[
+        expected_state = pq.FockState(d=3, config=config)
+        expected_state.apply_instructions(
+            instructions=[
                 pq.DensityMatrix(ket=(0, 0, 1), bra=(0, 0, 1)),
                 pq.DensityMatrix(ket=(0, 0, 1), bra=(1, 0, 1)) * (-6j),
                 pq.DensityMatrix(ket=(1, 0, 1), bra=(0, 0, 1)) * 6j,
@@ -112,19 +115,17 @@ def test_measure_particle_number_on_two_modes():
         )
 
     elif sample == (1, 1):
-        expected_state = pq.FockState.from_number_preparations(
-            d=3,
-            config=config,
-            number_preparations=[
+        expected_state = pq.FockState(d=3, config=config)
+        expected_state.apply_instructions(
+            instructions=[
                 pq.DensityMatrix(ket=(0, 1, 1), bra=(0, 1, 1)),
             ]
         )
 
     elif sample == (0, 2):
-        expected_state = pq.FockState.from_number_preparations(
-            d=3,
-            config=config,
-            number_preparations=[
+        expected_state = pq.FockState(d=3, config=config)
+        expected_state.apply_instructions(
+            instructions=[
                 pq.DensityMatrix(ket=(0, 0, 2), bra=(0, 0, 2))
             ]
         )
@@ -159,28 +160,25 @@ def test_measure_particle_number_on_all_modes():
     assert sample == (0, 0, 0) or sample == (0, 0, 1) or sample == (1, 0, 0)
 
     if sample == (0, 0, 0):
-        expected_state = pq.FockState.from_number_preparations(
-            d=3,
-            config=config,
-            number_preparations=[
+        expected_state = pq.FockState(d=3, config=config)
+        expected_state.apply_instructions(
+            instructions=[
                 pq.DensityMatrix(ket=(0, 0, 0), bra=(0, 0, 0)),
             ]
         )
 
     elif sample == (0, 0, 1):
-        expected_state = pq.FockState.from_number_preparations(
-            d=3,
-            config=config,
-            number_preparations=[
+        expected_state = pq.FockState(d=3, config=config)
+        expected_state.apply_instructions(
+            instructions=[
                 pq.DensityMatrix(ket=(0, 0, 1), bra=(0, 0, 1)),
             ]
         )
 
     elif sample == (1, 0, 0):
-        expected_state = pq.FockState.from_number_preparations(
-            d=3,
-            config=config,
-            number_preparations=[
+        expected_state = pq.FockState(d=3, config=config)
+        expected_state.apply_instructions(
+            instructions=[
                 pq.DensityMatrix(ket=(1, 0, 0), bra=(1, 0, 0)),
             ]
         )

--- a/tests/backends/fock/pure/test_measurements.py
+++ b/tests/backends/fock/pure/test_measurements.py
@@ -37,18 +37,18 @@ def test_measure_particle_number_on_one_mode():
     assert sample == (1, ) or sample == (2, )
 
     if sample == (1, ):
-        expected_state = pq.PureFockState.from_number_preparations(
-            d=3,
-            number_preparations=[
+        expected_state = pq.PureFockState(d=3)
+        expected_state.apply_instructions(
+            instructions=[
                 0.5773502691896258 * pq.StateVector(0, 0, 1),
                 0.816496580927726 * pq.StateVector(0, 1, 1),
             ]
         )
 
     elif sample == (2, ):
-        expected_state = pq.PureFockState.from_number_preparations(
-            d=3,
-            number_preparations=[
+        expected_state = pq.PureFockState(d=3)
+        expected_state.apply_instructions(
+            instructions=[
                 pq.StateVector(0, 0, 2)
             ]
         )
@@ -73,25 +73,25 @@ def test_measure_particle_number_on_two_modes():
     assert sample == (0, 1) or sample == (1, 1) or sample == (0, 2)
 
     if sample == (0, 1):
-        expected_state = pq.PureFockState.from_number_preparations(
-            d=3,
-            number_preparations=[
+        expected_state = pq.PureFockState(d=3)
+        expected_state.apply_instructions(
+            instructions=[
                 pq.StateVector(0, 0, 1)
             ]
         )
 
     elif sample == (1, 1):
-        expected_state = pq.PureFockState.from_number_preparations(
-            d=3,
-            number_preparations=[
+        expected_state = pq.PureFockState(d=3)
+        expected_state.apply_instructions(
+            instructions=[
                 pq.StateVector(0, 1, 1)
             ]
         )
 
     elif sample == (0, 2):
-        expected_state = pq.PureFockState.from_number_preparations(
-            d=3,
-            number_preparations=[
+        expected_state = pq.PureFockState(d=3)
+        expected_state.apply_instructions(
+            instructions=[
                 pq.StateVector(0, 0, 2)
             ]
         )
@@ -122,28 +122,25 @@ def test_measure_particle_number_on_all_modes():
     assert sample == (0, 0, 0) or sample == (1, 0, 0) or sample == (0, 0, 1)
 
     if sample == (0, 0, 0):
-        expected_state = pq.PureFockState.from_number_preparations(
-            d=3,
-            config=config,
-            number_preparations=[
+        expected_state = pq.PureFockState(d=3, config=config)
+        expected_state.apply_instructions(
+            instructions=[
                 pq.StateVector(0, 0, 0),
             ],
         )
 
     elif sample == (0, 0, 1):
-        expected_state = pq.PureFockState.from_number_preparations(
-            d=3,
-            config=config,
-            number_preparations=[
+        expected_state = pq.PureFockState(d=3, config=config)
+        expected_state.apply_instructions(
+            instructions=[
                 pq.StateVector(0, 0, 1),
             ]
         )
 
     elif sample == (1, 0, 0):
-        expected_state = pq.PureFockState.from_number_preparations(
-            d=3,
-            config=config,
-            number_preparations=[
+        expected_state = pq.PureFockState(d=3, config=config)
+        expected_state.apply_instructions(
+            instructions=[
                 pq.StateVector(1, 0, 0),
             ],
         )


### PR DESCRIPTION
**Problem**

The `BaseFockState.from_number_preparations` is not very specific, it
could be generalized to any state. Moreover, it is quite disturbing to
have another constructor for the `BaseFockState` subclasses.

**Solution**

The `State.apply_instructions` method has been created, which has been
refactored from `State.apply`.

Moreover, in `apply_instructions`, if the instruction doesn't have a
`modes` attribute, then it is assumed that the instruction is applied
to all the modes.