### PR TITLE
fix(gaussian): Config inheritance of states

### DIFF
--- a/piquasso/_backends/gaussian/calculations.py
+++ b/piquasso/_backends/gaussian/calculations.py
@@ -265,7 +265,7 @@ def _get_generaldyne_evolved_state(state, sample, modes, detection_covariance):
         cov_measured + full_detection_covariance
     ) @ (sample - mean_measured)
 
-    state = state.__class__(d=len(evolved_r_A) // 2)
+    state = GaussianState(d=len(evolved_r_A) // 2, config=state._config)
 
     state.xpxp_covariance_matrix = evolved_cov_outer
     state.xpxp_mean_vector = evolved_r_A
@@ -309,7 +309,7 @@ def _get_particle_number_measurement_samples(
         reduced_state.xxpp_covariance_matrix,
         hbar=state._config.hbar,
     )
-    pure_state = state.__class__(len(reduced_state))
+    pure_state = GaussianState(len(reduced_state), config=state._config)
     pure_state.xxpp_covariance_matrix = pure_covariance
 
     heterodyne_detection_covariance = np.identity(2)

--- a/piquasso/_backends/gaussian/state.py
+++ b/piquasso/_backends/gaussian/state.py
@@ -72,7 +72,7 @@ class GaussianState(State):
         C: np.ndarray,
         config: Config,
     ) -> "GaussianState":
-        obj = cls(d=len(m))
+        obj = cls(d=len(m), config=config)
 
         obj._m = m
         obj._G = G

--- a/tests/backends/gaussian/test_state.py
+++ b/tests/backends/gaussian/test_state.py
@@ -173,6 +173,26 @@ def test_rotated():
     )
 
 
+def test_rotated_state_inherits_config():
+    with pq.Program() as program:
+        pq.Q(all) | pq.Displacement(alpha=[1.0, 2.0, 3.0j])
+
+        pq.Q(0, 1) | pq.Squeezing2(r=np.log(2.0), phi=0.0)
+
+        pq.Q(0, 1) | pq.Beamsplitter(theta=np.pi / 2, phi=0)
+
+    config = pq.Config(hbar=1, seed_sequence=42)
+
+    simulator = pq.GaussianSimulator(d=3, config=config)
+    state = simulator.execute(program).state
+    state.validate()
+
+    reduced_state = state.rotated(phi=np.pi / 5)
+
+    assert state._config == config
+    assert reduced_state._config == state._config
+
+
 def test_reduced():
     with pq.Program() as program:
         pq.Q(all) | pq.Displacement(alpha=[1.0, 2.0, 3.0j])
@@ -207,6 +227,26 @@ def test_reduced():
         expected_reduced_covariance_matrix,
         reduced_state.xpxp_covariance_matrix,
     )
+
+
+def test_reduced_state_inherits_config():
+    with pq.Program() as program:
+        pq.Q(all) | pq.Displacement(alpha=[1.0, 2.0, 3.0j])
+
+        pq.Q(0, 1) | pq.Squeezing2(r=np.log(2.0), phi=0.0)
+
+        pq.Q(0, 1) | pq.Beamsplitter(theta=np.pi / 2, phi=0)
+
+    config = pq.Config(hbar=1, seed_sequence=42)
+
+    simulator = pq.GaussianSimulator(d=3, config=config)
+    state = simulator.execute(program).state
+    state.validate()
+
+    reduced_state = state.reduced(modes=(0,))
+
+    assert state._config == config
+    assert reduced_state._config == state._config
 
 
 def test_vacuum_covariance_is_proportional_to_identity():


### PR DESCRIPTION
There were 3 instances in the Gaussian backend, where the config is not
properly passed to a new instance of the state. This caused unusual
validation errors due to covariance matrices not adhering to the
Robertson-Schrödinger uncertainty relation, which turned out to be an
issue because the covariance matrices were divided with the default
`hbar` value, instead of the one in the config.

This has been fixed in this patch by passing the config to every
instantiation.

Several test cases were added, which would have failed with the original
code.