### PR TITLE
fix(requirements.txt): Bumping `black` version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,5 +13,5 @@ matplotlib==3.3.4
 nbsphinx==0.8.5
 pandoc==1.0.2
 ipykernel==5.5.0
-black==22.1.0
+black==22.3.0
 black[jupyter]


### PR DESCRIPTION
Running `black` resulted in the error
```
ImportError: cannot import name '_unicodefun' from 'click'
```
since the most recent release of `click` breaks `black`. However, this
has been fixed in `black==22.3.0`.

Issue: https://github.com/psf/black/issues/2964