### PR TITLE
refact(Simulator): Instruction map keys are classes

### DIFF
--- a/piquasso/_backends/fock/general/simulator.py
+++ b/piquasso/_backends/fock/general/simulator.py
@@ -14,9 +14,9 @@
 # limitations under the License.
 
 from piquasso.api.computer import Simulator
+from piquasso.instructions import preparations, gates, measurements
 
 from .state import FockState
-
 from .calculations import (
     passive_linear,
     linear,
@@ -32,25 +32,25 @@ from .calculations import (
 
 class FockSimulator(Simulator):
     _instruction_map = {
-        "DensityMatrix": density_matrix_instruction,
-        "Interferometer": passive_linear,
-        "Beamsplitter": passive_linear,
-        "Phaseshifter": passive_linear,
-        "MachZehnder": passive_linear,
-        "Fourier": passive_linear,
-        "Kerr": kerr,
-        "CrossKerr": cross_kerr,
-        "Squeezing": linear,
-        "QuadraticPhase": linear,
-        "Displacement": linear,
-        "PositionDisplacement": linear,
-        "MomentumDisplacement": linear,
-        "Squeezing2": linear,
-        "GaussianTransform": linear,
-        "ParticleNumberMeasurement": particle_number_measurement,
-        "Vacuum": vacuum,
-        "Create": create,
-        "Annihilate": annihilate,
+        preparations.Vacuum: vacuum,
+        preparations.Create: create,
+        preparations.Annihilate: annihilate,
+        preparations.DensityMatrix: density_matrix_instruction,
+        gates.Interferometer: passive_linear,
+        gates.Beamsplitter: passive_linear,
+        gates.Phaseshifter: passive_linear,
+        gates.MachZehnder: passive_linear,
+        gates.Fourier: passive_linear,
+        gates.Kerr: kerr,
+        gates.CrossKerr: cross_kerr,
+        gates.Squeezing: linear,
+        gates.QuadraticPhase: linear,
+        gates.Displacement: linear,
+        gates.PositionDisplacement: linear,
+        gates.MomentumDisplacement: linear,
+        gates.Squeezing2: linear,
+        gates.GaussianTransform: linear,
+        measurements.ParticleNumberMeasurement: particle_number_measurement,
     }
 
     state_class = FockState

--- a/piquasso/_backends/fock/pure/simulator.py
+++ b/piquasso/_backends/fock/pure/simulator.py
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from piquasso.api.computer import Simulator
-
 from .state import PureFockState
 
 from .calculations import (
@@ -29,28 +27,31 @@ from .calculations import (
     annihilate,
 )
 
+from piquasso.api.computer import Simulator
+from piquasso.instructions import preparations, gates, measurements
+
 
 class PureFockSimulator(Simulator):
     state_class = PureFockState
 
     _instruction_map = {
-        "StateVector": state_vector_instruction,
-        "Interferometer": passive_linear,
-        "Beamsplitter": passive_linear,
-        "Phaseshifter": passive_linear,
-        "MachZehnder": passive_linear,
-        "Fourier": passive_linear,
-        "Kerr": kerr,
-        "CrossKerr": cross_kerr,
-        "Squeezing": linear,
-        "QuadraticPhase": linear,
-        "Displacement": linear,
-        "PositionDisplacement": linear,
-        "MomentumDisplacement": linear,
-        "Squeezing2": linear,
-        "GaussianTransform": linear,
-        "ParticleNumberMeasurement": particle_number_measurement,
-        "Vacuum": vacuum,
-        "Create": create,
-        "Annihilate": annihilate,
+        preparations.Vacuum: vacuum,
+        preparations.Create: create,
+        preparations.Annihilate: annihilate,
+        preparations.StateVector: state_vector_instruction,
+        gates.Interferometer: passive_linear,
+        gates.Beamsplitter: passive_linear,
+        gates.Phaseshifter: passive_linear,
+        gates.MachZehnder: passive_linear,
+        gates.Fourier: passive_linear,
+        gates.Kerr: kerr,
+        gates.CrossKerr: cross_kerr,
+        gates.Squeezing: linear,
+        gates.QuadraticPhase: linear,
+        gates.Displacement: linear,
+        gates.PositionDisplacement: linear,
+        gates.MomentumDisplacement: linear,
+        gates.Squeezing2: linear,
+        gates.GaussianTransform: linear,
+        measurements.ParticleNumberMeasurement: particle_number_measurement,
     }

--- a/piquasso/_backends/gaussian/simulator.py
+++ b/piquasso/_backends/gaussian/simulator.py
@@ -13,6 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from piquasso.api.computer import Simulator
+from piquasso.instructions import preparations, gates, measurements
+
 from .state import GaussianState
 from .calculations import (
     passive_linear,
@@ -28,34 +31,32 @@ from .calculations import (
     threshold_measurement,
 )
 
-from piquasso.api.computer import Simulator
-
 
 class GaussianSimulator(Simulator):
     _instruction_map = {
-        "Interferometer": passive_linear,
-        "Beamsplitter": passive_linear,
-        "Phaseshifter": passive_linear,
-        "MachZehnder": passive_linear,
-        "Fourier": passive_linear,
-        "GaussianTransform": linear,
-        "Squeezing": linear,
-        "QuadraticPhase": linear,
-        "Squeezing2": linear,
-        "ControlledX": linear,
-        "ControlledZ": linear,
-        "Displacement": displacement,
-        "PositionDisplacement": displacement,
-        "MomentumDisplacement": displacement,
-        "Graph": graph,
-        "HomodyneMeasurement": homodyne_measurement,
-        "HeterodyneMeasurement": generaldyne_measurement,
-        "GeneraldyneMeasurement": generaldyne_measurement,
-        "Vacuum": vacuum,
-        "Mean": mean,
-        "Covariance": covariance,
-        "ParticleNumberMeasurement": particle_number_measurement,
-        "ThresholdMeasurement": threshold_measurement,
+        preparations.Vacuum: vacuum,
+        preparations.Mean: mean,
+        preparations.Covariance: covariance,
+        gates.Interferometer: passive_linear,
+        gates.Beamsplitter: passive_linear,
+        gates.Phaseshifter: passive_linear,
+        gates.MachZehnder: passive_linear,
+        gates.Fourier: passive_linear,
+        gates.GaussianTransform: linear,
+        gates.Squeezing: linear,
+        gates.QuadraticPhase: linear,
+        gates.Squeezing2: linear,
+        gates.ControlledX: linear,
+        gates.ControlledZ: linear,
+        gates.Displacement: displacement,
+        gates.PositionDisplacement: displacement,
+        gates.MomentumDisplacement: displacement,
+        gates.Graph: graph,
+        measurements.HomodyneMeasurement: homodyne_measurement,
+        measurements.HeterodyneMeasurement: generaldyne_measurement,
+        measurements.GeneraldyneMeasurement: generaldyne_measurement,
+        measurements.ParticleNumberMeasurement: particle_number_measurement,
+        measurements.ThresholdMeasurement: threshold_measurement,
     }
 
     state_class = GaussianState

--- a/piquasso/_backends/sampling/simulator.py
+++ b/piquasso/_backends/sampling/simulator.py
@@ -13,22 +13,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from piquasso.api.computer import Simulator
+from piquasso.instructions import preparations, gates, measurements, channels
+
 from .state import SamplingState
 from .calculations import state_vector, passive_linear, sampling, loss
-
-from piquasso.api.computer import Simulator
 
 
 class SamplingSimulator(Simulator):
     _instruction_map = {
-        "StateVector": state_vector,
-        "Beamsplitter": passive_linear,
-        "Phaseshifter": passive_linear,
-        "MachZehnder": passive_linear,
-        "Fourier": passive_linear,
-        "Sampling": sampling,
-        "Interferometer": passive_linear,
-        "Loss": loss,
+        preparations.StateVector: state_vector,
+        gates.Beamsplitter: passive_linear,
+        gates.Phaseshifter: passive_linear,
+        gates.MachZehnder: passive_linear,
+        gates.Fourier: passive_linear,
+        gates.Interferometer: passive_linear,
+        measurements.Sampling: sampling,
+        channels.Loss: loss,
     }
 
     state_class = SamplingState

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -65,7 +65,7 @@ def FakeState():
 
 
 @pytest.fixture
-def FakeSimulator(FakeState):
+def FakeSimulator(FakeState, FakePreparation, FakeGate, FakeMeasurement):
     def fake_calculation(state: FakeState, instruction: pq.Instruction, shots: int):
         return pq.api.result.Result(state=state)
 
@@ -73,9 +73,9 @@ def FakeSimulator(FakeState):
         state_class = FakeState
 
         _instruction_map = {
-            "FakePreparation": fake_calculation,
-            "FakeGate": fake_calculation,
-            "FakeMeasurement": fake_calculation,
+            FakePreparation: fake_calculation,
+            FakeGate: fake_calculation,
+            FakeMeasurement: fake_calculation,
         }
 
     return FakeSimulator


### PR DESCRIPTION
The `Simulator._instruction_map` got rewritten to use instruction
classes instead of just string, thereby reducing possible coding errors.