### PR TITLE
feat: Delete module override of main module

### DIFF
--- a/piquasso/__init__.py
+++ b/piquasso/__init__.py
@@ -16,15 +16,7 @@
 """The Piquasso module.
 
 One can access all the instructions and states from here as attributes.
-
-Important:
-    It is preferred to access every Piquasso object from this module directly if
-    possible, especially when you're using a plugin.
 """
-
-import sys
-from types import ModuleType
-from typing import Type, List, Any
 
 from piquasso.api.mode import Q
 from piquasso.api.config import Config
@@ -37,7 +29,7 @@ from piquasso._backends.sampling import SamplingState
 from piquasso._backends.gaussian import GaussianState
 from piquasso._backends.fock import FockState, PureFockState
 
-from piquasso.core import _registry
+from piquasso.core import registry
 
 from .instructions.preparations import (
     Vacuum,
@@ -130,10 +122,6 @@ _default_channels = {
 }
 
 
-def use(plugin: Type[Plugin]) -> None:
-    _registry.use_plugin(plugin, override=True)
-
-
 class _DefaultPlugin(Plugin):
     classes = {
         "SamplingState": SamplingState,
@@ -147,25 +135,7 @@ class _DefaultPlugin(Plugin):
     }
 
 
-_registry.use_plugin(_DefaultPlugin)
-
-
-class Piquasso(ModuleType):
-    def __init__(self, module: ModuleType) -> None:
-        self._module = module
-
-    def __getattr__(self, attribute: Any) -> Any:
-        try:
-            return _registry.items[attribute]
-        except KeyError:
-            return getattr(self._module, attribute)
-
-    def __dir__(self) -> List[str]:
-        return dir(self._module)
-
-
-Piquasso.__doc__ = sys.modules[__name__].__doc__
-sys.modules[__name__] = Piquasso(sys.modules[__name__])
+registry.use_plugin(_DefaultPlugin)
 
 
 __all__ = [

--- a/piquasso/api/instruction.py
+++ b/piquasso/api/instruction.py
@@ -19,7 +19,7 @@ from typing import Tuple, Any
 import numpy as np
 
 from .mode import Q
-from piquasso.core import _mixins, _registry
+from piquasso.core import _mixins, registry
 from piquasso.api.errors import InvalidProgram
 
 if typing.TYPE_CHECKING:
@@ -92,7 +92,7 @@ class Instruction(_mixins.DictMixin, _mixins.RegisterMixin, _mixins.CodeMixin):
                 An :class:`Instruction` initialized using the specified `dict`.
         """
 
-        class_ = _registry.get_class(dict_["type"])
+        class_ = registry.get_class(dict_["type"])
 
         instruction = class_(**dict_["attributes"]["constructor_kwargs"])
 

--- a/piquasso/api/state.py
+++ b/piquasso/api/state.py
@@ -25,7 +25,7 @@ from piquasso.api.errors import InvalidParameter
 from piquasso.api.result import Result
 from piquasso.api.instruction import Instruction
 
-from piquasso.core import _mixins, _registry
+from piquasso.core import _mixins, registry
 
 
 class State(_mixins.DictMixin, _mixins.CodeMixin, abc.ABC):
@@ -53,7 +53,7 @@ class State(_mixins.DictMixin, _mixins.CodeMixin, abc.ABC):
 
     @classmethod
     def from_dict(cls, dict_: dict) -> "State":
-        class_ = _registry.get_class(dict_["type"])
+        class_ = registry.get_class(dict_["type"])
         return class_(**dict_["attributes"]["constructor_kwargs"])
 
     def copy(self) -> "State":

--- a/piquasso/core/_blackbird.py
+++ b/piquasso/core/_blackbird.py
@@ -19,7 +19,7 @@ from typing import List, Mapping, Optional, Type
 
 import blackbird as bb
 
-from . import _registry
+from . import registry
 from .. import Instruction
 from ..api.errors import PiquassoException
 
@@ -35,21 +35,21 @@ def load_instructions(blackbird_program: bb.BlackbirdProgram) -> List[Instructio
     """
 
     instruction_map = {
-        "Dgate": _registry.items["Displacement"],
-        "Xgate": _registry.items["PositionDisplacement"],
-        "Zgate": _registry.items["MomentumDisplacement"],
-        "Sgate": _registry.items["Squeezing"],
-        "Pgate": _registry.items["QuadraticPhase"],
+        "Dgate": registry.get_class("Displacement"),
+        "Xgate": registry.get_class("PositionDisplacement"),
+        "Zgate": registry.get_class("MomentumDisplacement"),
+        "Sgate": registry.get_class("Squeezing"),
+        "Pgate": registry.get_class("QuadraticPhase"),
         "Vgate": None,
-        "Kgate": _registry.items["Kerr"],
-        "Rgate": _registry.items["Phaseshifter"],
-        "BSgate": _registry.items["Beamsplitter"],
-        "MZgate": _registry.items["MachZehnder"],
-        "S2gate": _registry.items["Squeezing2"],
-        "CXgate": _registry.items["ControlledX"],
-        "CZgate": _registry.items["ControlledZ"],
-        "CKgate": _registry.items["CrossKerr"],
-        "Fouriergate": _registry.items["Fourier"],
+        "Kgate": registry.get_class("Kerr"),
+        "Rgate": registry.get_class("Phaseshifter"),
+        "BSgate": registry.get_class("Beamsplitter"),
+        "MZgate": registry.get_class("MachZehnder"),
+        "S2gate": registry.get_class("Squeezing2"),
+        "CXgate": registry.get_class("ControlledX"),
+        "CZgate": registry.get_class("ControlledZ"),
+        "CKgate": registry.get_class("CrossKerr"),
+        "Fouriergate": registry.get_class("Fourier"),
     }
 
     return [

--- a/piquasso/core/registry.py
+++ b/piquasso/core/registry.py
@@ -17,16 +17,22 @@
 from typing import Type, Any
 
 from piquasso.api.plugin import Plugin
+from piquasso.api.errors import PiquassoException
 
-items = {}
+_items = {}
 
 
 def use_plugin(plugin: Type[Plugin], override: bool = False) -> None:
     for name, class_ in plugin.classes.items():
+        if not override and name in _items:
+            raise PiquassoException(
+                "Name conflict in the registry. Use 'override=True' in 'use_plugin' in "
+                "order to override existing items."
+            )
+
         class_.__name__ = name
-        if override or name not in items:
-            items[name] = class_
+        _items[name] = class_
 
 
 def get_class(name: str) -> Any:
-    return items[name]
+    return _items[name]

--- a/tests/api/program/conftest.py
+++ b/tests/api/program/conftest.py
@@ -20,12 +20,17 @@ import pytest
 import piquasso as pq
 
 
-@pytest.fixture(autouse=True)
-def setup_plugin():
+@pytest.fixture
+def DummyInstruction():
     class DummyInstruction(pq.Instruction):
         def __init__(self, **params):
             super().__init__(params=params)
 
+    return DummyInstruction
+
+
+@pytest.fixture
+def FakeState():
     class FakeState(pq.State):
         _instruction_map = {
             "DummyInstruction": "dummy_instruction",
@@ -38,10 +43,4 @@ def setup_plugin():
         def get_particle_detection_probability(self, occupation_number: tuple) -> float:
             raise NotImplementedError
 
-    class FakePlugin(pq.Plugin):
-        classes = {
-            "FakeState": FakeState,
-            "DummyInstruction": DummyInstruction,
-        }
-
-    pq.use(FakePlugin)
+    return FakeState

--- a/tests/api/program/test_instruction_registration.py
+++ b/tests/api/program/test_instruction_registration.py
@@ -16,9 +16,9 @@
 import piquasso as pq
 
 
-def test_single_mode_single_instruction_registry():
+def test_single_mode_single_instructionregistry(DummyInstruction):
     with pq.Program() as program:
-        pq.Q(0) | pq.DummyInstruction(dummyparam=420)
+        pq.Q(0) | DummyInstruction(dummyparam=420)
 
     assert len(program.instructions) == 1
 
@@ -26,9 +26,9 @@ def test_single_mode_single_instruction_registry():
     assert program.instructions[0].params == {"dummyparam": 420}
 
 
-def test_single_mode_multiple_instruction_registry():
+def test_single_mode_multiple_instructionregistry(DummyInstruction):
     with pq.Program() as program:
-        pq.Q(0, 1) | pq.DummyInstruction(dummyparam=420) | pq.DummyInstruction(
+        pq.Q(0, 1) | DummyInstruction(dummyparam=420) | DummyInstruction(
             dummyparam1=42, dummyparam2=320
         )
 
@@ -44,11 +44,11 @@ def test_single_mode_multiple_instruction_registry():
     }
 
 
-def test_multiple_mode_single_instruction_registry():
+def test_multiple_mode_single_instructionregistry(DummyInstruction):
     with pq.Program() as program:
-        pq.Q(2, 1, 0) | pq.DummyInstruction(dummyparam1=421)
-        pq.Q(1) | pq.DummyInstruction(dummyparam2=1)
-        pq.Q(0, 2) | pq.DummyInstruction(dummyparam3=999)
+        pq.Q(2, 1, 0) | DummyInstruction(dummyparam1=421)
+        pq.Q(1) | DummyInstruction(dummyparam2=1)
+        pq.Q(0, 2) | DummyInstruction(dummyparam3=999)
 
     assert len(program.instructions) == 3
 
@@ -62,11 +62,11 @@ def test_multiple_mode_single_instruction_registry():
     assert program.instructions[2].params == {"dummyparam3": 999}
 
 
-def test_multiple_mode_multiple_instruction_registry():
+def test_multiple_mode_multiple_instructionregistry(DummyInstruction):
     with pq.Program() as program:
-        pq.Q(4) | pq.DummyInstruction(param=2) | pq.DummyInstruction(param=0)
-        pq.Q(0, 2) | pq.DummyInstruction(param=999)
-        pq.Q(1, 0) | pq.DummyInstruction(param=1) | pq.DummyInstruction(param=9)
+        pq.Q(4) | DummyInstruction(param=2) | DummyInstruction(param=0)
+        pq.Q(0, 2) | DummyInstruction(param=999)
+        pq.Q(1, 0) | DummyInstruction(param=1) | DummyInstruction(param=9)
 
     assert len(program.instructions) == 5
 
@@ -86,21 +86,27 @@ def test_multiple_mode_multiple_instruction_registry():
     assert program.instructions[4].params == {"param": 9}
 
 
-def test_instruction_registration_with_no_modes_is_resolved_to_all_modes():
+def test_instruction_registration_with_no_modes_is_resolved_to_all_modes(
+    DummyInstruction,
+    FakeState,
+):
     with pq.Program() as program:
-        pq.Q() | pq.DummyInstruction(param="some-parameter")
+        pq.Q() | DummyInstruction(param="some-parameter")
 
-    state = pq.FakeState()
+    state = FakeState()
     state.apply(program)
 
     assert program.instructions[0].modes == tuple(range(state.d))
 
 
-def test_instruction_registration_with_all_keyword_is_resolved_to_all_modes():
+def test_instruction_registration_with_all_keyword_is_resolved_to_all_modes(
+    DummyInstruction,
+    FakeState,
+):
     with pq.Program() as program:
-        pq.Q(all) | pq.DummyInstruction(param="some-parameter")
+        pq.Q(all) | DummyInstruction(param="some-parameter")
 
-    state = pq.FakeState()
+    state = FakeState()
     state.apply(program)
 
     assert program.instructions[0].modes == tuple(range(state.d))

--- a/tests/api/program/test_program_stacking.py
+++ b/tests/api/program/test_program_stacking.py
@@ -16,10 +16,10 @@
 import piquasso as pq
 
 
-def test_single_instruction_program_stacking():
+def test_single_instruction_program_stacking(DummyInstruction):
     sub_program = pq.Program()
     with sub_program:
-        pq.Q(0, 1) | pq.DummyInstruction(param=420)
+        pq.Q(0, 1) | DummyInstruction(param=420)
 
     with pq.Program() as program:
         pq.Q(0, 1) | sub_program
@@ -28,11 +28,11 @@ def test_single_instruction_program_stacking():
     assert program.instructions[0].params == {"param": 420}
 
 
-def test_multiple_instruction_program_stacking():
+def test_multiple_instruction_program_stacking(DummyInstruction):
     sub_program = pq.Program()
     with sub_program:
-        pq.Q(0) | pq.DummyInstruction(param=2) | pq.DummyInstruction(param=4)
-        pq.Q(2, 3) | pq.DummyInstruction(param=10)
+        pq.Q(0) | DummyInstruction(param=2) | DummyInstruction(param=4)
+        pq.Q(2, 3) | DummyInstruction(param=10)
 
     with pq.Program() as program:
         pq.Q(0, 1, 2, 3) | sub_program
@@ -47,15 +47,15 @@ def test_multiple_instruction_program_stacking():
     assert program.instructions[2].params == {"param": 10}
 
 
-def test_multiple_instruction_mixed_program_stacking():
+def test_multiple_instruction_mixed_program_stacking(DummyInstruction):
     sub_program = pq.Program()
     with sub_program:
-        pq.Q(0, 1) | pq.DummyInstruction(param=10)
+        pq.Q(0, 1) | DummyInstruction(param=10)
 
     with pq.Program() as program:
-        pq.Q(2) | pq.DummyInstruction(param=2)
+        pq.Q(2) | DummyInstruction(param=2)
         pq.Q(0, 1) | sub_program
-        pq.Q(3) | pq.DummyInstruction(param=0)
+        pq.Q(3) | DummyInstruction(param=0)
 
     assert program.instructions[0].modes == (2,)
     assert program.instructions[0].params == {"param": 2}
@@ -67,11 +67,11 @@ def test_multiple_instruction_mixed_program_stacking():
     assert program.instructions[2].params == {"param": 0}
 
 
-def test_mixed_index_program_stacking():
+def test_mixed_index_program_stacking(DummyInstruction):
     sub_program = pq.Program()
     with sub_program:
-        pq.Q(0, 1) | pq.DummyInstruction(param=10)
-        pq.Q(2, 3) | pq.DummyInstruction(param=100)
+        pq.Q(0, 1) | DummyInstruction(param=10)
+        pq.Q(2, 3) | DummyInstruction(param=100)
 
     with pq.Program() as program:
         pq.Q(0, 2, 1, 3) | sub_program

--- a/tests/api/test_blackbird.py
+++ b/tests/api/test_blackbird.py
@@ -73,7 +73,7 @@ def test_loads_blackbird_parses_operations_with_classes_from_plugin():
             "Beamsplitter": MyBeamsplitter,
         }
 
-    pq.use(Plugin)
+    pq.registry.use_plugin(Plugin, override=True)
 
     program = pq.Program()
 

--- a/tests/api/test_parsing.py
+++ b/tests/api/test_parsing.py
@@ -18,7 +18,7 @@ import pytest
 import piquasso as pq
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def FakeInstruction():
     class FakeInstruction(pq.Instruction):
         def __init__(self, first_param, second_param):
@@ -32,7 +32,7 @@ def FakeInstruction():
     return FakeInstruction
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def FakeState():
     class FakeState(pq.State):
         _instruction_map = {
@@ -58,7 +58,7 @@ def FakeState():
     return FakeState
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture(autouse=True, scope="module")
 def setup(FakeState, FakeInstruction):
     class FakePlugin(pq.Plugin):
         classes = {
@@ -66,7 +66,7 @@ def setup(FakeState, FakeInstruction):
             "FakeInstruction": FakeInstruction,
         }
 
-    pq.use(FakePlugin)
+    pq.registry.use_plugin(FakePlugin)
 
 
 @pytest.fixture

--- a/tests/test_instructions.py
+++ b/tests/test_instructions.py
@@ -47,7 +47,7 @@ def test_instruction_initialization_from_dict():
             "DummyInstruction": DummyInstruction,
         }
 
-    pq.use(DummyPlugin)
+    pq.registry.use_plugin(DummyPlugin)
 
     instruction = Instruction.from_dict(instruction_dict)
 


### PR DESCRIPTION
**Problem**

A huge problem with `piquasso` is that the main module is overridden
with a custom class in order to override `__getattr__` to access items
from the `core._registry`. This enables the user to override classes in
`piquasso` dynamically.

Dynamic overriding is not necessarily needed: the idea behind this was
that in a script, one should be able change the underlying algorithms
with a `pq.use(SomePlugin)` call. Without this, one would have to change
the underlying classes (typically `State` subclasses). However, this can
easily be parametrized in the script as well.

Moreover, it can also cause major confusion: at first sight it is not
that apparent, that a different implementation is running than the
original.

**Solution**

Overriding the main module has been deleted. The `registry` is kept,
since we need to resolve classes from dicts and blackbird code, still.

We also want to support overriding classes, since it is also desired to
JSONs from an API call in the future, and it is convenient not to change
the JSON schema in the UI with the change of classes in the backend.