### PR TITLE
feat(sampling): TransmissivityMatrix

### DIFF
--- a/piquasso/__init__.py
+++ b/piquasso/__init__.py
@@ -86,6 +86,7 @@ from .instructions.channels import (
     DeterministicGaussianChannel,
     Attenuator,
     Loss,
+    TransmissivityMatrix,
 )
 
 
@@ -150,6 +151,7 @@ __all__ = [
     "DeterministicGaussianChannel",
     "Attenuator",
     "Loss",
+    "TransmissivityMatrix",
 ]
 
 __version__ = "0.8.1"

--- a/piquasso/_backends/sampling/calculations.py
+++ b/piquasso/_backends/sampling/calculations.py
@@ -113,6 +113,20 @@ def loss(state: SamplingState, instruction: Instruction, shots: int) -> Result:
     return Result(state=state)
 
 
+def transmissivity_matrix(
+    state: SamplingState, instruction: Instruction, shots: int
+) -> Result:
+    state.is_lossy = True
+
+    _apply_matrix_on_modes(
+        state=state,
+        matrix=instruction._all_params["transmissivity_matrix"],
+        modes=instruction.modes,
+    )
+
+    return Result(state=state)
+
+
 def particle_number_measurement(
     state: SamplingState, instruction: Instruction, shots: int
 ) -> Result:

--- a/piquasso/_backends/sampling/simulator.py
+++ b/piquasso/_backends/sampling/simulator.py
@@ -22,6 +22,7 @@ from .calculations import (
     passive_linear,
     particle_number_measurement,
     loss,
+    transmissivity_matrix,
 )
 
 
@@ -66,6 +67,7 @@ class SamplingSimulator(Simulator):
         gates.Interferometer: passive_linear,
         measurements.ParticleNumberMeasurement: particle_number_measurement,
         channels.Loss: loss,
+        channels.TransmissivityMatrix: transmissivity_matrix,
     }
 
     _state_class = SamplingState

--- a/piquasso/_backends/sampling/state.py
+++ b/piquasso/_backends/sampling/state.py
@@ -135,3 +135,13 @@ class SamplingState(State):
             config, permanent_calculator
         )
         return distribution_calculator.calculate_distribution()
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, SamplingState):
+            return False
+
+        return (
+            np.allclose(self.initial_state, other.initial_state)
+            and np.allclose(self.interferometer, other.interferometer)
+            and self.is_lossy == other.is_lossy
+        )

--- a/piquasso/_math/validations.py
+++ b/piquasso/_math/validations.py
@@ -28,3 +28,11 @@ def all_natural(array: Iterable) -> bool:
 
 def all_real_and_positive(vector: Iterable) -> bool:
     return all(element >= 0.0 or np.isclose(element, 0.0) for element in vector)
+
+
+def all_in_interval(vector: Iterable, lower: float, upper: float) -> bool:
+    return all(
+        (element >= lower or np.isclose(element, lower))
+        and (element <= upper or np.isclose(element, upper))
+        for element in vector
+    )

--- a/piquasso/instructions/gates.py
+++ b/piquasso/instructions/gates.py
@@ -200,7 +200,7 @@ class Beamsplitter(_GaussianGate):
                 Phase angle of the beamsplitter.
                 (defaults to :math:`\phi = \pi/2` that gives a symmetric beamsplitter)
             theta (float):
-                The transmittivity angle of the beamsplitter.
+                The transmissivity angle of the beamsplitter.
                 (defaults to :math:`\theta=\pi/4` that gives a 50-50 beamsplitter)
         """
 


### PR DESCRIPTION
The channel `TransmissivityMatrix` might be handy if the user wants to
model more general losses in the `SamplingSimulator`. With this one can
specify a general transmissivity matrix, which is essentially equivalent
to a `Loss` channel with two (generally different) `Interferometer`
gates before and after.

Tests have been written. For these, and `__eq__` method is constructed
in `SamplingState`.