### PR TITLE
fix(_backends): `get_particle_detection_probability`

### DIFF
--- a/piquasso/_backends/fock/general/state.py
+++ b/piquasso/_backends/fock/general/state.py
@@ -18,7 +18,7 @@ from typing import Tuple, Any, Generator, Dict
 import numpy as np
 
 from piquasso.api.config import Config
-from piquasso.api.errors import InvalidState
+from piquasso.api.errors import InvalidState, PiquassoException
 from piquasso._math.linalg import is_selfadjoint
 from piquasso._math.fock import cutoff_cardinality, FockOperatorBasis
 
@@ -96,6 +96,12 @@ class FockState(BaseFockState):
         return self._density_matrix[:cardinality, :cardinality]
 
     def get_particle_detection_probability(self, occupation_number: tuple) -> float:
+        if len(occupation_number) != self.d:
+            raise PiquassoException(
+                f"The specified occupation number should have length '{self.d}': "
+                f"occupation_number='{occupation_number}'."
+            )
+
         index = self._space.index(occupation_number)
         return np.diag(self._density_matrix)[index].real
 

--- a/piquasso/_backends/fock/pure/state.py
+++ b/piquasso/_backends/fock/pure/state.py
@@ -18,7 +18,7 @@ from typing import Tuple, Generator, Any, Dict
 import numpy as np
 
 from piquasso.api.config import Config
-from piquasso.api.errors import InvalidState
+from piquasso.api.errors import InvalidState, PiquassoException
 from piquasso._math.fock import cutoff_cardinality, FockBasis
 
 from ..state import BaseFockState
@@ -94,6 +94,12 @@ class PureFockState(BaseFockState):
     def get_particle_detection_probability(
         self, occupation_number: Tuple[int, ...]
     ) -> float:
+        if len(occupation_number) != self.d:
+            raise PiquassoException(
+                f"The specified occupation number should have length '{self.d}': "
+                f"occupation_number='{occupation_number}'."
+            )
+
         index = self._space.index(occupation_number)
 
         return np.real(

--- a/piquasso/_backends/gaussian/state.py
+++ b/piquasso/_backends/gaussian/state.py
@@ -18,7 +18,7 @@ from typing import Tuple, List
 import numpy as np
 
 from piquasso.api.config import Config
-from piquasso.api.errors import InvalidState, InvalidParameter
+from piquasso.api.errors import InvalidState, InvalidParameter, PiquassoException
 from piquasso.api.state import State
 
 from piquasso._math.functions import gaussian_wigner_function
@@ -684,6 +684,12 @@ class GaussianState(State):
     def get_particle_detection_probability(
         self, occupation_number: Tuple[int, ...]
     ) -> float:
+        if len(occupation_number) != self.d:
+            raise PiquassoException(
+                f"The specified occupation number should have length '{self.d}': "
+                f"occupation_number='{occupation_number}'."
+            )
+
         calculation = DensityMatrixCalculation(
             self.complex_displacement,
             self.complex_covariance,

--- a/piquasso/_backends/sampling/state.py
+++ b/piquasso/_backends/sampling/state.py
@@ -24,6 +24,7 @@ from piquasso._math.validations import all_natural
 from piquasso.api.config import Config
 from piquasso.api.errors import InvalidState
 from piquasso.api.state import State
+from piquasso.api.errors import PiquassoException
 
 from theboss.distribution_calculators.bs_distribution_calculator_with_fixed_losses import (  # noqa: E501
     BSDistributionCalculatorWithFixedLosses,
@@ -72,6 +73,12 @@ class SamplingState(State):
     def get_particle_detection_probability(
         self, occupation_number: Tuple[int, ...]
     ) -> float:
+        if len(occupation_number) != self.d:
+            raise PiquassoException(
+                f"The specified occupation number should have length '{self.d}': "
+                f"occupation_number='{occupation_number}'."
+            )
+
         number_of_particles = sum(occupation_number)
 
         if number_of_particles != self.particle_number:

--- a/tests/backends/fock/test_gates.py
+++ b/tests/backends/fock/test_gates.py
@@ -61,6 +61,23 @@ def test_displacement_probabilities(SimulatorClass):
     )
 
 
+@pytest.mark.parametrize("SimulatorClass", (pq.PureFockSimulator, pq.FockSimulator))
+def test_displacement_get_fock_prob(SimulatorClass):
+    with pq.Program() as program:
+        pq.Q() | pq.Vacuum()
+
+        pq.Q(0) | pq.Displacement(r=0.2, phi=np.pi / 3)
+
+    simulator = SimulatorClass(d=2, config=pq.Config(cutoff=8))
+
+    state = simulator.execute(program).state
+
+    state.validate()
+    assert np.isclose(
+        state.get_particle_detection_probability(occupation_number=(0, 1)), 0.0
+    )
+
+
 def test_PureFockState_squeezing():
     r = 0.5
     phi = np.pi / 3

--- a/tests/backends/test_state.py
+++ b/tests/backends/test_state.py
@@ -1,0 +1,47 @@
+#
+# Copyright 2021 Budapest Quantum Computing Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+import numpy as np
+
+import piquasso as pq
+
+
+@pytest.mark.parametrize(
+    "SimulatorClass",
+    (
+        pq.GaussianSimulator,
+        pq.PureFockSimulator,
+        pq.FockSimulator,
+        pq.SamplingSimulator,
+    ),
+)
+def test_get_particle_detection_probability_raises_PiquassoException_wrong_modes(
+    SimulatorClass,
+):
+    wrong_occupation_number = (0, 1)
+
+    with pq.Program() as program:
+        pq.Q(0) | pq.Phaseshifter(np.pi / 3)
+
+    simulator = SimulatorClass(d=3)
+
+    state = simulator.execute(program).state
+
+    with pytest.raises(pq.api.errors.PiquassoException):
+        state.get_particle_detection_probability(
+            occupation_number=wrong_occupation_number
+        )


### PR DESCRIPTION
The method `get_particle_detection_probability` accepted all kinds of
occupation numbers, but gave wrong (complex) results silently. This has
been fixed by raising an error, if the wrong length of occupation
numbers are specified.