### PR TITLE
Support different configs, Extract permanent + hafnian

### DIFF
--- a/piquasso/_backends/fock/general/calculations.py
+++ b/piquasso/_backends/fock/general/calculations.py
@@ -34,7 +34,10 @@ def passive_linear(state: FockState, instruction: Instruction, shots: int) -> Re
     operator: np.ndarray = instruction._all_params["passive_block"]
 
     fock_operator = state._space.get_passive_fock_operator(
-        operator, modes=instruction.modes, d=state._space.d
+        operator,
+        modes=instruction.modes,
+        d=state._space.d,
+        permanent_function=state._config.permanent_function,
     )
 
     state._density_matrix = (
@@ -225,6 +228,7 @@ def linear(state: FockState, instruction: Instruction, shots: int) -> Result:
         modes=instruction.modes,
         passive_block=instruction._all_params["passive_block"],
         active_block=instruction._all_params["active_block"],
+        permanent_function=state._config.permanent_function,
     )
 
     state._density_matrix = (

--- a/piquasso/_backends/fock/pure/calculations.py
+++ b/piquasso/_backends/fock/pure/calculations.py
@@ -64,7 +64,10 @@ def passive_linear(
     operator: np.ndarray = instruction._all_params["passive_block"]
 
     fock_operator = state._space.get_passive_fock_operator(
-        operator, modes=instruction.modes, d=state._space.d
+        operator,
+        modes=instruction.modes,
+        d=state._space.d,
+        permanent_function=state._config.permanent_function,
     )
 
     state._state_vector = fock_operator @ state._state_vector
@@ -203,6 +206,7 @@ def linear(state: PureFockState, instruction: Instruction, shots: int) -> Result
         modes=instruction.modes,
         passive_block=instruction._all_params["passive_block"],
         active_block=instruction._all_params["active_block"],
+        permanent_function=state._config.permanent_function,
     )
 
     state._state_vector = operator @ state._state_vector

--- a/piquasso/_backends/gaussian/calculations.py
+++ b/piquasso/_backends/gaussian/calculations.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Tuple, List, Callable
+from typing import Tuple, List
 
 import itertools
 import scipy
@@ -33,7 +33,6 @@ from piquasso.api.instruction import Instruction
 from piquasso.api.errors import InvalidInstruction
 
 from piquasso._math.linalg import reduce_
-from piquasso._math.hafnian import loop_hafnian
 from piquasso._math.indices import get_operator_index, get_auxiliary_operator_index
 from piquasso._math.decompositions import decompose_to_pure_and_mixed
 
@@ -298,7 +297,6 @@ def _get_particle_number_measurement_samples(
     state: GaussianState,
     instruction: Instruction,
     shots: int,
-    loop_hafnian_func: Callable = loop_hafnian,
 ) -> List[Tuple[int, ...]]:
 
     modes: Tuple[int, ...] = instruction.modes
@@ -348,7 +346,6 @@ def _get_particle_number_measurement_samples(
             choice = _get_particle_number_choice(
                 evolved_state,
                 sample,
-                loop_hafnian_func,
             )
 
             sample = sample + (choice,)
@@ -361,7 +358,6 @@ def _get_particle_number_measurement_samples(
 def _get_particle_number_choice(
     state: GaussianState,
     previous_sample: Tuple[int, ...],
-    loop_hafnian_func: Callable,
 ) -> int:
     r"""
     The original equations are
@@ -422,7 +418,7 @@ def _get_particle_number_choice(
 
         np.fill_diagonal(B_reduced, gamma_reduced)
 
-        weight = abs(loop_hafnian_func(B_reduced)) ** 2 / factorial(n)
+        weight = abs(state._config.loop_hafnian_function(B_reduced)) ** 2 / factorial(n)
         weights = np.append(weights, weight)
 
     weights /= np.sum(weights)

--- a/piquasso/_backends/gaussian/probabilities.py
+++ b/piquasso/_backends/gaussian/probabilities.py
@@ -20,8 +20,9 @@ import numpy as np
 from scipy.special import factorial
 
 from piquasso._math.linalg import block_reduce, reduce_
-from piquasso._math.hafnian import loop_hafnian
 from piquasso._math.torontonian import torontonian
+
+from piquasso.api.typing import HafnianFunction
 
 
 class DensityMatrixCalculation:
@@ -29,6 +30,7 @@ class DensityMatrixCalculation:
         self,
         complex_displacement: np.ndarray,
         complex_covariance: np.ndarray,
+        loop_hafnian_function: HafnianFunction,
     ) -> None:
         d = len(complex_displacement) // 2
         Q = (complex_covariance + np.identity(2 * d)) / 2
@@ -52,6 +54,8 @@ class DensityMatrixCalculation:
             -0.5 * self._gamma @ complex_displacement
         ) / np.sqrt(np.linalg.det(Q))
 
+        self.loop_hafnian_function = loop_hafnian_function
+
     def _get_A_reduced(self, reduce_on: Tuple[int, ...]) -> np.ndarray:
         A_reduced = reduce_(self._A, reduce_on=reduce_on)
 
@@ -68,7 +72,7 @@ class DensityMatrixCalculation:
 
         return (
             self._normalization
-            * loop_hafnian(A_reduced)
+            * self.loop_hafnian_function(A_reduced)
             / np.sqrt(np.prod(factorial(reduce_on)))
         )
 

--- a/piquasso/_backends/gaussian/state.py
+++ b/piquasso/_backends/gaussian/state.py
@@ -664,6 +664,7 @@ class GaussianState(State):
         calculation = DensityMatrixCalculation(
             complex_displacement=self.complex_displacement,
             complex_covariance=self.complex_covariance,
+            loop_hafnian_function=self._config.loop_hafnian_function,
         )
 
         return calculation.get_density_matrix(
@@ -730,6 +731,7 @@ class GaussianState(State):
         calculation = DensityMatrixCalculation(
             self.complex_displacement,
             self.complex_covariance,
+            loop_hafnian_function=self._config.loop_hafnian_function,
         )
 
         return calculation.get_density_matrix_element(
@@ -742,6 +744,7 @@ class GaussianState(State):
         calculation = DensityMatrixCalculation(
             complex_displacement=self.complex_displacement,
             complex_covariance=self.complex_covariance,
+            loop_hafnian_function=self._config.loop_hafnian_function,
         )
 
         return calculation.get_particle_number_detection_probabilities(

--- a/piquasso/_math/permanent.py
+++ b/piquasso/_math/permanent.py
@@ -1,0 +1,31 @@
+#
+# Copyright 2021 Budapest Quantum Computing Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from theboss.boson_sampling_utilities.permanent_calculators.glynn_gray_permanent_calculator import (  # noqa: E501
+    GlynnGrayPermanentCalculator,
+)
+
+
+def _permanent(matrix, rows, columns, calculator_class):
+    calculator = calculator_class(matrix, rows, columns)
+
+    return calculator.compute_permanent()
+
+
+def glynn_gray_permanent(matrix, rows, columns):
+    return _permanent(
+        matrix, rows, columns, calculator_class=GlynnGrayPermanentCalculator
+    )

--- a/piquasso/api/config.py
+++ b/piquasso/api/config.py
@@ -20,6 +20,11 @@ import copy
 import random
 import numpy as np
 
+from piquasso._math.permanent import glynn_gray_permanent
+from piquasso._math.hafnian import loop_hafnian
+
+from piquasso.api.typing import PermanentFunction, HafnianFunction
+
 
 class Config:
     """The configuration for the simulation."""
@@ -33,6 +38,8 @@ class Config:
         use_torontonian: bool = False,
         cutoff: int = 4,
         measurement_cutoff: int = 5,
+        permanent_function: PermanentFunction = glynn_gray_permanent,
+        loop_hafnian_function: HafnianFunction = loop_hafnian,
     ):
         self.seed_sequence = seed_sequence or int.from_bytes(
             os.urandom(8), byteorder="big"
@@ -42,6 +49,8 @@ class Config:
         self.use_torontonian = use_torontonian
         self.cutoff = cutoff
         self.measurement_cutoff = measurement_cutoff
+        self.permanent_function = permanent_function
+        self.loop_hafnian_function = loop_hafnian_function
 
     @property
     def seed_sequence(self):

--- a/piquasso/api/simulator.py
+++ b/piquasso/api/simulator.py
@@ -38,10 +38,11 @@ class Simulator(Computer, abc.ABC):
     """Base class for all simulators defined in Piquasso."""
 
     _state_class: Type[State]
+    _config_class: Type[Config] = Config
 
     def __init__(self, d: int, config: Optional[Config] = None) -> None:
         self.d = d
-        self.config = config.copy() if config is not None else Config()
+        self.config = config.copy() if config is not None else self._config_class()
 
     @property
     @abc.abstractmethod

--- a/piquasso/api/state.py
+++ b/piquasso/api/state.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Tuple
+from typing import Tuple, Type, Optional
 
 import abc
 import copy
@@ -30,8 +30,10 @@ class State(abc.ABC):
         d (int): Instance attribute specifying the number of modes.
     """
 
-    def __init__(self, config: Config = None) -> None:
-        self._config = config.copy() if config is not None else Config()
+    _config_class: Type[Config] = Config
+
+    def __init__(self, config: Optional[Config] = None) -> None:
+        self._config = config.copy() if config is not None else self._config_class()
 
     def _get_auxiliary_modes(self, modes: Tuple[int, ...]) -> Tuple[int, ...]:
         return tuple(np.delete(np.arange(self.d), modes))

--- a/piquasso/api/typing.py
+++ b/piquasso/api/typing.py
@@ -1,0 +1,22 @@
+#
+# Copyright 2021 Budapest Quantum Computing Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+
+from typing import Callable, Tuple
+
+
+PermanentFunction = Callable[[np.ndarray, Tuple[int, ...], Tuple[int, ...]], float]
+HafnianFunction = Callable[[np.ndarray], float]

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -72,12 +72,22 @@ def FakeState():
 
 
 @pytest.fixture
-def FakeSimulator(FakeState, FakePreparation, FakeGate, FakeMeasurement):
+def FakeConfig():
+    class FakeConfig(pq.api.config.Config):
+        pass
+
+    return FakeConfig
+
+
+@pytest.fixture
+def FakeSimulator(FakeState, FakeConfig, FakePreparation, FakeGate, FakeMeasurement):
     def fake_calculation(state: FakeState, instruction: pq.Instruction, shots: int):
         return pq.api.result.Result(state=state)
 
     class FakeSimulator(pq.Simulator):
         _state_class = FakeState
+
+        _config_class = FakeConfig
 
         _instruction_map = {
             FakePreparation: fake_calculation,

--- a/tests/api/test_config.py
+++ b/tests/api/test_config.py
@@ -36,3 +36,67 @@ def test_Config_seed_generates_same_output():
     reproduced_sample = config2.rng.multivariate_normal(mean=mean, cov=covariance)
 
     assert np.allclose(sample, reproduced_sample)
+
+
+def test_Config_with_overriding_defaults():
+    """
+    NOTE: This test basically tests Python itself, but it is left here for us to
+    remember that the `Config` class defaults need to be able to overridden for any
+    plugin which might want to use e.g. different permanent or hafnian calculation.
+    """
+
+    def plugin_permanent_function():
+        return 42
+
+    def plugin_loop_hafnian_function():
+        return 43
+
+    class PluginConfig(pq.api.config.Config):
+        def __init__(
+            self,
+            permanent_function=plugin_permanent_function,
+            loop_hafnian_function=plugin_loop_hafnian_function,
+            **kwargs
+        ) -> None:
+            super().__init__(
+                permanent_function=permanent_function,
+                loop_hafnian_function=loop_hafnian_function,
+                **kwargs,
+            )
+
+    plugin_config = PluginConfig()
+
+    assert plugin_config.permanent_function is plugin_permanent_function
+    assert plugin_config.loop_hafnian_function is plugin_loop_hafnian_function
+
+    assert plugin_config.permanent_function() == 42
+    assert plugin_config.loop_hafnian_function() == 43
+
+
+def test_Config_subclass_defaults_can_be_overridden_by_user():
+    """
+    NOTE: This test basically tests Python itself, but it is left here for us to
+    remember that the `Config` class defaults need to be able to overridden for any
+    plugin which might want to use e.g. different permanent or hafnian calculation.
+    """
+
+    def plugin_permanent_function():
+        return 42
+
+    def user_defined_permanent_function():
+        return 44
+
+    class PluginConfig(pq.api.config.Config):
+        def __init__(
+            self, permanent_function=plugin_permanent_function, **kwargs
+        ) -> None:
+            super().__init__(
+                permanent_function=permanent_function,
+                **kwargs,
+            )
+
+    plugin_config = PluginConfig(permanent_function=user_defined_permanent_function)
+
+    assert plugin_config.permanent_function is not plugin_permanent_function
+
+    assert plugin_config.permanent_function is user_defined_permanent_function

--- a/tests/api/test_simulator.py
+++ b/tests/api/test_simulator.py
@@ -227,3 +227,15 @@ def test_program_execution_with_initial_state_of_wrong_type_raises_InvalidState(
 
     with pytest.raises(pq.api.errors.InvalidState):
         simulator.execute(program, initial_state=state)
+
+
+def test_Config_override(FakeSimulator, FakeConfig):
+
+    with pq.Program() as program:
+        pass
+
+    simulator = FakeSimulator(d=1)
+    state = simulator.execute(program).state
+
+    assert isinstance(simulator.config, FakeConfig)
+    assert isinstance(state._config, FakeConfig)


### PR DESCRIPTION
Different default configs are needed to be supported, since we might
want to use different parameters in plugins.

The permanent and hafnian calculation functions are moved to `Config` in
order to
    
1) enable the user to specify it, if needed;
2) enable a plugin to override it.
    
Tests were written accordingly in `test_config.py`.