### PR TITLE
fix(tests): Wrong class as `initial_state`

### DIFF
--- a/tests/api/test_simulator.py
+++ b/tests/api/test_simulator.py
@@ -188,3 +188,42 @@ def test_program_execution_with_measurement_not_being_last_raises_InvalidSimulat
 
     with pytest.raises(pq.api.errors.InvalidSimulation):
         simulator.execute(program)
+
+
+def test_program_execution_with_initial_state(
+    FakeSimulator,
+    FakeGate,
+    FakeState,
+):
+    with pq.Program() as program:
+        pq.Q() | FakeGate()
+
+    simulator = FakeSimulator(d=1)
+
+    state = FakeState(d=1)
+
+    simulator.validate(program)
+    simulator.execute(program, initial_state=state)
+
+
+def test_program_execution_with_initial_state_of_wrong_type_raises_InvalidState(
+    FakeSimulator,
+    FakeGate,
+    FakeState,
+):
+    class OtherFakeState(FakeState):
+        pass
+
+    FakeSimulator.state_class = OtherFakeState
+
+    with pq.Program() as program:
+        pq.Q() | FakeGate()
+
+    simulator = FakeSimulator(d=1)
+
+    state = FakeState(d=1)
+
+    simulator.validate(program)
+
+    with pytest.raises(pq.api.errors.InvalidState):
+        simulator.execute(program, initial_state=state)

--- a/tests/backends/fock/test_preparations.py
+++ b/tests/backends/fock/test_preparations.py
@@ -22,8 +22,9 @@ def test_from_fock_state_preserves_fock_probabilities():
     with pq.Program() as pure_state_preparation_program:
         pq.Q(1) | pq.StateVector([1])
 
-    simulator = pq.PureFockSimulator(d=2, config=pq.Config(cutoff=4))
-    pure_state_preparation_state = simulator.execute(
+    pure_simulator = pq.PureFockSimulator(d=2, config=pq.Config(cutoff=4))
+    mixed_simulator = pq.FockSimulator(d=2, config=pq.Config(cutoff=4))
+    pure_state_preparation_state = pure_simulator.execute(
         pure_state_preparation_program
     ).state
 
@@ -35,12 +36,12 @@ def test_from_fock_state_preserves_fock_probabilities():
     with pq.Program() as mixed_state_program:
         pq.Q(0, 1) | beamsplitter
 
-    pure_state = simulator.execute(
+    pure_state = pure_simulator.execute(
         pure_state_program,
         initial_state=pure_state_preparation_state,
     ).state
 
-    mixed_state = simulator.execute(
+    mixed_state = mixed_simulator.execute(
         mixed_state_program,
         initial_state=pq.FockState.from_fock_state(pure_state_preparation_state),
     ).state


### PR DESCRIPTION
There was a test which specified a `FockState` for a
`PureFockSimulator`. It went unnoticed due to the way the calculations
are registered, but it wouldn't work with a `DensityMatrix` registered
in the program.

Tests were written for these cases.