### PR TITLE
fix(gaussian): Attenuator channel

### DIFF
--- a/piquasso/_backends/gaussian/calculations.py
+++ b/piquasso/_backends/gaussian/calculations.py
@@ -587,10 +587,15 @@ def deterministic_gaussian_channel(
     mean_vector = state.xpxp_mean_vector
     covariance_matrix = state.xpxp_covariance_matrix
 
-    mean_vector[indices] = X @ mean_vector[indices]
-    covariance_matrix[matrix_indices] = X @ covariance_matrix[matrix_indices] @ X.T + Y
+    embedded_X = np.identity(len(mean_vector), dtype=complex)
+    embedded_X[matrix_indices] = X
 
-    state.xpxp_mean_vector = mean_vector
-    state.xpxp_covariance_matrix = covariance_matrix
+    embedded_Y = np.zeros_like(embedded_X)
+    embedded_Y[matrix_indices] = Y
+
+    state.xpxp_mean_vector = embedded_X @ mean_vector
+    state.xpxp_covariance_matrix = (
+        embedded_X @ covariance_matrix @ embedded_X.T + embedded_Y
+    )
 
     return Result(state=state)

--- a/tests/backends/gaussian/test_channels.py
+++ b/tests/backends/gaussian/test_channels.py
@@ -212,6 +212,19 @@ def test_Attenuator_with_zero_thermal_exciation():
     )
 
 
+def test_Attenuator_with_multiple_modes():
+    with pq.Program() as program:
+        pq.Q(0, 1) | pq.Squeezing2(0.3)
+
+        pq.Q(0) | pq.Attenuator(theta=0.1, mean_thermal_excitation=0)
+
+    simulator = pq.GaussianSimulator(d=2)
+
+    state = simulator.execute(program).state
+
+    assert np.isclose(state.mean_photon_number(modes=(0, 1)), 0.18454097911952028)
+
+
 def test_Attenuator_with_nonzero_thermal_exciation():
     original_mean_photon_number = 2
     theta = np.pi / 6


### PR DESCRIPTION
The `Attenuator` channel haven't been implemented correctly, since the
matrices `X` and `Y` were not embedded. This has been fixed in this
patch, and a test case has been included.