### PR TITLE
feat(measurements): Delete `Sampling`

### DIFF
--- a/docs/tutorials/boson-sampling.ipynb
+++ b/docs/tutorials/boson-sampling.ipynb
@@ -2,6 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "429e356e",
    "metadata": {},
    "source": [
     "# Boson Sampling"
@@ -9,14 +10,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 4,
+   "id": "22562b59",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "<Result samples=[(1, 0, 0, 1), (0, 1, 0, 1), (0, 1, 0, 1), (1, 0, 0, 1), (1, 0, 0, 1)] state=<piquasso._backends.sampling.state.SamplingState object at 0x7ff85831ac10>>\n"
+      "[(1, 0, 0, 1), (1, 0, 0, 1), (1, 0, 0, 1), (1, 0, 0, 1), (1, 0, 0, 1)]\n"
      ]
     }
    ],
@@ -31,13 +33,13 @@
     "    pq.Q(0, 1) | pq.Beamsplitter(theta=np.pi / 3, phi=np.pi / 4)\n",
     "    pq.Q(2, 3) | pq.Beamsplitter(theta=np.pi / 2, phi=np.pi / 3)\n",
     "\n",
-    "    pq.Q() | pq.Sampling()\n",
+    "    pq.Q() | pq.ParticleNumberMeasurement()\n",
     "\n",
     "simulator = pq.SamplingSimulator(d=4)\n",
     "\n",
     "result = simulator.execute(program, shots=5)\n",
     "\n",
-    "print(result)"
+    "print(result.samples)"
    ]
   }
  ],

--- a/piquasso/__init__.py
+++ b/piquasso/__init__.py
@@ -80,7 +80,6 @@ from .instructions.measurements import (
     HomodyneMeasurement,
     HeterodyneMeasurement,
     GeneraldyneMeasurement,
-    Sampling,
 )
 
 from .instructions.channels import (
@@ -140,7 +139,6 @@ __all__ = [
     "ControlledX",
     "ControlledZ",
     "Interferometer",
-    "Sampling",
     "Graph",
     # Measurements
     "ParticleNumberMeasurement",

--- a/piquasso/_backends/sampling/calculations.py
+++ b/piquasso/_backends/sampling/calculations.py
@@ -113,7 +113,23 @@ def loss(state: SamplingState, instruction: Instruction, shots: int) -> Result:
     return Result(state=state)
 
 
-def sampling(state: SamplingState, instruction: Instruction, shots: int) -> Result:
+def particle_number_measurement(
+    state: SamplingState, instruction: Instruction, shots: int
+) -> Result:
+    """
+    Simulates a boson sampling using generalized Clifford & Clifford algorithm
+    from [Brod, Oszmaniec 2020] see
+    `this article <https://arxiv.org/pdf/1612.01199.pdf>`_ for more details.
+
+    This method assumes that initial_state is given in the second quantization
+    description (mode occupation). `theboss` module requires the input states to be
+    numpy arrays, therefore the state is prepared as accordingly.
+
+    Generalized Cliffords simulation strategy form [Brod, Oszmaniec 2020] was used
+    as it allows effective simulation of broader range of input states than original
+    algorithm.
+    """
+
     initial_state = np.array(state.initial_state)
     permanent_calculator = RyserGuanPermanentCalculator(
         matrix=state.interferometer, input_state=initial_state

--- a/piquasso/_backends/sampling/simulator.py
+++ b/piquasso/_backends/sampling/simulator.py
@@ -17,7 +17,12 @@ from piquasso.api.simulator import Simulator
 from piquasso.instructions import preparations, gates, measurements, channels
 
 from .state import SamplingState
-from .calculations import state_vector, passive_linear, sampling, loss
+from .calculations import (
+    state_vector,
+    passive_linear,
+    particle_number_measurement,
+    loss,
+)
 
 
 class SamplingSimulator(Simulator):
@@ -46,7 +51,7 @@ class SamplingSimulator(Simulator):
         :class:`~piquasso.instructions.gates.Interferometer`.
 
     Supported measurements:
-        :class:`~piquasso.instructions.measurements.Sampling`.
+        :class:`~piquasso.instructions.measurements.ParticleNumberMeasurement`.
 
     Supported channels:
         :class:`~piquasso.instructions.channels.Loss`.
@@ -59,7 +64,7 @@ class SamplingSimulator(Simulator):
         gates.MachZehnder: passive_linear,
         gates.Fourier: passive_linear,
         gates.Interferometer: passive_linear,
-        measurements.Sampling: sampling,
+        measurements.ParticleNumberMeasurement: particle_number_measurement,
         channels.Loss: loss,
     }
 

--- a/piquasso/instructions/measurements.py
+++ b/piquasso/instructions/measurements.py
@@ -189,23 +189,3 @@ class HeterodyneMeasurement(Measurement):
                 detection_covariance=np.identity(2),
             ),
         )
-
-
-class Sampling(Measurement):
-    r"""Boson Sampling.
-
-    Simulates a boson sampling using generalized Clifford & Clifford algorithm
-    from [Brod, Oszmaniec 2020] see
-    `this article <https://arxiv.org/pdf/1612.01199.pdf>`_ for more details.
-
-    This method assumes that initial_state is given in the second quantization
-    description (mode occupation). `theboss` module requires the input states to be
-    numpy arrays, therefore the state is prepared as accordingly.
-
-    Generalized Cliffords simulation strategy form [Brod, Oszmaniec 2020] was used
-    as it allows effective simulation of broader range of input states than original
-    algorithm.
-    """
-
-    def __init__(self) -> None:
-        super().__init__()

--- a/tests/backends/sampling/test_gates.py
+++ b/tests/backends/sampling/test_gates.py
@@ -28,7 +28,7 @@ def test_program():
         pq.Q(1, 2, 3) | pq.Interferometer(U)
         pq.Q(3) | pq.Phaseshifter(0.5)
         pq.Q(4) | pq.Phaseshifter(0.5)
-        pq.Q() | pq.Sampling()
+        pq.Q() | pq.ParticleNumberMeasurement()
 
     simulator = pq.SamplingSimulator(d=5)
     result = simulator.execute(program, shots=10)
@@ -130,7 +130,7 @@ def test_lossy_program():
 
         pq.Q() | pq.Loss(losses)
         pq.Q(0) | pq.Loss(transmissivity=0.0)
-        pq.Q() | pq.Sampling()
+        pq.Q() | pq.ParticleNumberMeasurement()
 
     result = simulator.execute(program, shots=1)
     sample = result.samples[0]

--- a/tests/backends/sampling/test_measurements.py
+++ b/tests/backends/sampling/test_measurements.py
@@ -41,7 +41,7 @@ def test_sampling_raises_InvalidParameter_for_negative_shot_value(
     with pq.Program() as program:
         pq.Q() | pq.StateVector([1, 1, 1, 0, 0])
         pq.Q() | pq.Interferometer(interferometer_matrix)
-        pq.Q() | pq.Sampling()
+        pq.Q() | pq.ParticleNumberMeasurement()
 
     simulator = pq.SamplingSimulator(d=5)
 
@@ -55,7 +55,7 @@ def test_sampling_samples_number(interferometer_matrix):
     with pq.Program() as program:
         pq.Q() | pq.StateVector([1, 1, 1, 0, 0])
         pq.Q() | pq.Interferometer(interferometer_matrix)
-        pq.Q() | pq.Sampling()
+        pq.Q() | pq.ParticleNumberMeasurement()
 
     simulator = pq.SamplingSimulator(d=5)
     result = simulator.execute(program, shots)
@@ -71,7 +71,7 @@ def test_sampling_mode_permutation(interferometer_matrix):
     with pq.Program() as program:
         pq.Q() | pq.StateVector([1, 1, 1, 0, 0])
         pq.Q() | pq.Interferometer(interferometer_matrix)
-        pq.Q() | pq.Sampling()
+        pq.Q() | pq.ParticleNumberMeasurement()
 
     simulator = pq.SamplingSimulator(d=5)
     result = simulator.execute(program, shots)
@@ -90,7 +90,7 @@ def test_sampling_multiple_samples_for_permutation_interferometer(
     with pq.Program() as program:
         pq.Q() | pq.StateVector([1, 1, 1, 0, 0])
         pq.Q() | pq.Interferometer(interferometer_matrix)
-        pq.Q() | pq.Sampling()
+        pq.Q() | pq.ParticleNumberMeasurement()
 
     simulator = pq.SamplingSimulator(d=5)
     result = simulator.execute(program, shots)
@@ -111,7 +111,7 @@ def test_mach_zehnder():
     with pq.Program() as program:
         pq.Q() | pq.StateVector([1, 1, 1, 0, 0])
         pq.Q(0, 1) | pq.MachZehnder(int_=int_, ext=ext)
-        pq.Q() | pq.Sampling()
+        pq.Q() | pq.ParticleNumberMeasurement()
 
     simulator = pq.SamplingSimulator(d=5)
     simulator.execute(program, shots=1)
@@ -121,7 +121,7 @@ def test_fourier():
     with pq.Program() as program:
         pq.Q() | pq.StateVector([1, 1, 1, 0, 0])
         pq.Q(0) | pq.Fourier()
-        pq.Q() | pq.Sampling()
+        pq.Q() | pq.ParticleNumberMeasurement()
 
     simulator = pq.SamplingSimulator(d=5)
     simulator.execute(program, shots=1)
@@ -133,7 +133,7 @@ def test_uniform_loss():
 
         pq.Q(all) | pq.Loss(transmissivity=0.9)
 
-        pq.Q() | pq.Sampling()
+        pq.Q() | pq.ParticleNumberMeasurement()
 
     simulator = pq.SamplingSimulator(d=5)
     state = simulator.execute(program, shots=1).state
@@ -148,7 +148,7 @@ def test_general_loss():
         pq.Q(0) | pq.Loss(transmissivity=0.4)
         pq.Q(1) | pq.Loss(transmissivity=0.5)
 
-        pq.Q() | pq.Sampling()
+        pq.Q() | pq.ParticleNumberMeasurement()
 
     simulator = pq.SamplingSimulator(d=5)
     simulator.execute(program, shots=1)


### PR DESCRIPTION
The `SamplingSimulator`s `Sampling` measurement class is redundant
since it is essentially the same thing as `ParticleNumberMeasurement` in
the other simulator classes. Therefore the `SamplingSimulator` is
rewritten to use `ParticleNumberMeasurement` instead.