### PR TITLE
ci: Unit tests should run last

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,7 +1,7 @@
 [flake8]
 # Longer line-length is more convenient for math
 max-line-length = 88
-exclude = .tox,pennylane,.venv
+exclude = .tox,.venv
 extend-ignore = W605,  # Ignoring latex syntax in docstrings
                 E201,  # Ignoring whitespace after '(' or '[' for matrices
 		E203

--- a/tox.ini
+++ b/tox.ini
@@ -15,10 +15,10 @@ python =
 [testenv]
 deps = -rrequirements.txt
 commands =
-    coverage run -m pytest tests -s
+    flake8
     black --check .
-    flake8 --exclude='.tox,.venv'
     mypy piquasso
+    coverage run -m pytest tests -s
     coverage xml --omit='.tox/*','*/tests/*'
     coverage erase
 


### PR DESCRIPTION
If e.g. there is a linter or formatter error, the unit tests are still
executed regardless. To spare time, the faster checks are placed before
the longer unit test run.

Moreover, `pennylane` has been removed from the `.flake8` config file,
since we don't use `pennylane` anymore.