### PR TITLE
feat(config): Moving reduction to loop hafnian + feat(gaussian): Hafnian and loop hafnian cases

### DIFF
--- a/piquasso/_backends/gaussian/calculations.py
+++ b/piquasso/_backends/gaussian/calculations.py
@@ -400,6 +400,8 @@ def _get_particle_number_choice(
 
     d = len(state)
 
+    is_displaced = state._is_displaced()
+
     B = -np.linalg.inv(state.Q_matrix)[d:, :d]
     alpha = state.complex_displacement[:d]
 
@@ -412,9 +414,13 @@ def _get_particle_number_choice(
     for n in possible_choices:
         occupation_numbers = previous_sample + (n,)
 
-        weight = abs(
+        hafnian_value = (
             state._config.loop_hafnian_function(B, gamma, occupation_numbers)
-        ) ** 2 / factorial(n)
+            if is_displaced
+            else state._config.hafnian_function(B, occupation_numbers)
+        )
+
+        weight = abs(hafnian_value) ** 2 / factorial(n)
         weights = np.append(weights, weight)
 
     weights /= np.sum(weights)

--- a/piquasso/_backends/gaussian/calculations.py
+++ b/piquasso/_backends/gaussian/calculations.py
@@ -32,7 +32,6 @@ from piquasso.api.result import Result
 from piquasso.api.instruction import Instruction
 from piquasso.api.errors import InvalidInstruction
 
-from piquasso._math.linalg import reduce_
 from piquasso._math.indices import get_operator_index, get_auxiliary_operator_index
 from piquasso._math.decompositions import decompose_to_pure_and_mixed
 
@@ -413,12 +412,9 @@ def _get_particle_number_choice(
     for n in possible_choices:
         occupation_numbers = previous_sample + (n,)
 
-        B_reduced = reduce_(B, reduce_on=occupation_numbers)
-        gamma_reduced = reduce_(gamma, reduce_on=occupation_numbers)
-
-        np.fill_diagonal(B_reduced, gamma_reduced)
-
-        weight = abs(state._config.loop_hafnian_function(B_reduced)) ** 2 / factorial(n)
+        weight = abs(
+            state._config.loop_hafnian_function(B, gamma, occupation_numbers)
+        ) ** 2 / factorial(n)
         weights = np.append(weights, weight)
 
     weights /= np.sum(weights)

--- a/piquasso/_backends/gaussian/probabilities.py
+++ b/piquasso/_backends/gaussian/probabilities.py
@@ -19,7 +19,7 @@ import numpy as np
 
 from scipy.special import factorial
 
-from piquasso._math.linalg import block_reduce, reduce_
+from piquasso._math.linalg import block_reduce
 from piquasso._math.torontonian import torontonian
 
 from piquasso.api.typing import HafnianFunction
@@ -56,23 +56,14 @@ class DensityMatrixCalculation:
 
         self.loop_hafnian_function = loop_hafnian_function
 
-    def _get_A_reduced(self, reduce_on: Tuple[int, ...]) -> np.ndarray:
-        A_reduced = reduce_(self._A, reduce_on=reduce_on)
-
-        np.fill_diagonal(A_reduced, reduce_(self._gamma, reduce_on=reduce_on))
-
-        return A_reduced
-
     def get_density_matrix_element(
         self, bra: Tuple[int, ...], ket: Tuple[int, ...]
     ) -> float:
         reduce_on = ket + bra
 
-        A_reduced = self._get_A_reduced(reduce_on=reduce_on)
-
         return (
             self._normalization
-            * self.loop_hafnian_function(A_reduced)
+            * self.loop_hafnian_function(self._A, self._gamma, reduce_on)
             / np.sqrt(np.prod(factorial(reduce_on)))
         )
 

--- a/piquasso/_backends/gaussian/probabilities.py
+++ b/piquasso/_backends/gaussian/probabilities.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import abc
+
 from typing import List, Tuple
 
 import numpy as np
@@ -22,39 +24,15 @@ from scipy.special import factorial
 from piquasso._math.linalg import block_reduce
 from piquasso._math.torontonian import torontonian
 
-from piquasso.api.typing import HafnianFunction
+from piquasso.api.typing import HafnianFunction, LoopHafnianFunction
 
 
-class DensityMatrixCalculation:
-    def __init__(
-        self,
-        complex_displacement: np.ndarray,
-        complex_covariance: np.ndarray,
-        loop_hafnian_function: HafnianFunction,
-    ) -> None:
-        d = len(complex_displacement) // 2
-        Q = (complex_covariance + np.identity(2 * d)) / 2
+class DensityMatrixCalculation(abc.ABC):
+    _normalization: float
 
-        Qinv = np.linalg.inv(Q)
-        identity = np.identity(d)
-        zeros = np.zeros_like(identity)
-
-        X = np.block(
-            [
-                [zeros, identity],
-                [identity, zeros],
-            ],
-        )
-
-        self._A: np.ndarray = X @ (np.identity(2 * d, dtype=complex) - Qinv)
-
-        self._gamma: np.ndarray = complex_displacement.conj() @ Qinv
-
-        self._normalization: np.ndarray = np.exp(
-            -0.5 * self._gamma @ complex_displacement
-        ) / np.sqrt(np.linalg.det(Q))
-
-        self.loop_hafnian_function = loop_hafnian_function
+    @abc.abstractmethod
+    def calculate_hafnian(self, reduce_on: Tuple[int, ...]) -> float:
+        pass
 
     def get_density_matrix_element(
         self, bra: Tuple[int, ...], ket: Tuple[int, ...]
@@ -63,7 +41,7 @@ class DensityMatrixCalculation:
 
         return (
             self._normalization
-            * self.loop_hafnian_function(self._A, self._gamma, reduce_on)
+            * self.calculate_hafnian(reduce_on)
             / np.sqrt(np.prod(factorial(reduce_on)))
         )
 
@@ -99,6 +77,71 @@ class DensityMatrixCalculation:
         ret[abs(ret) < 1e-10] = 0.0
 
         return ret
+
+
+class NondisplacedDensityMatrixCalculation(DensityMatrixCalculation):
+    def __init__(
+        self,
+        complex_covariance: np.ndarray,
+        hafnian_function: HafnianFunction,
+    ) -> None:
+        d = len(complex_covariance) // 2
+        Q = (complex_covariance + np.identity(2 * d)) / 2
+
+        Qinv = np.linalg.inv(Q)
+        identity = np.identity(d)
+        zeros = np.zeros_like(identity)
+
+        X = np.block(
+            [
+                [zeros, identity],
+                [identity, zeros],
+            ],
+        )
+
+        self._A: np.ndarray = X @ (np.identity(2 * d, dtype=complex) - Qinv)
+
+        self._normalization: float = 1 / np.sqrt(np.linalg.det(Q))
+
+        self.hafnian_function = hafnian_function
+
+    def calculate_hafnian(self, reduce_on: Tuple[int, ...]) -> float:
+        return self.hafnian_function(self._A, reduce_on)
+
+
+class DisplacedDensityMatrixCalculation(DensityMatrixCalculation):
+    def __init__(
+        self,
+        complex_displacement: np.ndarray,
+        complex_covariance: np.ndarray,
+        loop_hafnian_function: LoopHafnianFunction,
+    ) -> None:
+        d = len(complex_displacement) // 2
+        Q = (complex_covariance + np.identity(2 * d)) / 2
+
+        Qinv = np.linalg.inv(Q)
+        identity = np.identity(d)
+        zeros = np.zeros_like(identity)
+
+        X = np.block(
+            [
+                [zeros, identity],
+                [identity, zeros],
+            ],
+        )
+
+        self._A: np.ndarray = X @ (np.identity(2 * d, dtype=complex) - Qinv)
+
+        self._gamma: np.ndarray = complex_displacement.conj() @ Qinv
+
+        self._normalization: float = np.exp(
+            -0.5 * self._gamma @ complex_displacement
+        ) / np.sqrt(np.linalg.det(Q))
+
+        self.loop_hafnian_function = loop_hafnian_function
+
+    def calculate_hafnian(self, reduce_on: Tuple[int, ...]) -> float:
+        return self.loop_hafnian_function(self._A, self._gamma, reduce_on)
 
 
 def calculate_click_probability(

--- a/piquasso/_math/hafnian.py
+++ b/piquasso/_math/hafnian.py
@@ -158,6 +158,12 @@ def loop_hafnian(matrix):
     return _hafnian(matrix, polynom_function=_get_loop_polynom_coefficients)
 
 
+def hafnian_with_reduction(matrix, reduce_on):
+    reduced_matrix = reduce_(matrix, reduce_on)
+
+    return hafnian(reduced_matrix)
+
+
 def _reduce_matrix_with_diagonal(matrix, diagonal, reduce_on):
     reduced_diagonal = reduce_(diagonal, reduce_on=reduce_on)
     reduced_matrix = reduce_(matrix, reduce_on=reduce_on)

--- a/piquasso/_math/hafnian.py
+++ b/piquasso/_math/hafnian.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 import math
-from functools import lru_cache, partial
+from functools import lru_cache
 from itertools import combinations_with_replacement
 from typing import List, Callable
 
@@ -22,6 +22,7 @@ import numpy as np
 from scipy.linalg import block_diag
 
 from .combinatorics import powerset
+from .linalg import reduce_
 
 
 @lru_cache()
@@ -149,6 +150,24 @@ def _get_loop_polynom_coefficients(
     return ret
 
 
-hafnian = partial(_hafnian, polynom_function=_get_polynom_coefficients)
+def hafnian(matrix):
+    return _hafnian(matrix, polynom_function=_get_polynom_coefficients)
 
-loop_hafnian = partial(_hafnian, polynom_function=_get_loop_polynom_coefficients)
+
+def loop_hafnian(matrix):
+    return _hafnian(matrix, polynom_function=_get_loop_polynom_coefficients)
+
+
+def _reduce_matrix_with_diagonal(matrix, diagonal, reduce_on):
+    reduced_diagonal = reduce_(diagonal, reduce_on=reduce_on)
+    reduced_matrix = reduce_(matrix, reduce_on=reduce_on)
+
+    np.fill_diagonal(reduced_matrix, reduced_diagonal)
+
+    return reduced_matrix
+
+
+def loop_hafnian_with_reduction(matrix, diagonal, reduce_on):
+    reduced_matrix = _reduce_matrix_with_diagonal(matrix, diagonal, reduce_on)
+
+    return loop_hafnian(reduced_matrix)

--- a/piquasso/api/config.py
+++ b/piquasso/api/config.py
@@ -21,9 +21,9 @@ import random
 import numpy as np
 
 from piquasso._math.permanent import glynn_gray_permanent
-from piquasso._math.hafnian import loop_hafnian_with_reduction
+from piquasso._math.hafnian import hafnian_with_reduction, loop_hafnian_with_reduction
 
-from piquasso.api.typing import PermanentFunction, HafnianFunction
+from piquasso.api.typing import PermanentFunction, HafnianFunction, LoopHafnianFunction
 
 from piquasso.core import _mixins
 
@@ -41,7 +41,8 @@ class Config(_mixins.CodeMixin):
         cutoff: int = 4,
         measurement_cutoff: int = 5,
         permanent_function: PermanentFunction = glynn_gray_permanent,
-        loop_hafnian_function: HafnianFunction = loop_hafnian_with_reduction,
+        hafnian_function: HafnianFunction = hafnian_with_reduction,
+        loop_hafnian_function: LoopHafnianFunction = loop_hafnian_with_reduction,
     ):
         self._original_seed_sequence = seed_sequence
         self.seed_sequence = seed_sequence or int.from_bytes(
@@ -53,6 +54,7 @@ class Config(_mixins.CodeMixin):
         self.cutoff = cutoff
         self.measurement_cutoff = measurement_cutoff
         self.permanent_function = permanent_function
+        self.hafnian_function = hafnian_function
         self.loop_hafnian_function = loop_hafnian_function
 
     def __eq__(self, other: object) -> bool:

--- a/piquasso/api/config.py
+++ b/piquasso/api/config.py
@@ -21,7 +21,7 @@ import random
 import numpy as np
 
 from piquasso._math.permanent import glynn_gray_permanent
-from piquasso._math.hafnian import loop_hafnian
+from piquasso._math.hafnian import loop_hafnian_with_reduction
 
 from piquasso.api.typing import PermanentFunction, HafnianFunction
 
@@ -41,7 +41,7 @@ class Config(_mixins.CodeMixin):
         cutoff: int = 4,
         measurement_cutoff: int = 5,
         permanent_function: PermanentFunction = glynn_gray_permanent,
-        loop_hafnian_function: HafnianFunction = loop_hafnian,
+        loop_hafnian_function: HafnianFunction = loop_hafnian_with_reduction,
     ):
         self._original_seed_sequence = seed_sequence
         self.seed_sequence = seed_sequence or int.from_bytes(

--- a/piquasso/api/typing.py
+++ b/piquasso/api/typing.py
@@ -19,4 +19,5 @@ from typing import Callable, Tuple
 
 
 PermanentFunction = Callable[[np.ndarray, Tuple[int, ...], Tuple[int, ...]], float]
-HafnianFunction = Callable[[np.ndarray, np.ndarray, Tuple[int, ...]], float]
+HafnianFunction = Callable[[np.ndarray, Tuple[int, ...]], float]
+LoopHafnianFunction = Callable[[np.ndarray, np.ndarray, Tuple[int, ...]], float]

--- a/piquasso/api/typing.py
+++ b/piquasso/api/typing.py
@@ -19,4 +19,4 @@ from typing import Callable, Tuple
 
 
 PermanentFunction = Callable[[np.ndarray, Tuple[int, ...], Tuple[int, ...]], float]
-HafnianFunction = Callable[[np.ndarray], float]
+HafnianFunction = Callable[[np.ndarray, np.ndarray, Tuple[int, ...]], float]

--- a/scripts/gbs_nondisplaced_histogram_script.py
+++ b/scripts/gbs_nondisplaced_histogram_script.py
@@ -1,0 +1,80 @@
+#
+# Copyright 2021 Budapest Quantum Computing Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import subprocess
+
+import numpy as np
+import matplotlib.pyplot as plt
+
+import piquasso as pq
+
+import strawberryfields as sf
+
+
+def gbs_nondisplaced_histogram_script():
+    d = 5
+    shots = 200
+
+    # NOTE: In SF the measurement cutoff is 5, and couldn't be changed.
+    pq_simulator = pq.GaussianSimulator(d=d, config=pq.Config(measurement_cutoff=5))
+
+    with pq.Program() as pq_program:
+        pq.Q(all) | pq.Squeezing(r=0.5)
+
+        pq.Q(0, 1) | pq.Beamsplitter(0.0959408065906761, 0.06786053071484363)
+        pq.Q(2, 3) | pq.Beamsplitter(0.7730047654405018, 1.453770233324797)
+        pq.Q(1, 2) | pq.Beamsplitter(1.0152680371119776, 1.2863559998816205)
+        pq.Q(3, 4) | pq.Beamsplitter(1.3205517879465705, 0.5236836466492961)
+        pq.Q(0, 1) | pq.Beamsplitter(4.394480318177715, 4.481575657714487)
+        pq.Q(2, 3) | pq.Beamsplitter(2.2300919706807534, 1.5073556513699888)
+        pq.Q(1, 2) | pq.Beamsplitter(2.2679037068773673, 1.9550229282085838)
+        pq.Q(3, 4) | pq.Beamsplitter(3.340269832485504, 3.289367083610399)
+
+        pq.Q(0, 1, 2) | pq.ParticleNumberMeasurement()
+
+    sf_program = sf.Program(d)
+    sf_engine = sf.Engine(backend="gaussian")
+
+    with sf_program.context as q:
+        sf.ops.Sgate(0.5) | q[0]
+        sf.ops.Sgate(0.5) | q[1]
+        sf.ops.Sgate(0.5) | q[2]
+        sf.ops.Sgate(0.5) | q[3]
+        sf.ops.Sgate(0.5) | q[4]
+
+        sf.ops.BSgate(0.0959408065906761, 0.06786053071484363) | (q[0], q[1])
+        sf.ops.BSgate(0.7730047654405018, 1.453770233324797) | (q[2], q[3])
+        sf.ops.BSgate(1.0152680371119776, 1.2863559998816205) | (q[1], q[2])
+        sf.ops.BSgate(1.3205517879465705, 0.5236836466492961) | (q[3], q[4])
+        sf.ops.BSgate(4.394480318177715, 4.481575657714487) | (q[0], q[1])
+        sf.ops.BSgate(2.2300919706807534, 1.5073556513699888) | (q[2], q[3])
+        sf.ops.BSgate(2.2679037068773673, 1.9550229282085838) | (q[1], q[2])
+        sf.ops.BSgate(3.340269832485504, 3.289367083610399) | (q[3], q[4])
+
+        sf.ops.MeasureFock() | (q[0], q[1], q[2])
+
+    pq_results = np.array(pq_simulator.execute(pq_program, shots=shots).samples)
+    sf_results = sf_engine.run(sf_program, shots=shots).samples
+
+    n_bins = 20
+
+    fig, axs = plt.subplots(1, 2, sharey=True, tight_layout=True)
+
+    axs[0].hist(pq_results, bins=n_bins)
+    axs[1].hist(sf_results, bins=n_bins)
+
+    fig.savefig("histogram.png")
+
+    subprocess.call(("xdg-open", "histogram.png"))

--- a/tests/_math/test_hafnian.py
+++ b/tests/_math/test_hafnian.py
@@ -18,7 +18,12 @@ import pytest
 import numpy as np
 
 from scipy.linalg import block_diag
-from piquasso._math.hafnian import hafnian, loop_hafnian
+from piquasso._math.hafnian import (
+    hafnian,
+    loop_hafnian,
+    hafnian_with_reduction,
+    loop_hafnian_with_reduction,
+)
 
 
 def test_hafnian_on_2_by_2_real_matrix():
@@ -244,4 +249,24 @@ def test_loop_hafnian_of_complex_symmetric_block_diagonal_matrix(
     assert np.isclose(
         submatrix_loop_hafnian.conj() * submatrix_loop_hafnian,
         matrix_loop_hafnian,
+    )
+
+
+def test_loop_hafnian_and_hafnian_with_zero_reduction():
+
+    matrix = np.array(
+        [
+            [1j, 2, 3j, 4],
+            [2, 6, 7, 8j],
+            [3j, 7, 3, 4],
+            [4, 8j, 4, 8j],
+        ],
+        dtype=complex,
+    )
+
+    reduce_on = (1, 2)
+
+    assert np.isclose(
+        hafnian_with_reduction(matrix, reduce_on),
+        loop_hafnian_with_reduction(matrix, np.zeros(len(matrix)), reduce_on),
     )


### PR DESCRIPTION
**1st commit**

The reduction step is moved to the `loop_hafnian_function` in `config`.

**2nd commit**

When the loop hafnian is calculated with no displacement, one could
easily use the regular hafnian function instead, which is implemented in
this patch. The hafnian function could be specified in the config.
    
A new script has been written testing GBS with no displacement.
