### PR TITLE
FIX(clements): Handling 0 matrix elements

### DIFF
--- a/piquasso/decompositions/clements.py
+++ b/piquasso/decompositions/clements.py
@@ -165,6 +165,12 @@ class Clements:
         Calculates the parameters required to eliminate the lower triangular
         element `i`, `j` of `U` using `T`.
         """
+        if np.isclose(self.U[i - 1, j], 0.0):
+            return {
+                "modes": (i - 1, i),
+                "params": (np.pi / 2, 0),
+            }
+
         r = -self.U[i, j] / self.U[i - 1, j]
         theta = np.arctan(np.abs(r))
         phi = np.angle(r)
@@ -179,6 +185,13 @@ class Clements:
         Calculates the parameters required to eliminate the upper triangular
         `i`, `j` of `U` using `T.transposed`.
         """
+
+        if np.isclose(self.U[i, j + 1], 0.0):
+            return {
+                "modes": (j, j + 1),
+                "params": (np.pi / 2, 0),
+            }
+
         r = self.U[i, j] / self.U[i, j + 1]
         theta = np.arctan(np.abs(r))
         phi = np.angle(r)

--- a/tests/decompositions/test_clements.py
+++ b/tests/decompositions/test_clements.py
@@ -139,3 +139,44 @@ def test_clements_decomposition_and_composition_on_n_modes(n, dummy_unitary, tol
     original = Clements.from_decomposition(decomposition)
 
     assert (U - original < tolerance).all()
+
+
+@pytest.mark.parametrize("n", [2, 3, 4, 5])
+def test_clements_decomposition_and_composition_on_n_modes_for_identity(n):
+    identity = np.identity(n)
+
+    decomposition = Clements(identity)
+
+    diagonalized = decomposition.U
+
+    assert np.isclose(
+        sum(sum(np.abs(diagonalized))), sum(np.abs(np.diag(diagonalized)))
+    ), "Absolute sum of matrix elements should be equal to the "
+    "diagonal elements, if the matrix is properly diagonalized."
+
+    matrix_from_decomposition = Clements.from_decomposition(decomposition)
+
+    assert np.allclose(identity, matrix_from_decomposition)
+
+
+def test_clements_decomposition_and_composition_on_n_modes_for_matrix_with_0_terms():
+    matrix = np.array(
+        [
+            [1 / np.sqrt(2), 0, 1 / np.sqrt(2)],
+            [0, 1, 0],
+            [1 / np.sqrt(2), 0, -1 / np.sqrt(2)],
+        ]
+    )
+
+    decomposition = Clements(matrix)
+
+    diagonalized = decomposition.U
+
+    assert np.isclose(
+        sum(sum(np.abs(diagonalized))), sum(np.abs(np.diag(diagonalized)))
+    ), "Absolute sum of matrix elements should be equal to the "
+    "diagonal elements, if the matrix is properly diagonalized."
+
+    matrix_from_decomposition = Clements.from_decomposition(decomposition)
+
+    assert np.allclose(matrix, matrix_from_decomposition)


### PR DESCRIPTION
During test writing for the Clements decomposition under
`piquasso/decompositions/clements.py`, an issue has been encountered.
Namely, there is a possible zero division error during the
decomposition: one needs to handle the zero division case separately in
the `Clements` class.