### PR TITLE
Removing odd attributes from `State`

### DIFF
--- a/piquasso/_backends/fock/general/calculations.py
+++ b/piquasso/_backends/fock/general/calculations.py
@@ -25,13 +25,13 @@ from piquasso.api.instruction import Instruction
 from piquasso.api.result import Result
 
 
-def vacuum(state: FockState, instruction: Instruction) -> FockState:
+def vacuum(state: FockState, instruction: Instruction) -> Result:
     state.reset()
 
-    return state
+    return Result(state=state)
 
 
-def passive_linear(state: FockState, instruction: Instruction) -> FockState:
+def passive_linear(state: FockState, instruction: Instruction) -> Result:
     operator: np.ndarray = instruction._all_params["passive_block"]
 
     index = state._get_operator_index(instruction.modes)
@@ -46,12 +46,10 @@ def passive_linear(state: FockState, instruction: Instruction) -> FockState:
         fock_operator @ state._density_matrix @ fock_operator.conjugate().transpose()
     )
 
-    return state
+    return Result(state=state)
 
 
-def particle_number_measurement(
-    state: FockState, instruction: Instruction
-) -> FockState:
+def particle_number_measurement(state: FockState, instruction: Instruction) -> Result:
     probability_map = _get_probability_map(
         state=state,
         modes=instruction.modes,
@@ -75,9 +73,7 @@ def particle_number_measurement(
         normalization=normalization,
     )
 
-    state.result = Result(samples=samples)  # type: ignore
-
-    return state
+    return Result(state=state, samples=samples)  # type: ignore
 
 
 def _get_probability_map(
@@ -135,27 +131,27 @@ def _get_projected_density_matrix(
     return new_density_matrix
 
 
-def create(state: FockState, instruction: Instruction) -> FockState:
+def create(state: FockState, instruction: Instruction) -> Result:
     operator = state._space.get_creation_operator(instruction.modes)
 
     state._density_matrix = operator @ state._density_matrix @ operator.transpose()
 
     state.normalize()
 
-    return state
+    return Result(state=state)
 
 
-def annihilate(state: FockState, instruction: Instruction) -> FockState:
+def annihilate(state: FockState, instruction: Instruction) -> Result:
     operator = state._space.get_annihilation_operator(instruction.modes)
 
     state._density_matrix = operator @ state._density_matrix @ operator.transpose()
 
     state.normalize()
 
-    return state
+    return Result(state=state)
 
 
-def kerr(state: FockState, instruction: Instruction) -> FockState:
+def kerr(state: FockState, instruction: Instruction) -> Result:
     mode = instruction.modes[0]
     xi = instruction._all_params["xi"]
 
@@ -169,10 +165,10 @@ def kerr(state: FockState, instruction: Instruction) -> FockState:
 
         state._density_matrix[index] *= coefficient
 
-    return state
+    return Result(state=state)
 
 
-def cross_kerr(state: FockState, instruction: Instruction) -> FockState:
+def cross_kerr(state: FockState, instruction: Instruction) -> Result:
     modes = instruction.modes
     xi = instruction._all_params["xi"]
 
@@ -188,10 +184,10 @@ def cross_kerr(state: FockState, instruction: Instruction) -> FockState:
 
         state._density_matrix[index] *= coefficient
 
-    return state
+    return Result(state=state)
 
 
-def linear(state: FockState, instruction: Instruction) -> FockState:
+def linear(state: FockState, instruction: Instruction) -> Result:
     operator = state._space.get_linear_fock_operator(
         modes=instruction.modes,
         cache_size=state._config.cache_size,
@@ -207,13 +203,13 @@ def linear(state: FockState, instruction: Instruction) -> FockState:
 
     state.normalize()
 
-    return state
+    return Result(state=state)
 
 
-def density_matrix_instruction(state: FockState, instruction: Instruction) -> FockState:
+def density_matrix_instruction(state: FockState, instruction: Instruction) -> Result:
     _add_occupation_number_basis(state, **instruction.params)
 
-    return state
+    return Result(state=state)
 
 
 def _add_occupation_number_basis(

--- a/piquasso/_backends/fock/general/calculations.py
+++ b/piquasso/_backends/fock/general/calculations.py
@@ -25,13 +25,13 @@ from piquasso.api.instruction import Instruction
 from piquasso.api.result import Result
 
 
-def vacuum(state: FockState, instruction: Instruction) -> Result:
+def vacuum(state: FockState, instruction: Instruction, shots: int) -> Result:
     state.reset()
 
     return Result(state=state)
 
 
-def passive_linear(state: FockState, instruction: Instruction) -> Result:
+def passive_linear(state: FockState, instruction: Instruction, shots: int) -> Result:
     operator: np.ndarray = instruction._all_params["passive_block"]
 
     index = state._get_operator_index(instruction.modes)
@@ -49,7 +49,9 @@ def passive_linear(state: FockState, instruction: Instruction) -> Result:
     return Result(state=state)
 
 
-def particle_number_measurement(state: FockState, instruction: Instruction) -> Result:
+def particle_number_measurement(
+    state: FockState, instruction: Instruction, shots: int
+) -> Result:
     probability_map = _get_probability_map(
         state=state,
         modes=instruction.modes,
@@ -58,7 +60,7 @@ def particle_number_measurement(state: FockState, instruction: Instruction) -> R
     samples = random.choices(
         population=list(probability_map.keys()),
         weights=list(probability_map.values()),
-        k=state.shots,
+        k=shots,
     )
 
     # NOTE: We choose the last sample for multiple shots.
@@ -131,7 +133,7 @@ def _get_projected_density_matrix(
     return new_density_matrix
 
 
-def create(state: FockState, instruction: Instruction) -> Result:
+def create(state: FockState, instruction: Instruction, shots: int) -> Result:
     operator = state._space.get_creation_operator(instruction.modes)
 
     state._density_matrix = operator @ state._density_matrix @ operator.transpose()
@@ -141,7 +143,7 @@ def create(state: FockState, instruction: Instruction) -> Result:
     return Result(state=state)
 
 
-def annihilate(state: FockState, instruction: Instruction) -> Result:
+def annihilate(state: FockState, instruction: Instruction, shots: int) -> Result:
     operator = state._space.get_annihilation_operator(instruction.modes)
 
     state._density_matrix = operator @ state._density_matrix @ operator.transpose()
@@ -151,7 +153,7 @@ def annihilate(state: FockState, instruction: Instruction) -> Result:
     return Result(state=state)
 
 
-def kerr(state: FockState, instruction: Instruction) -> Result:
+def kerr(state: FockState, instruction: Instruction, shots: int) -> Result:
     mode = instruction.modes[0]
     xi = instruction._all_params["xi"]
 
@@ -168,7 +170,7 @@ def kerr(state: FockState, instruction: Instruction) -> Result:
     return Result(state=state)
 
 
-def cross_kerr(state: FockState, instruction: Instruction) -> Result:
+def cross_kerr(state: FockState, instruction: Instruction, shots: int) -> Result:
     modes = instruction.modes
     xi = instruction._all_params["xi"]
 
@@ -187,7 +189,7 @@ def cross_kerr(state: FockState, instruction: Instruction) -> Result:
     return Result(state=state)
 
 
-def linear(state: FockState, instruction: Instruction) -> Result:
+def linear(state: FockState, instruction: Instruction, shots: int) -> Result:
     operator = state._space.get_linear_fock_operator(
         modes=instruction.modes,
         cache_size=state._config.cache_size,
@@ -206,7 +208,9 @@ def linear(state: FockState, instruction: Instruction) -> Result:
     return Result(state=state)
 
 
-def density_matrix_instruction(state: FockState, instruction: Instruction) -> Result:
+def density_matrix_instruction(
+    state: FockState, instruction: Instruction, shots: int
+) -> Result:
     _add_occupation_number_basis(state, **instruction.params)
 
     return Result(state=state)

--- a/piquasso/_backends/fock/pure/calculations.py
+++ b/piquasso/_backends/fock/pure/calculations.py
@@ -28,7 +28,7 @@ from piquasso._math.fock import FockBasis
 
 def particle_number_measurement(
     state: PureFockState, instruction: Instruction
-) -> PureFockState:
+) -> Result:
     probability_map = _get_probability_map(
         state=state,
         modes=instruction.modes,
@@ -52,18 +52,16 @@ def particle_number_measurement(
         normalization=normalization,
     )
 
-    state.result = Result(samples=samples)  # type: ignore
-
-    return state
+    return Result(state=state, samples=samples)  # type: ignore
 
 
-def vacuum(state: PureFockState, instruction: Instruction) -> PureFockState:
+def vacuum(state: PureFockState, instruction: Instruction) -> Result:
     state.reset()
 
-    return state
+    return Result(state=state)
 
 
-def passive_linear(state: PureFockState, instruction: Instruction) -> PureFockState:
+def passive_linear(state: PureFockState, instruction: Instruction) -> Result:
     operator: np.ndarray = instruction._all_params["passive_block"]
 
     index = state._get_operator_index(instruction.modes)
@@ -76,7 +74,7 @@ def passive_linear(state: PureFockState, instruction: Instruction) -> PureFockSt
 
     state._state_vector = fock_operator @ state._state_vector
 
-    return state
+    return Result(state=state)
 
 
 def _get_probability_map(
@@ -134,27 +132,27 @@ def _get_projected_state_vector(
     return new_state_vector
 
 
-def create(state: PureFockState, instruction: Instruction) -> PureFockState:
+def create(state: PureFockState, instruction: Instruction) -> Result:
     operator = state._space.get_creation_operator(instruction.modes)
 
     state._state_vector = operator @ state._state_vector
 
     state.normalize()
 
-    return state
+    return Result(state=state)
 
 
-def annihilate(state: PureFockState, instruction: Instruction) -> PureFockState:
+def annihilate(state: PureFockState, instruction: Instruction) -> Result:
     operator = state._space.get_annihilation_operator(instruction.modes)
 
     state._state_vector = operator @ state._state_vector
 
     state.normalize()
 
-    return state
+    return Result(state=state)
 
 
-def kerr(state: PureFockState, instruction: Instruction) -> PureFockState:
+def kerr(state: PureFockState, instruction: Instruction) -> Result:
     mode = instruction.modes[0]
     xi = instruction._all_params["xi"]
 
@@ -163,10 +161,10 @@ def kerr(state: PureFockState, instruction: Instruction) -> PureFockState:
         coefficient = np.exp(1j * xi * number * (2 * number + 1))
         state._state_vector[index] *= coefficient
 
-    return state
+    return Result(state=state)
 
 
-def cross_kerr(state: PureFockState, instruction: Instruction) -> PureFockState:
+def cross_kerr(state: PureFockState, instruction: Instruction) -> Result:
     modes = instruction.modes
     xi = instruction._all_params["xi"]
 
@@ -174,10 +172,10 @@ def cross_kerr(state: PureFockState, instruction: Instruction) -> PureFockState:
         coefficient = np.exp(1j * xi * basis[modes[0]] * basis[modes[1]])
         state._state_vector[index] *= coefficient
 
-    return state
+    return Result(state=state)
 
 
-def linear(state: PureFockState, instruction: Instruction) -> PureFockState:
+def linear(state: PureFockState, instruction: Instruction) -> Result:
     operator = state._space.get_linear_fock_operator(
         modes=instruction.modes,
         cache_size=state._config.cache_size,
@@ -191,19 +189,17 @@ def linear(state: PureFockState, instruction: Instruction) -> PureFockState:
 
     state.normalize()
 
-    return state
+    return Result(state=state)
 
 
-def state_vector_instruction(
-    state: PureFockState, instruction: Instruction
-) -> PureFockState:
+def state_vector_instruction(state: PureFockState, instruction: Instruction) -> Result:
     _add_occupation_number_basis(
         state=state,
         **instruction._all_params,
         modes=instruction.modes,
     )
 
-    return state
+    return Result(state=state)
 
 
 def _add_occupation_number_basis(  # type: ignore

--- a/piquasso/_backends/fock/pure/calculations.py
+++ b/piquasso/_backends/fock/pure/calculations.py
@@ -27,7 +27,7 @@ from piquasso._math.fock import FockBasis
 
 
 def particle_number_measurement(
-    state: PureFockState, instruction: Instruction
+    state: PureFockState, instruction: Instruction, shots: int
 ) -> Result:
     probability_map = _get_probability_map(
         state=state,
@@ -37,7 +37,7 @@ def particle_number_measurement(
     samples = random.choices(
         population=list(probability_map.keys()),
         weights=list(probability_map.values()),
-        k=state.shots,
+        k=shots,
     )
 
     # NOTE: We choose the last sample for multiple shots.
@@ -55,13 +55,15 @@ def particle_number_measurement(
     return Result(state=state, samples=samples)  # type: ignore
 
 
-def vacuum(state: PureFockState, instruction: Instruction) -> Result:
+def vacuum(state: PureFockState, instruction: Instruction, shots: int) -> Result:
     state.reset()
 
     return Result(state=state)
 
 
-def passive_linear(state: PureFockState, instruction: Instruction) -> Result:
+def passive_linear(
+    state: PureFockState, instruction: Instruction, shots: int
+) -> Result:
     operator: np.ndarray = instruction._all_params["passive_block"]
 
     index = state._get_operator_index(instruction.modes)
@@ -132,7 +134,7 @@ def _get_projected_state_vector(
     return new_state_vector
 
 
-def create(state: PureFockState, instruction: Instruction) -> Result:
+def create(state: PureFockState, instruction: Instruction, shots: int) -> Result:
     operator = state._space.get_creation_operator(instruction.modes)
 
     state._state_vector = operator @ state._state_vector
@@ -142,7 +144,7 @@ def create(state: PureFockState, instruction: Instruction) -> Result:
     return Result(state=state)
 
 
-def annihilate(state: PureFockState, instruction: Instruction) -> Result:
+def annihilate(state: PureFockState, instruction: Instruction, shots: int) -> Result:
     operator = state._space.get_annihilation_operator(instruction.modes)
 
     state._state_vector = operator @ state._state_vector
@@ -152,7 +154,7 @@ def annihilate(state: PureFockState, instruction: Instruction) -> Result:
     return Result(state=state)
 
 
-def kerr(state: PureFockState, instruction: Instruction) -> Result:
+def kerr(state: PureFockState, instruction: Instruction, shots: int) -> Result:
     mode = instruction.modes[0]
     xi = instruction._all_params["xi"]
 
@@ -164,7 +166,7 @@ def kerr(state: PureFockState, instruction: Instruction) -> Result:
     return Result(state=state)
 
 
-def cross_kerr(state: PureFockState, instruction: Instruction) -> Result:
+def cross_kerr(state: PureFockState, instruction: Instruction, shots: int) -> Result:
     modes = instruction.modes
     xi = instruction._all_params["xi"]
 
@@ -175,7 +177,7 @@ def cross_kerr(state: PureFockState, instruction: Instruction) -> Result:
     return Result(state=state)
 
 
-def linear(state: PureFockState, instruction: Instruction) -> Result:
+def linear(state: PureFockState, instruction: Instruction, shots: int) -> Result:
     operator = state._space.get_linear_fock_operator(
         modes=instruction.modes,
         cache_size=state._config.cache_size,
@@ -192,7 +194,9 @@ def linear(state: PureFockState, instruction: Instruction) -> Result:
     return Result(state=state)
 
 
-def state_vector_instruction(state: PureFockState, instruction: Instruction) -> Result:
+def state_vector_instruction(
+    state: PureFockState, instruction: Instruction, shots: int
+) -> Result:
     _add_occupation_number_basis(
         state=state,
         **instruction._all_params,

--- a/piquasso/_backends/gaussian/calculations.py
+++ b/piquasso/_backends/gaussian/calculations.py
@@ -36,7 +36,7 @@ from piquasso._math.hafnian import loop_hafnian
 from piquasso._math.decompositions import decompose_to_pure_and_mixed
 
 
-def passive_linear(state: GaussianState, instruction: Instruction) -> GaussianState:
+def passive_linear(state: GaussianState, instruction: Instruction) -> Result:
     modes = instruction.modes
     T: np.ndarray = instruction._all_params["passive_block"]
 
@@ -49,7 +49,7 @@ def passive_linear(state: GaussianState, instruction: Instruction) -> GaussianSt
 
     _apply_passive_linear_to_C_and_G(state, T, modes=modes)
 
-    return state
+    return Result(state=state)
 
 
 def _apply_passive_linear_to_C_and_G(
@@ -81,7 +81,7 @@ def _apply_passive_linear_to_auxiliary_modes(
     state._G[:, modes] = state._G[modes, :].transpose()
 
 
-def linear(state: GaussianState, instruction: Instruction) -> GaussianState:
+def linear(state: GaussianState, instruction: Instruction) -> Result:
     modes = instruction.modes
     passive_block: np.ndarray = instruction._all_params["passive_block"]
     active_block: np.ndarray = instruction._all_params["active_block"]
@@ -94,7 +94,7 @@ def linear(state: GaussianState, instruction: Instruction) -> GaussianState:
 
     _apply_linear_to_C_and_G(state, passive_block, active_block, modes)
 
-    return state
+    return Result(state=state)
 
 
 def _apply_linear_to_C_and_G(
@@ -149,7 +149,7 @@ def _apply_linear_to_auxiliary_modes(
     state._G[:, modes] = state._G[modes, :].transpose()
 
 
-def displacement(state: GaussianState, instruction: Instruction) -> GaussianState:
+def displacement(state: GaussianState, instruction: Instruction) -> Result:
     modes = instruction.modes
     displacement_vector: np.ndarray = instruction._all_params["displacement_vector"]
 
@@ -157,12 +157,10 @@ def displacement(state: GaussianState, instruction: Instruction) -> GaussianStat
         modes,
     ] += displacement_vector
 
-    return state
+    return Result(state=state)
 
 
-def generaldyne_measurement(
-    state: GaussianState, instruction: Instruction
-) -> GaussianState:
+def generaldyne_measurement(state: GaussianState, instruction: Instruction) -> Result:
     modes = instruction.modes
     detection_covariance = instruction._all_params["detection_covariance"]
 
@@ -199,9 +197,7 @@ def generaldyne_measurement(
     state.xpxp_mean_vector = evolved_mean
     state.xpxp_covariance_matrix = evolved_cov
 
-    state.result = Result(samples=list(map(tuple, list(samples))))
-
-    return state
+    return Result(state=state, samples=list(map(tuple, list(samples))))
 
 
 def _get_generaldyne_samples(state, modes, shots, detection_covariance):
@@ -284,13 +280,11 @@ def _map_modes_to_xpxp_indices(modes):
 def particle_number_measurement(
     state: GaussianState,
     instruction: Instruction,
-) -> GaussianState:
+) -> Result:
 
     samples = _get_particle_number_measurement_samples(state, instruction)
 
-    state.result = Result(samples=samples)
-
-    return state
+    return Result(state=state, samples=samples)
 
 
 def _get_particle_number_measurement_samples(
@@ -422,9 +416,7 @@ def _get_particle_number_choice(
     return np.random.choice(possible_choices, p=weights)
 
 
-def threshold_measurement(
-    state: GaussianState, instruction: Instruction
-) -> GaussianState:
+def threshold_measurement(state: GaussianState, instruction: Instruction) -> Result:
     """
     NOTE: The same logic is used here, as for the particle number measurement.
     However, at threshold measurement there is no sense of measurement cutoff,
@@ -439,9 +431,7 @@ def threshold_measurement(
     else:
         samples = _generate_threshold_samples_using_hafnian(state, instruction)
 
-    state.result = Result(samples=samples)
-
-    return state
+    return Result(state=state, samples=samples)
 
 
 def _generate_threshold_samples_using_torontonian(
@@ -515,9 +505,7 @@ def _generate_threshold_samples_using_hafnian(state, instruction):
     return threshold_samples
 
 
-def homodyne_measurement(
-    state: GaussianState, instruction: Instruction
-) -> GaussianState:
+def homodyne_measurement(state: GaussianState, instruction: Instruction) -> Result:
     phi = instruction._all_params["phi"]
 
     instruction_copy: Instruction = instruction.copy()  # type: ignore
@@ -525,39 +513,38 @@ def homodyne_measurement(
     phaseshift = np.identity(len(instruction.modes)) * np.exp(-1j * phi)
     instruction_copy._extra_params["passive_block"] = phaseshift
 
-    passive_linear(state, instruction_copy)
+    result = passive_linear(state, instruction_copy)
 
-    generaldyne_measurement(state, instruction)
+    result = generaldyne_measurement(result.state, instruction)
 
-    return state
+    return Result(state=state, samples=result.samples)
 
 
-def vacuum(state: GaussianState, instruction: Instruction) -> GaussianState:
+def vacuum(state: GaussianState, instruction: Instruction) -> Result:
     state.reset()
 
-    return state
+    return Result(state=state)
 
 
-def mean(state: GaussianState, instruction: Instruction) -> GaussianState:
+def mean(state: GaussianState, instruction: Instruction) -> Result:
     state.xpxp_mean_vector = instruction._all_params["mean"]
 
-    return state
+    return Result(state=state)
 
 
-def covariance(state: GaussianState, instruction: Instruction) -> GaussianState:
+def covariance(state: GaussianState, instruction: Instruction) -> Result:
     state.xpxp_covariance_matrix = instruction._all_params["cov"]
 
-    return state
+    return Result(state=state)
 
 
-def graph(state: GaussianState, instruction: Instruction) -> GaussianState:
+def graph(state: GaussianState, instruction: Instruction) -> Result:
     """
     TODO: Find a better solution for multiple operations.
     """
     instruction._all_params["squeezing"].modes = instruction.modes
     instruction._all_params["interferometer"].modes = instruction.modes
 
-    linear(state, instruction._all_params["squeezing"])
-    passive_linear(state, instruction._all_params["interferometer"])
+    result = linear(state, instruction._all_params["squeezing"])
 
-    return state
+    return passive_linear(result.state, instruction._all_params["interferometer"])

--- a/piquasso/_backends/sampling/calculations.py
+++ b/piquasso/_backends/sampling/calculations.py
@@ -51,7 +51,7 @@ from BoSS.simulation_strategies.simulation_strategy_interface import (
 )
 
 
-def state_vector(state: SamplingState, instruction: Instruction) -> SamplingState:
+def state_vector(state: SamplingState, instruction: Instruction) -> Result:
     if not np.all(state.initial_state == 0):
         raise InvalidState("State vector is already set.")
 
@@ -67,10 +67,10 @@ def state_vector(state: SamplingState, instruction: Instruction) -> SamplingStat
 
     state.initial_state = np.rint(initial_state).astype(int)
 
-    return state
+    return Result(state=state)
 
 
-def passive_linear(state: SamplingState, instruction: Instruction) -> SamplingState:
+def passive_linear(state: SamplingState, instruction: Instruction) -> Result:
     r"""Applies an interferometer to the circuit.
 
     This can be interpreted as placing another interferometer in the network, just
@@ -86,7 +86,7 @@ def passive_linear(state: SamplingState, instruction: Instruction) -> SamplingSt
         modes=instruction.modes,
     )
 
-    return state
+    return Result(state=state)
 
 
 def _apply_matrix_on_modes(
@@ -99,7 +99,7 @@ def _apply_matrix_on_modes(
     state.interferometer = embedded @ state.interferometer
 
 
-def loss(state: SamplingState, instruction: Instruction) -> SamplingState:
+def loss(state: SamplingState, instruction: Instruction) -> Result:
     state.is_lossy = True
 
     _apply_matrix_on_modes(
@@ -108,10 +108,10 @@ def loss(state: SamplingState, instruction: Instruction) -> SamplingState:
         modes=instruction.modes,
     )
 
-    return state
+    return Result(state=state)
 
 
-def sampling(state: SamplingState, instruction: Instruction) -> SamplingState:
+def sampling(state: SamplingState, instruction: Instruction) -> Result:
     initial_state = np.array(state.initial_state)
     permanent_calculator = RyserGuanPermanentCalculator(
         matrix=state.interferometer, input_state=initial_state
@@ -125,9 +125,7 @@ def sampling(state: SamplingState, instruction: Instruction) -> SamplingState:
         initial_state, samples_number=state.shots
     )
 
-    state.result = Result(samples=list(map(tuple, samples)))
-
-    return state
+    return Result(state=state, samples=list(map(tuple, samples)))
 
 
 def _get_sampling_simulation_strategy(

--- a/piquasso/_backends/sampling/calculations.py
+++ b/piquasso/_backends/sampling/calculations.py
@@ -51,7 +51,7 @@ from BoSS.simulation_strategies.simulation_strategy_interface import (
 )
 
 
-def state_vector(state: SamplingState, instruction: Instruction) -> Result:
+def state_vector(state: SamplingState, instruction: Instruction, shots: int) -> Result:
     if not np.all(state.initial_state == 0):
         raise InvalidState("State vector is already set.")
 
@@ -70,7 +70,9 @@ def state_vector(state: SamplingState, instruction: Instruction) -> Result:
     return Result(state=state)
 
 
-def passive_linear(state: SamplingState, instruction: Instruction) -> Result:
+def passive_linear(
+    state: SamplingState, instruction: Instruction, shots: int
+) -> Result:
     r"""Applies an interferometer to the circuit.
 
     This can be interpreted as placing another interferometer in the network, just
@@ -99,7 +101,7 @@ def _apply_matrix_on_modes(
     state.interferometer = embedded @ state.interferometer
 
 
-def loss(state: SamplingState, instruction: Instruction) -> Result:
+def loss(state: SamplingState, instruction: Instruction, shots: int) -> Result:
     state.is_lossy = True
 
     _apply_matrix_on_modes(
@@ -111,7 +113,7 @@ def loss(state: SamplingState, instruction: Instruction) -> Result:
     return Result(state=state)
 
 
-def sampling(state: SamplingState, instruction: Instruction) -> Result:
+def sampling(state: SamplingState, instruction: Instruction, shots: int) -> Result:
     initial_state = np.array(state.initial_state)
     permanent_calculator = RyserGuanPermanentCalculator(
         matrix=state.interferometer, input_state=initial_state
@@ -122,7 +124,7 @@ def sampling(state: SamplingState, instruction: Instruction) -> Result:
     sampling_simulator = BosonSamplingSimulator(simulation_strategy)
 
     samples = sampling_simulator.get_classical_simulation_results(
-        initial_state, samples_number=state.shots
+        initial_state, samples_number=shots
     )
 
     return Result(state=state, samples=list(map(tuple, samples)))

--- a/piquasso/api/computer.py
+++ b/piquasso/api/computer.py
@@ -141,7 +141,7 @@ class Simulator(Computer, abc.ABC):
         instructions: List[Instruction],
         initial_state: State = None,
         shots: int = 1,
-    ) -> State:
+    ) -> Result:
         if not isinstance(shots, int) or shots < 1:
             raise InvalidParameter(
                 f"The number of shots should be a positive integer: shots={shots}."
@@ -158,6 +158,8 @@ class Simulator(Computer, abc.ABC):
         # TODO: This is not a nice solution.
         state.shots = shots
 
+        result = Result(state=state)
+
         for instruction in instructions:
             if not hasattr(instruction, "modes") or instruction.modes is tuple():
                 instruction.modes = tuple(range(self.d))
@@ -167,13 +169,13 @@ class Simulator(Computer, abc.ABC):
 
             calculation = self._instruction_map[instruction.__class__.__name__]
 
-            state = calculation(state, instruction)
+            result = calculation(result.state, instruction)
 
-        return state
+        return result
 
     def execute(
         self, program: Program, shots: int = 1, initial_state: State = None
-    ) -> Optional[Result]:
+    ) -> Result:
         """Applies the given program to the state and executes it.
 
         Args:
@@ -185,11 +187,6 @@ class Simulator(Computer, abc.ABC):
 
         instructions: List[Instruction] = program.instructions
 
-        state = self.execute_instructions(
+        return self.execute_instructions(
             instructions, initial_state=initial_state, shots=shots
-        )
-
-        return Result(
-            samples=state.result.samples if state.result else [],
-            state=state,
         )

--- a/piquasso/api/computer.py
+++ b/piquasso/api/computer.py
@@ -155,9 +155,6 @@ class Simulator(Computer, abc.ABC):
         else:
             state = self.create_initial_state()
 
-        # TODO: This is not a nice solution.
-        state.shots = shots
-
         result = Result(state=state)
 
         for instruction in instructions:
@@ -169,7 +166,7 @@ class Simulator(Computer, abc.ABC):
 
             calculation = self._instruction_map[instruction.__class__.__name__]
 
-            result = calculation(result.state, instruction)
+            result = calculation(result.state, instruction, shots)
 
         return result
 

--- a/piquasso/api/result.py
+++ b/piquasso/api/result.py
@@ -13,18 +13,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import typing
-
 from typing import TypeVar, List, Tuple, Generic, Optional
 
-
-if typing.TYPE_CHECKING:
-    from piquasso.api.state import State
+from piquasso.api.state import State
 
 TNum = TypeVar("TNum", int, float)
 
+TState = TypeVar("TState", bound=State)
 
-class Result(Generic[TNum]):
+
+class Result(Generic[TState, TNum]):
     """Class for collecting results.
 
     Args:
@@ -33,10 +31,12 @@ class Result(Generic[TNum]):
     """
 
     def __init__(
-        self, samples: List[Tuple[TNum, ...]], state: Optional["State"] = None
+        self,
+        state: TState,
+        samples: Optional[List[Tuple[TNum, ...]]] = None,
     ) -> None:
-        self.samples: List[Tuple[TNum, ...]] = samples
-        self.state = state
+        self.state: TState = state
+        self.samples: List[Tuple[TNum, ...]] = samples or []
 
     def __repr__(self) -> str:
         return f"<Result samples={self.samples}>"

--- a/piquasso/api/state.py
+++ b/piquasso/api/state.py
@@ -30,8 +30,6 @@ class State(abc.ABC):
     """
 
     def __init__(self, config: Config = None) -> None:
-        self.shots: int = None  # type: ignore
-
         self._config = config.copy() if config is not None else Config()
 
     @property

--- a/piquasso/api/state.py
+++ b/piquasso/api/state.py
@@ -15,12 +15,11 @@
 
 import abc
 import copy
-from typing import Tuple, Optional
+from typing import Tuple
 
 import numpy as np
 
 from piquasso.api.config import Config
-from piquasso.api.result import Result
 
 
 class State(abc.ABC):
@@ -31,7 +30,6 @@ class State(abc.ABC):
     """
 
     def __init__(self, config: Config = None) -> None:
-        self.result: Optional[Result] = None
         self.shots: int = None  # type: ignore
 
         self._config = config.copy() if config is not None else Config()

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -67,7 +67,7 @@ def FakeState():
 @pytest.fixture
 def FakeSimulator(FakeState):
     def fake_calculation(state: FakeState, instruction: pq.Instruction):
-        return state
+        return pq.api.result.Result(state=state)
 
     class FakeSimulator(pq.Simulator):
         state_class = FakeState

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -66,7 +66,7 @@ def FakeState():
 
 @pytest.fixture
 def FakeSimulator(FakeState):
-    def fake_calculation(state: FakeState, instruction: pq.Instruction):
+    def fake_calculation(state: FakeState, instruction: pq.Instruction, shots: int):
         return pq.api.result.Result(state=state)
 
     class FakeSimulator(pq.Simulator):

--- a/tests/backends/fock/general/test_measurements.py
+++ b/tests/backends/fock/general/test_measurements.py
@@ -60,7 +60,7 @@ def test_measure_particle_number_on_one_mode():
                 2 / 3 * pq.DensityMatrix(ket=(0, 1, 1), bra=(0, 1, 1)),
                 2j * pq.DensityMatrix(ket=(1, 0, 1), bra=(0, 0, 1)),
             ]
-        )
+        ).state
 
     elif sample == (2,):
         expected_simulator = pq.FockSimulator(
@@ -69,7 +69,7 @@ def test_measure_particle_number_on_one_mode():
         )
         expected_state = expected_simulator.execute_instructions(
             instructions=[pq.DensityMatrix(ket=(0, 0, 2), bra=(0, 0, 2))]
-        )
+        ).state
 
     assert result.state == expected_state
 
@@ -110,7 +110,7 @@ def test_measure_particle_number_on_two_modes():
                 pq.DensityMatrix(ket=(0, 0, 1), bra=(1, 0, 1)) * (-6j),
                 pq.DensityMatrix(ket=(1, 0, 1), bra=(0, 0, 1)) * 6j,
             ]
-        )
+        ).state
 
     elif sample == (1, 1):
         expected_simulator = pq.FockSimulator(d=3, config=config)
@@ -118,13 +118,13 @@ def test_measure_particle_number_on_two_modes():
             instructions=[
                 pq.DensityMatrix(ket=(0, 1, 1), bra=(0, 1, 1)),
             ]
-        )
+        ).state
 
     elif sample == (0, 2):
         expected_simulator = pq.FockSimulator(d=3, config=config)
         expected_state = expected_simulator.execute_instructions(
             instructions=[pq.DensityMatrix(ket=(0, 0, 2), bra=(0, 0, 2))]
-        )
+        ).state
 
     assert result.state == expected_state
 
@@ -161,7 +161,7 @@ def test_measure_particle_number_on_all_modes():
             instructions=[
                 pq.DensityMatrix(ket=(0, 0, 0), bra=(0, 0, 0)),
             ]
-        )
+        ).state
 
     elif sample == (0, 0, 1):
         expected_simulator = pq.FockSimulator(d=3, config=config)
@@ -169,7 +169,7 @@ def test_measure_particle_number_on_all_modes():
             instructions=[
                 pq.DensityMatrix(ket=(0, 0, 1), bra=(0, 0, 1)),
             ]
-        )
+        ).state
 
     elif sample == (1, 0, 0):
         expected_simulator = pq.FockSimulator(d=3, config=config)
@@ -177,7 +177,7 @@ def test_measure_particle_number_on_all_modes():
             instructions=[
                 pq.DensityMatrix(ket=(1, 0, 0), bra=(1, 0, 0)),
             ]
-        )
+        ).state
 
     assert result.state == expected_state
 

--- a/tests/backends/fock/pure/test_measurements.py
+++ b/tests/backends/fock/pure/test_measurements.py
@@ -43,13 +43,13 @@ def test_measure_particle_number_on_one_mode():
                 0.5773502691896258 * pq.StateVector([0, 0, 1]),
                 0.816496580927726 * pq.StateVector([0, 1, 1]),
             ]
-        )
+        ).state
 
     elif sample == (2,):
         expected_simulator = pq.PureFockSimulator(d=3)
         expected_state = expected_simulator.execute_instructions(
             instructions=[pq.StateVector([0, 0, 2])]
-        )
+        ).state
 
     assert result.state == expected_state
 
@@ -75,19 +75,19 @@ def test_measure_particle_number_on_two_modes():
         expected_simulator = pq.PureFockSimulator(d=3)
         expected_state = expected_simulator.execute_instructions(
             instructions=[pq.StateVector([0, 0, 1])]
-        )
+        ).state
 
     elif sample == (1, 1):
         expected_simulator = pq.PureFockSimulator(d=3)
         expected_state = expected_simulator.execute_instructions(
             instructions=[pq.StateVector([0, 1, 1])]
-        )
+        ).state
 
     elif sample == (0, 2):
         expected_simulator = pq.PureFockSimulator(d=3)
         expected_state = expected_simulator.execute_instructions(
             instructions=[pq.StateVector([0, 0, 2])]
-        )
+        ).state
 
     assert result.state == expected_state
 
@@ -117,7 +117,7 @@ def test_measure_particle_number_on_all_modes():
             instructions=[
                 pq.StateVector([0, 0, 0]),
             ],
-        )
+        ).state
 
     elif sample == (0, 0, 1):
         expected_simulator = pq.PureFockSimulator(d=3, config=config)
@@ -125,7 +125,7 @@ def test_measure_particle_number_on_all_modes():
             instructions=[
                 pq.StateVector([0, 0, 1]),
             ]
-        )
+        ).state
 
     elif sample == (1, 0, 0):
         expected_simulator = pq.PureFockSimulator(d=3, config=config)
@@ -133,7 +133,7 @@ def test_measure_particle_number_on_all_modes():
             instructions=[
                 pq.StateVector([1, 0, 0]),
             ],
-        )
+        ).state
 
     assert result.state == expected_state
 


### PR DESCRIPTION
Generally, the `State` classes should not have any memory regarding
the simulation whatsoever, which makes sense from the perspective of a
user as well.
