### PR TITLE
fix(typing): Typing errors on 3.8 and above

### DIFF
--- a/piquasso/_backends/gaussian/calculations.py
+++ b/piquasso/_backends/gaussian/calculations.py
@@ -410,7 +410,7 @@ def _get_particle_number_choice(
 
     gamma = alpha.conj() - alpha @ B
 
-    weights = np.array([])
+    weights: np.ndarray = np.array([])
 
     possible_choices = tuple(range(state._config.measurement_cutoff))
 

--- a/piquasso/_math/hermite.py
+++ b/piquasso/_math/hermite.py
@@ -13,14 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Collection
-
 import numpy as np
 
 
-def modified_hermite_multidim(
-    B: np.ndarray, n: Collection[int], alpha: np.ndarray
-) -> complex:
+def modified_hermite_multidim(B, n, alpha):
     try:
         index = tuple(n).index(next(filter(lambda x: x != 0, tuple(n))))
     except StopIteration:

--- a/piquasso/_math/validations.py
+++ b/piquasso/_math/validations.py
@@ -19,7 +19,7 @@ import numpy as np
 
 
 def is_natural(number: Union[int, float]) -> bool:
-    return np.isclose(number % 1, 0.0) and round(number) >= 0
+    return bool(np.isclose(number % 1, 0.0) and round(number) >= 0)
 
 
 def all_natural(array: Iterable) -> bool:


### PR DESCRIPTION
There were some problems on Python version 3.8 and above with the
typing, these were corrected in this patch, except for
`modified_hermite_multidim`, where I deleted all the typings. The
solution would be really messy, and type hinting this function is not
very helpful anyway.