### PR TITLE
fix(fock): Explicit casting of complex coefficients

### DIFF
--- a/piquasso/_backends/fock/general/state.py
+++ b/piquasso/_backends/fock/general/state.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Tuple, Any, Generator
+from typing import Tuple, Any, Generator, Dict
 
 import numpy as np
 
@@ -104,6 +104,15 @@ class FockState(BaseFockState):
         cardinality = cutoff_cardinality(d=self.d, cutoff=self._config.cutoff)
 
         return np.diag(self._density_matrix).real[:cardinality]
+
+    @property
+    def fock_probabilities_map(self) -> Dict[Tuple[int, ...], float]:
+        probability_map: Dict[Tuple[int, ...], float] = {}
+
+        for index, basis in self._space.basis:
+            probability_map[tuple(basis)] = np.abs(self._density_matrix[index, index])
+
+        return probability_map
 
     def reduced(self, modes: Tuple[int, ...]) -> "FockState":
         modes_to_eliminate = self._get_auxiliary_modes(modes)

--- a/piquasso/_backends/fock/pure/state.py
+++ b/piquasso/_backends/fock/pure/state.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Tuple, Generator, Any
+from typing import Tuple, Generator, Any, Dict
 
 import numpy as np
 
@@ -105,6 +105,15 @@ class PureFockState(BaseFockState):
         cardinality = cutoff_cardinality(d=self._space.d, cutoff=self._config.cutoff)
 
         return (self._state_vector * self._state_vector.conjugate()).real[:cardinality]
+
+    @property
+    def fock_probabilities_map(self) -> Dict[Tuple[int, ...], float]:
+        probability_map: Dict[Tuple[int, ...], float] = {}
+
+        for index, basis in self._space.basis:
+            probability_map[tuple(basis)] = np.abs(self._state_vector[index]) ** 2
+
+        return probability_map
 
     def normalize(self) -> None:
         if np.isclose(self.norm, 0):

--- a/piquasso/_backends/fock/state.py
+++ b/piquasso/_backends/fock/state.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Tuple, Generator, Any
+from typing import Tuple, Generator, Any, Dict
 
 import abc
 import numpy as np
@@ -73,4 +73,9 @@ class BaseFockState(State, abc.ABC):
         """
         Resets this object to a vacuum state.
         """
+        pass
+
+    @property
+    @abc.abstractmethod
+    def fock_probabilities_map(self) -> Dict[Tuple[int, ...], float]:
         pass

--- a/piquasso/_math/fock.py
+++ b/piquasso/_math/fock.py
@@ -309,7 +309,7 @@ class FockSpace(tuple):
         return FockBasis(temp)
 
     def get_projection_operator_indices_for_pure(
-        self, *, subspace_basis: FockBasis, modes: Tuple[int, ...]
+        self, *, subspace_basis: Tuple[int, ...], modes: Tuple[int, ...]
     ) -> List[int]:
         return [
             index
@@ -318,7 +318,7 @@ class FockSpace(tuple):
         ]
 
     def get_projection_operator_indices(
-        self, *, subspace_basis: FockBasis, modes: Tuple[int, ...]
+        self, *, subspace_basis: Tuple[int, ...], modes: Tuple[int, ...]
     ) -> Tuple[Tuple[int, ...], Tuple[int, ...]]:
         return tuple(  # type: ignore
             zip(

--- a/tests/backends/fock/pure/test_state.py
+++ b/tests/backends/fock/pure/test_state.py
@@ -45,3 +45,35 @@ def test_PureFockState_reduced():
     reduced_state = state.reduced(modes=(1,))
 
     assert expected_reduced_state == reduced_state
+
+
+def test_PureFockState_fock_probabilities_map():
+    with pq.Program() as program:
+        pq.Q() | pq.StateVector([0, 1]) / 2
+
+        pq.Q() | pq.StateVector([0, 2]) / 2
+        pq.Q() | pq.StateVector([2, 0]) / np.sqrt(2)
+
+    simulator = pq.PureFockSimulator(d=2)
+    state = simulator.execute(program).state
+
+    expected_fock_probabilities = {
+        (0, 0): 0.0,
+        (0, 1): 0.25,
+        (1, 0): 0.0,
+        (0, 2): 0.25,
+        (1, 1): 0.0,
+        (2, 0): 0.5,
+        (0, 3): 0.0,
+        (1, 2): 0.0,
+        (2, 1): 0.0,
+        (3, 0): 0.0,
+    }
+
+    actual_fock_probabilities = state.fock_probabilities_map
+
+    for occupation_number, expected_probability in expected_fock_probabilities.items():
+        assert np.isclose(
+            actual_fock_probabilities[occupation_number],
+            expected_probability,
+        )


### PR DESCRIPTION
During the calculation of the `ParticleNumberMeasurement` instruction in
the `fock` backends, the elements of the state vector or density matrix
is cast with `float`. This wouldn't be a problem where all the modes are
measured, but it definitely doesn't work for less modes in general,
because (essentially) the imaginary parts are thrown away.

The algorithm has been rewritten to reduce the state to the measured
modes first, and then calculate the particle number measurement
probabilities corresponding to the reduced state.