### PR TITLE
fix(fock): Reduction passes config

### DIFF
--- a/piquasso/_backends/fock/general/state.py
+++ b/piquasso/_backends/fock/general/state.py
@@ -117,7 +117,7 @@ class FockState(BaseFockState):
     def reduced(self, modes: Tuple[int, ...]) -> "FockState":
         modes_to_eliminate = self._get_auxiliary_modes(modes)
 
-        reduced_state = FockState(d=len(modes))
+        reduced_state = FockState(d=len(modes), config=self._config)
 
         for index, (basis, dual_basis) in self._space.operator_basis_diagonal_on_modes(
             modes=modes_to_eliminate

--- a/tests/backends/fock/pure/test_state.py
+++ b/tests/backends/fock/pure/test_state.py
@@ -47,6 +47,19 @@ def test_PureFockState_reduced():
     assert expected_reduced_state == reduced_state
 
 
+def test_PureFockState_reduced_preserves_Config():
+    with pq.Program() as program:
+        pq.Q() | pq.StateVector([0, 1]) / 2
+
+        pq.Q() | pq.StateVector([0, 2]) / 2
+        pq.Q() | pq.StateVector([2, 0]) / np.sqrt(2)
+
+    simulator = pq.PureFockSimulator(d=2, config=pq.Config(cutoff=10))
+    state = simulator.execute(program).state
+
+    assert state._config.cutoff == 10
+
+
 def test_PureFockState_fock_probabilities_map():
     with pq.Program() as program:
         pq.Q() | pq.StateVector([0, 1]) / 2


### PR DESCRIPTION
In the `reduced()` method, the new `FockState` instance didn't inherit
the `_config` attribute, which resulted in errors. This has been fixed
in this patch.