### PR TITLE
feature(fock): Calculate Fidelity of any fock state.

### DIFF
--- a/piquasso/_backends/fock/state.py
+++ b/piquasso/_backends/fock/state.py
@@ -17,7 +17,7 @@ from typing import Tuple, Generator, Any, Dict, List
 
 import abc
 import numpy as np
-
+from scipy.linalg import sqrtm
 from piquasso.api.config import Config
 from piquasso.api.state import State
 
@@ -199,3 +199,29 @@ class BaseFockState(State, abc.ABC):
                 W += 2 * np.real(rho[m, n] * Wlist[n])
 
         return 0.5 * W * g ** 2
+
+    def calculate_fidelity(self, state: "BaseFockState") -> float:
+        """Calculates the state fidelity between two quantum states.
+
+        The state fidelity :math:`F` between two density matrices
+        :math:`\rho_1, \rho_2` is given by:
+
+        .. math::
+            \operatorname{F}(\rho_1, \rho_2) = \operatorname{Tr}(\sqrt{\sqrt{\rho_1}
+                \rho_2\sqrt{\rho_1}})^2
+
+        Args:
+            state: Either a :class:`~piquasso._backends.fock.pure.state.PureFockState`
+            or a :class:`~piquasso._backends.fock.general.state.FockState` that can be
+            used to calculate the fidelity aganist it.
+
+        Returns:
+            float: The calculated fidelity.
+        """
+
+        sqrt_density_1 = sqrtm(self.density_matrix)
+        sqrt_density_2 = sqrtm(state.density_matrix)
+        squared_matrix = np.dot(sqrt_density_1, sqrt_density_2)
+        # Trace norm of the matrix. For more details please check:
+        # https://www.quantiki.org/wiki/trace-norm
+        return float((np.linalg.norm(squared_matrix, ord="nuc") ** 2).real)

--- a/tests/backends/fock/general/test_state.py
+++ b/tests/backends/fock/general/test_state.py
@@ -89,7 +89,7 @@ def test_FockState_quadratures_mean_variance():
         pq.Q(1) | pq.Squeezing(r=0.1, phi=1.0)
         pq.Q(2) | pq.Displacement(r=0.2, phi=np.pi / 2)
 
-    simulator = pq.FockSimulator(d=3, config=pq.Config(cutoff=14, hbar=2))
+    simulator = pq.FockSimulator(d=3, config=pq.Config(cutoff=8, hbar=2))
     result = simulator.execute(program)
 
     mean_on_0th, variance_on_0th = result.state.quadratures_mean_variance(modes=(0,))

--- a/tests/backends/fock/pure/test_state.py
+++ b/tests/backends/fock/pure/test_state.py
@@ -99,7 +99,7 @@ def test_PureFockState_quadratures_mean_variance():
         pq.Q(1) | pq.Squeezing(r=0.1, phi=1.0)
         pq.Q(2) | pq.Displacement(r=0.2, phi=np.pi / 2)
 
-    simulator = pq.PureFockSimulator(d=3, config=pq.Config(cutoff=14, hbar=2))
+    simulator = pq.PureFockSimulator(d=3, config=pq.Config(cutoff=8, hbar=2))
     result = simulator.execute(program)
 
     mean_1, var_1 = result.state.quadratures_mean_variance(modes=(0,))

--- a/tests/backends/fock/test_state.py
+++ b/tests/backends/fock/test_state.py
@@ -42,16 +42,16 @@ def test_FockState_quadratures_mean_variance(SimulatorClass):
     with pq.Program() as program:
         pq.Q() | pq.Vacuum()
 
-        pq.Q(0) | pq.Displacement(alpha=1 - 0.5j)
+        pq.Q(0) | pq.Displacement(alpha=0.2 - 0.2j)
         pq.Q(0) | pq.Squeezing(r=0.2)
 
-    simulator = SimulatorClass(d=1, config=pq.Config(cutoff=10))
+    simulator = SimulatorClass(d=1, config=pq.Config(cutoff=6))
     state = simulator.execute(program).state
 
     mean, var = state.quadratures_mean_variance(modes=(0,))
 
-    assert np.isclose(mean, 1.6374076, atol=1e-5)
-    assert np.isclose(var, 0.6705157, atol=1e-4)
+    assert np.isclose(mean, 0.3275267, atol=1e-5)
+    assert np.isclose(var, 0.6709301, atol=1e-4)
 
 
 @pytest.mark.parametrize("SimulatorClass", (pq.FockSimulator, pq.PureFockSimulator))
@@ -114,3 +114,25 @@ def test_FockState_wigner_function_raises_InvalidModes_for_multiple_modes_specif
             positions=[1, 1.1],
             momentums=[-0.5, -0.6],
         )
+
+
+@pytest.mark.parametrize("SimulatorClass", (pq.FockSimulator, pq.PureFockSimulator))
+def test_FockState_calculate_fidelity(
+    SimulatorClass,
+):
+    with pq.Program() as program:
+        pq.Q() | pq.Vacuum()
+
+        pq.Q(0) | pq.Squeezing(r=0.2, phi=np.pi / 2)
+
+    simulator = SimulatorClass(d=1, config=pq.Config(cutoff=6))
+    state = simulator.execute(program).state
+
+    with pq.Program() as program_2:
+        pq.Q() | pq.Vacuum()
+
+        pq.Q(0) | pq.Squeezing(r=0.2, phi=-np.pi / 2)
+
+    state_2 = simulator.execute(program_2).state
+
+    assert np.isclose(state.calculate_fidelity(state_2), 0.92507584)


### PR DESCRIPTION
- A method called `calculate_fidelity` has been implemented in
  `fock/state.py` under the `BaseFockState` class.
- A generic test has been implemented in `fock/test_state.py`
- Modified the cutoff and the active parameters in other test cases to speed up the test cycle.

related to #86