### PR TITLE
Check IPython notebook executability and flake8 tests.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,16 +2,17 @@ strawberryfields==0.21.0
 matplotlib==3.3.4
 
 # Testing
-pytest==5.2
+pytest==7.1.1
 pytest-profiling==1.7.0
 pytest-benchmark==3.2.3
 coverage==5.3
 mypy==0.910
 flake8==3.8.3
+nbqa==1.3.1
+nbmake==1.3.0
 
 # Formatting
 black==22.3.0
-black[jupyter]
 
 # Documentation
 nbsphinx>=0.8.8

--- a/tox.ini
+++ b/tox.ini
@@ -16,8 +16,10 @@ python =
 deps = -rrequirements.txt
 commands =
     flake8
+    nbqa flake8 .
     black --check .
     mypy piquasso
+    pytest --nbmake docs
     coverage run -m pytest tests -s
     coverage xml --omit='.tox/*','*/tests/*'
     coverage erase


### PR DESCRIPTION
nbmake has been added to the development dependencies to test if the *.ipynb files in docs/ can indeed be executed.

nbqa has been added in order to check *.ipynb files with flake8.

pytest has been updated to install nbmake.

tox.ini has been updated to test *.ipynb files.