### PR TITLE
doc: Constructor parameter documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,6 +26,8 @@ author = "Budapest Quantum Computing Group"
 # -- General configuration ---------------------------------------------------
 
 add_module_names = False
+autodoc_member_order = "bysource"
+autoclass_content = "both"
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom

--- a/piquasso/_backends/fock/general/state.py
+++ b/piquasso/_backends/fock/general/state.py
@@ -31,14 +31,16 @@ class FockState(BaseFockState):
     Note:
         If you only work with pure states, it is advised to use
         :class:`~piquasso._backends.fock.pure.state.PureFockState` instead.
-
-    Args:
-        density_matrix (numpy.ndarray, optional): The initial density matrix.
-        d (int): The number of modes.
-        cutoff (int): The Fock space cutoff.
     """
 
     def __init__(self, *, d: int, config: Config = None) -> None:
+        """
+        Args:
+            density_matrix (numpy.ndarray, optional): The initial density matrix.
+            d (int): The number of modes.
+            cutoff (int): The Fock space cutoff.
+        """
+
         super().__init__(d=d, config=config)
 
         self._density_matrix = self._get_empty()

--- a/piquasso/_backends/fock/pure/state.py
+++ b/piquasso/_backends/fock/pure/state.py
@@ -36,14 +36,16 @@ class PureFockState(BaseFockState):
         {d + c - 1 \choose c - 1},
 
     where :math:`c \in \mathbb{N}` is the Fock space cutoff.
-
-    Args:
-        state_vector (numpy.ndarray, optional): The initial state vector.
-        d (int): The number of modes.
-        cutoff (int): The Fock space cutoff.
     """
 
     def __init__(self, *, d: int, config: Config = None) -> None:
+        """
+        Args:
+            state_vector (numpy.ndarray, optional): The initial state vector.
+            d (int): The number of modes.
+            cutoff (int): The Fock space cutoff.
+        """
+
         super().__init__(d=d, config=config)
 
         self._state_vector = self._get_empty()

--- a/piquasso/_backends/gaussian/state.py
+++ b/piquasso/_backends/gaussian/state.py
@@ -369,8 +369,8 @@ class GaussianState(State):
         .. math::
             \mu_{c} := W \mu_{xxpp},
 
-        where :math:`\mu_{xxpp}` is the xxpp-ordered mean vector :attr:`xxpp_mean`
-        and
+        where :math:`\mu_{xxpp}` is the xxpp-ordered mean vector
+        :attr:`xxpp_mean_vector` and
 
         .. math::
             W = \frac{1}{\sqrt{2}} \begin{bmatrix}
@@ -452,7 +452,7 @@ class GaussianState(State):
                 a_i \exp(-i \phi) + a_i^\dagger \exp(i \phi)
             \right),
 
-        meaning that e.g. the annihilation operators `a_i` are transformed just
+        meaning that e.g. the annihilation operators :math:`a_i` are transformed just
         multiplied by a phase factor :math:`\exp(-i \phi)` under this phase space
         rotation, i.e.
 

--- a/piquasso/api/instruction.py
+++ b/piquasso/api/instruction.py
@@ -28,8 +28,11 @@ if typing.TYPE_CHECKING:
 
 class Instruction(_mixins.DictMixin, _mixins.RegisterMixin, _mixins.CodeMixin):
     """
+    Base class for all instructions.
+
     Args:
-        *params: Variable length argument list.
+        params: Mapping of parameters specified by the users.
+        extra_params: Mapping of extra parameters, typically calculated ones.
     """
 
     _subclasses: Dict[str, Type["Instruction"]] = {}

--- a/piquasso/api/mode.py
+++ b/piquasso/api/mode.py
@@ -62,19 +62,20 @@ class Q:
             pq.Q(0, 1) | pq.Squeezing(r=0.5)
 
             pq.Q() | pq.ParticleNumberMeasurement()
-
-    Args:
-        *modes (int):
-            Variable length list of non-negative integers specifying the modes.
-
-    Raises:
-        InvalidModes:
-            Raised if
-            - the specified modes are not distinct;
-            - negative integers were specified.
     """
 
     def __init__(self, *modes: Union[int, Any]) -> None:
+        """
+        Args:
+            *modes (int):
+                Variable length list of non-negative integers specifying the modes.
+
+        Raises:
+            InvalidModes:
+                Raised if
+                - the specified modes are not distinct;
+                - negative integers were specified.
+        """
         is_all = modes == (all,)
 
         if not is_all and any(mode < 0 for mode in modes):

--- a/piquasso/api/program.py
+++ b/piquasso/api/program.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List, Tuple, Any
+from typing import List, Tuple, Any, Optional
 
 import blackbird
 from piquasso.core import _context, _blackbird
@@ -40,18 +40,20 @@ class Program(_mixins.DictMixin, _mixins.RegisterMixin):
 
         simulator = pq.GaussianSimulator(d=5)
         result = simulator.execute(program)
-
-    Args:
-        instructions (list[~piquasso.api.instruction.Instruction], optional):
-            The set of instructions, e.g. quantum gates and measurements.
     """
 
     instructions: list
 
     def __init__(
         self,
-        instructions: list = None,
+        instructions: Optional[list] = None,
     ) -> None:
+        """
+        Args:
+            instructions (list[~piquasso.api.instruction.Instruction], optional):
+                The set of instructions, e.g. quantum gates and measurements.
+        """
+
         self.instructions: List[Instruction] = instructions or []
 
     @staticmethod

--- a/piquasso/api/result.py
+++ b/piquasso/api/result.py
@@ -23,18 +23,19 @@ TState = TypeVar("TState", bound=State)
 
 
 class Result(Generic[TState, TNum]):
-    """Class for collecting results.
-
-    Args:
-        state (State): The resulting simulated state.
-        samples (list[tuple[int or float]]): The generated samples.
-    """
+    """Class for collecting results."""
 
     def __init__(
         self,
         state: TState,
         samples: Optional[List[Tuple[TNum, ...]]] = None,
     ) -> None:
+        """
+        Args:
+            state (State): The resulting simulated state.
+            samples (list[tuple[int or float]]): The generated samples.
+        """
+
         self.state: TState = state
         self.samples: List[Tuple[TNum, ...]] = samples or []
 

--- a/piquasso/api/state.py
+++ b/piquasso/api/state.py
@@ -60,7 +60,7 @@ class State(abc.ABC):
             each particle number conserving subspace, lexicographic ordering is used.
 
         Returns:
-            np.ndarray: The particle detection probabilities.
+            numpy.ndarray: The particle detection probabilities.
         """
         pass
 

--- a/piquasso/decompositions/clements.py
+++ b/piquasso/decompositions/clements.py
@@ -32,15 +32,16 @@ class T(np.ndarray):
 
     The matrix is automatically embedded in a `d` times `d` identity
     matrix, which can be readily applied during decomposition.
-
-    Args:
-        operation (dict):
-            A dict containing the angle parameters and the modes on which the
-            beamsplitter operation is applied.
-        d (int): The total number of modes.
     """
 
     def __new__(cls, operation: dict, d: int) -> "T":
+        """
+        Args:
+            operation (dict):
+                A dict containing the angle parameters and the modes on which the
+                beamsplitter operation is applied.
+            d (int): The total number of modes.
+        """
 
         theta, phi = operation["params"]
         i, j = operation["modes"]
@@ -94,15 +95,15 @@ class T(np.ndarray):
 
 
 class Clements:
-    """
-    Args:
-        U (numpy.ndarray): The (square) unitary matrix to be decomposed.
-        decompose (bool):
-            Optional, if `True`, the decomposition is automatically calculated.
-            Defaults to `True`.
-    """
-
     def __init__(self, U: np.ndarray, decompose: bool = True):
+        """
+        Args:
+            U (numpy.ndarray): The (square) unitary matrix to be decomposed.
+            decompose (bool):
+                Optional, if `True`, the decomposition is automatically calculated.
+                Defaults to `True`.
+        """
+
         self.U: np.ndarray = U
         self.d: int = U.shape[0]
         self.inverse_operations: List[dict] = []

--- a/piquasso/instructions/channels.py
+++ b/piquasso/instructions/channels.py
@@ -27,12 +27,13 @@ class Loss(Gate, _mixins.ScalingMixin):
     Note:
         Currently, this instruction can only be used along with
         :class:`~piquasso._backends.sampling.state.SamplingState`.
-
-    Args:
-        transmissivity (numpy.ndarray): The transmissivity array.
     """
 
     def __init__(self, transmissivity: np.ndarray) -> None:
+        """
+        Args:
+            transmissivity (numpy.ndarray): The transmissivity array.
+        """
         super().__init__(
             params=dict(transmissivity=transmissivity),
             extra_params=dict(

--- a/piquasso/instructions/gates.py
+++ b/piquasso/instructions/gates.py
@@ -191,17 +191,19 @@ class Beamsplitter(_BogoliubovTransformation):
         \end{bmatrix},
 
     where :math:`t = \cos(\theta)` and :math:`r = e^{i \phi} \sin(\theta)`.
-
-    Args:
-        phi (float):
-            Phase angle of the beamsplitter.
-            (defaults to :math:`\phi = \pi/2` that gives a symmetric beamsplitter)
-        theta (float):
-            The transmittivity angle of the beamsplitter.
-            (defaults to :math:`\theta=\pi/4` that gives a 50-50 beamsplitter)
     """
 
     def __init__(self, theta: float = 0.0, phi: float = np.pi / 4) -> None:
+        """
+        Args:
+            phi (float):
+                Phase angle of the beamsplitter.
+                (defaults to :math:`\phi = \pi/2` that gives a symmetric beamsplitter)
+            theta (float):
+                The transmittivity angle of the beamsplitter.
+                (defaults to :math:`\theta=\pi/4` that gives a 50-50 beamsplitter)
+        """
+
         t = np.cos(theta)
         r = np.exp(1j * phi) * np.sin(theta)
 
@@ -237,12 +239,14 @@ class Phaseshifter(_ScalableBogoliubovTransformation):
             e^{i \phi} & 0 \\
             0 & e^{- i \phi}
         \end{bmatrix}
-
-    Args:
-        phi (float): The angle of the rotation.
     """
 
     def __init__(self, phi: float) -> None:
+        """
+        Args:
+            phi (float): The angle of the rotation.
+        """
+
         super().__init__(
             params=dict(phi=phi), passive_block=np.diag(np.exp(1j * np.atleast_1d(phi)))
         )
@@ -269,13 +273,14 @@ class MachZehnder(_BogoliubovTransformation):
         \end{bmatrix},
 
     where :math:`\phi_{int}, \phi_{ext} \in \mathbb{R}`.
-
-    Args:
-        int_ (float): The internal angle.
-        ext (float): The external angle.
     """
 
     def __init__(self, int_: float, ext: float) -> None:
+        """
+        Args:
+            int_ (float): The internal angle.
+            ext (float): The external angle.
+        """
         int_phase, ext_phase = np.exp(1j * np.array([int_, ext]))
 
         super().__init__(
@@ -334,20 +339,21 @@ class GaussianTransform(_BogoliubovTransformation):
     .. math::
         P P^\dagger - A A^\dagger &= I_{d \times d} \\
         P A^T &= A P^T
-
-    Args:
-        passive (numpy.ndarray):
-            The passive submatrix of the symplectic matrix corresponding to the
-            transformation.
-        active (numpy.ndarray):
-            The active submatrix of the symplectic matrix corresponding to the
-            transformation.
-
-    Raises:
-        InvalidParameters: Raised if the parameters do not form a symplectic matrix.
     """
 
     def __init__(self, passive: np.ndarray, active: np.ndarray) -> None:
+        """
+        Args:
+            passive (numpy.ndarray):
+                The passive submatrix of the symplectic matrix corresponding to the
+                transformation.
+            active (numpy.ndarray):
+                The active submatrix of the symplectic matrix corresponding to the
+                transformation.
+
+        Raises:
+            InvalidParameters: Raised if the parameters do not form a symplectic matrix.
+        """
         if not is_symplectic(
             np.block([[passive, active], [active.conj(), passive.conj()]]),
             form_func=complex_symplectic_form,
@@ -390,13 +396,14 @@ class Squeezing(_ScalableBogoliubovTransformation):
         \right ),
 
     where :math:`z \in \mathbb{C}^{d \times d}` is a symmetric matrix.
-
-    Args:
-        r (float): The amplitude of the squeezing instruction.
-        phi (float): The squeezing angle.
     """
 
     def __init__(self, r: float, phi: float = 0.0) -> None:
+        """
+        Args:
+            r (float): The amplitude of the squeezing instruction.
+            phi (float): The squeezing angle.
+        """
         super().__init__(
             params=dict(r=r, phi=phi),
             passive_block=np.diag(np.atleast_1d(np.cosh(r))),
@@ -453,13 +460,14 @@ class Squeezing2(_BogoliubovTransformation):
             0 & e^{- i \phi} \sinh r & \cosh r & 0 \\
             e^{- i \phi} \sinh r & 0 & 0 & \cosh r
         \end{bmatrix}.
-
-    Args:
-        r (float): The amplitude of the squeezing instruction.
-        phi (float): The squeezing angle.
     """
 
     def __init__(self, r: float, phi: float = 0.0) -> None:
+        """
+        Args:
+            r (float): The amplitude of the squeezing instruction.
+            phi (float): The squeezing angle.
+        """
         super().__init__(
             params=dict(r=r, phi=phi),
             passive_block=np.array(
@@ -575,16 +583,17 @@ class Displacement(_ScalableBogoliubovTransformation):
         \alpha = r \exp \left (
             i \phi
         \right ).
-
-    Args:
-        alpha (complex): The displacement.
-        r (float): The displacement magnitude.
-        phi (float): The displacement angle.
     """
 
     def __init__(
         self, *, alpha: complex = None, r: float = None, phi: float = None
     ) -> None:
+        """
+        Args:
+            alpha (complex): The displacement.
+            r (float): The displacement magnitude.
+            phi (float): The displacement angle.
+        """
         alpha_: np.ndarray
 
         if alpha is not None and r is None and phi is None:
@@ -605,14 +614,15 @@ class Displacement(_ScalableBogoliubovTransformation):
 class PositionDisplacement(_ScalableBogoliubovTransformation):
     r"""Position displacement gate.
 
-    Args:
-        x (float): The position displacement.
-
     Note:
         The specified displacement is automatically scaled by :math:`\sqrt{2 \hbar}`.
     """
 
     def __init__(self, x: float) -> None:
+        """
+        Args:
+            x (float): The position displacement.
+        """
         super().__init__(
             params=dict(x=x),
             displacement_vector=np.atleast_1d(x),
@@ -622,14 +632,15 @@ class PositionDisplacement(_ScalableBogoliubovTransformation):
 class MomentumDisplacement(_ScalableBogoliubovTransformation):
     r"""Momentum displacement gate.
 
-    Args:
-        p (float): The momentum displacement.
-
     Note:
         The specified displacement is automatically scaled by :math:`\sqrt{2 \hbar}`.
     """
 
     def __init__(self, p: float) -> None:
+        """
+        Args:
+            p (float): The momentum displacement.
+        """
         super().__init__(
             params=dict(p=p),
             displacement_vector=1j * np.atleast_1d(p),
@@ -650,12 +661,13 @@ class Kerr(Gate):
 
     .. math::
         K(\xi) a K(\xi) = a \exp(- i \xi (1 + 2 n))
-
-    Args:
-        xi (float): The magnitude of the Kerr nonlinear term.
     """
 
     def __init__(self, xi: float) -> None:
+        """
+        Args:
+            xi (float): The magnitude of the Kerr nonlinear term.
+        """
         super().__init__(params=dict(xi=xi))
 
 
@@ -674,12 +686,13 @@ class CrossKerr(Gate):
     .. math::
         CK_{ij} (\xi) a_i CK_{ij} (\xi) &= a_i \exp(- i \xi n_j) \\
         CK_{ij} (\xi) a_j CK_{ij} (\xi) &= a_j \exp(- i \xi n_i)
-
-    Args:
-        xi (float): The magnitude of the Cross-Kerr nonlinear term.
     """
 
     def __init__(self, xi: float) -> None:
+        """
+        Args:
+            xi (float): The magnitude of the Cross-Kerr nonlinear term.
+        """
         super().__init__(params=dict(xi=xi))
 
 

--- a/piquasso/instructions/measurements.py
+++ b/piquasso/instructions/measurements.py
@@ -91,13 +91,21 @@ class GeneraldyneMeasurement(Measurement):
     state characterizing the general-dyne detection. Notably, the heterodyne detection
     would correspond to a non-displaced Gaussian state with covariance
     :math:`\sigma_m = I_{d \times d}`.
-
-    Args:
-        detection_covariance (numpy.ndarray):
-            A 2-by-2 symplectic matrix corresponding to a purely quadratic Hamiltonian.
     """
 
     def __init__(self, detection_covariance: np.ndarray) -> None:
+        """
+        Args:
+            detection_covariance (numpy.ndarray):
+                A 2-by-2 symplectic matrix corresponding to a purely quadratic
+                Hamiltonian.
+
+        Raises:
+            InvalidParameter:
+                When the detection covariance does not satisfy the Robertson-Schrödinger
+                uncertainty relation.
+        """
+
         if not is_positive_semidefinite(detection_covariance + 1j * symplectic_form(1)):
             raise InvalidParameter(
                 "The parameter 'detection_covariance' is invalid, since it doesn't "
@@ -130,17 +138,19 @@ class HomodyneMeasurement(Measurement):
     with a strong coherent state :math:`| \alpha \rangle`, where :math:`\alpha >> 1`,
     then subtracting the detected intensities of the two outputs.
     The mixing is performed with a 50:50 beamsplitter.
-
-    Args:
-        phi (float): Phase space rotation angle.
-        z (float):
-            Squeezing amplitude. In the limit of `z` going to infinity one would recover
-            the pure homodyne measurement in the so-called strong oscillator limit.
-            Conversely, setting `z = 1` would correspond to
-            :class:`HeterodyneMeasurement`.
     """
 
     def __init__(self, phi: float = 0.0, z: float = 1e-4) -> None:
+        """
+        Args:
+            phi (float): Phase space rotation angle.
+            z (float):
+                Squeezing amplitude. In the limit of `z` going to infinity one would
+                recover the pure homodyne measurement in the so-called strong oscillator
+                limit. Conversely, setting `z = 1` would correspond to
+                :class:`HeterodyneMeasurement`.
+        """
+
         super().__init__(
             params=dict(
                 phi=phi,

--- a/piquasso/instructions/preparations.py
+++ b/piquasso/instructions/preparations.py
@@ -58,6 +58,11 @@ class Mean(Preparation):
     """
 
     def __init__(self, mean: np.ndarray) -> None:
+        """
+        Args:
+            mean (numpy.ndarray):
+                The vector of the first canonical moments in `xpxp`-ordering.
+        """
         super().__init__(params=dict(mean=mean))
 
 
@@ -77,6 +82,11 @@ class Covariance(Preparation):
     """
 
     def __init__(self, cov: np.ndarray) -> None:
+        """
+        Args:
+            cov (numpy.ndarray): The covariance matrix in `xpxp`-ordering.
+        """
+
         super().__init__(params=dict(cov=cov))
 
 
@@ -100,6 +110,17 @@ class StateVector(Preparation, _mixins.WeightMixin):
     def __init__(
         self, occupation_numbers: Iterable[int], coefficient: complex = 1.0
     ) -> None:
+        """
+        Args:
+            occupation_numbers (Iterable[int]): The occupation numbers.
+            coefficient (complex, optional):
+                The coefficient of the occupation number. Defaults to 1.0.
+
+        Raises:
+            InvalidState:
+                If the specified occupation numbers are not all natural numbers.
+        """
+
         if not all_natural(occupation_numbers):
             raise InvalidState(
                 f"Invalid occupation numbers: occupation_numbers={occupation_numbers}"
@@ -139,6 +160,25 @@ class DensityMatrix(Preparation, _mixins.WeightMixin):
         bra: Iterable[int],
         coefficient: complex = 1.0,
     ) -> None:
+        """
+        Args:
+            bra (Iterable[int]): The bra vector.
+            ket (Iterable[int]): The ket vector.
+            coefficient (complex, optional):
+                The coefficient of the operator defined by the "bra" and "ket" vectors.
+                Defaults to 1.0.
+
+        Raises:
+            InvalidState:
+                If the specified "bra" or "ket" vectors are not all natural numbers.
+        """
+
+        if not all_natural(ket):
+            raise InvalidState(f"Invalid ket vector: ket={ket}")
+
+        if not all_natural(bra):
+            raise InvalidState(f"Invalid ket vector: ket={bra}")
+
         super().__init__(
             params=dict(
                 ket=tuple(ket),


### PR DESCRIPTION
The documentation of the constructor parameters is moved to the
`__init__` method, which is concatenated in the documentation by
`sphinx`.

The ordering of classes in the documentation is changed to be the
order in the source code.