### PR TITLE
fix(FockSimulator): Wrong auxiliary modes in calculation

### DIFF
--- a/piquasso/_backends/fock/general/calculations.py
+++ b/piquasso/_backends/fock/general/calculations.py
@@ -163,7 +163,7 @@ def cubic_phase(state: FockState, instruction: Instruction, shots: int) -> Resul
         embedded_operator = state._space.embed_matrix(
             operator,
             modes=(mode,),
-            auxiliary_modes=state._get_auxiliary_modes(instruction.modes),
+            auxiliary_modes=state._get_auxiliary_modes(modes=(mode,)),
         )
         state._density_matrix = (
             embedded_operator
@@ -208,7 +208,7 @@ def displacement(state: FockState, instruction: Instruction, shots: int) -> Resu
         embedded_operator = state._space.embed_matrix(
             operator,
             modes=(mode,),
-            auxiliary_modes=state._get_auxiliary_modes(instruction.modes),
+            auxiliary_modes=state._get_auxiliary_modes(modes=(mode,)),
         )
 
         state._density_matrix = (
@@ -235,7 +235,7 @@ def squeezing(state: FockState, instruction: Instruction, shots: int) -> Result:
         embedded_operator = state._space.embed_matrix(
             operator,
             modes=(mode,),
-            auxiliary_modes=state._get_auxiliary_modes(instruction.modes),
+            auxiliary_modes=state._get_auxiliary_modes(modes=(mode,)),
         )
 
         state._density_matrix = (

--- a/tests/backends/test_backend_equivalence.py
+++ b/tests/backends/test_backend_equivalence.py
@@ -183,6 +183,43 @@ def test_fock_probabilities_with_displaced_state(SimulatorClass):
 @pytest.mark.parametrize(
     "SimulatorClass",
     (
+        pq.PureFockSimulator,
+        pq.FockSimulator,
+        pq.GaussianSimulator,
+    ),
+)
+def test_Displacement_equivalence_on_multiple_modes(SimulatorClass):
+    with pq.Program() as program:
+        pq.Q() | pq.Vacuum()
+
+        pq.Q(0, 1) | pq.Displacement(alpha=[0.01, 0.02])
+
+        pq.Q(0, 1) | pq.Beamsplitter(theta=np.pi / 3)
+
+    simulator = SimulatorClass(d=2)
+
+    state = simulator.execute(program).state
+
+    assert is_proportional(
+        state.fock_probabilities,
+        [
+            0.99950012,
+            0.00020242,
+            0.00029733,
+            0.00000002,
+            0.00000006,
+            0.00000004,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+        ],
+    )
+
+
+@pytest.mark.parametrize(
+    "SimulatorClass",
+    (
         pq.GaussianSimulator,
         pq.PureFockSimulator,
         pq.FockSimulator,
@@ -306,6 +343,32 @@ def test_fock_probabilities_with_two_single_mode_squeezings(SimulatorClass):
     assert is_proportional(
         probabilities,
         [0.9754467, 0.0, 0.0, 0.0048449, 0.0, 0.01900025, 0.0, 0.0, 0.0, 0.0],
+    )
+
+
+@pytest.mark.parametrize(
+    "SimulatorClass",
+    (
+        pq.GaussianSimulator,
+        pq.PureFockSimulator,
+        pq.FockSimulator,
+    ),
+)
+def test_Squeezing_equivalence_on_multiple_modes(SimulatorClass):
+    with pq.Program() as program:
+        pq.Q() | pq.Vacuum()
+
+        pq.Q(0, 1) | pq.Squeezing(r=[0.1, 0.2], phi=[np.pi / 5, np.pi / 3])
+
+        pq.Q(0, 1) | pq.Beamsplitter(theta=np.pi / 3)
+
+    simulator = SimulatorClass(d=2)
+
+    state = simulator.execute(program).state
+
+    assert is_proportional(
+        state.fock_probabilities,
+        [0.97613795, 0.0, 0.0, 0.01246268, 0.00601937, 0.00537999, 0.0, 0.0, 0.0, 0.0],
     )
 
 
@@ -919,6 +982,42 @@ def test_cubic_phase_equivalency(SimulatorClass):
 
     assert np.isclose(fidelity, 1.0)
     assert np.isclose(fidelity, state_2.fidelity(state_1))
+
+
+@pytest.mark.parametrize(
+    "SimulatorClass",
+    (
+        pq.PureFockSimulator,
+        pq.FockSimulator,
+    ),
+)
+def test_CubicPhase_equivalence_on_multiple_modes(SimulatorClass):
+    with pq.Program() as program:
+        pq.Q() | pq.Vacuum()
+
+        pq.Q(0, 1) | pq.CubicPhase(gamma=[0.1, 0.2])
+
+        pq.Q(0, 1) | pq.Beamsplitter(theta=np.pi / 3)
+
+    simulator = SimulatorClass(d=2)
+
+    state = simulator.execute(program).state
+
+    assert is_proportional(
+        state.fock_probabilities,
+        [
+            0.97960898,
+            0.00474935,
+            0.00710543,
+            0.00029005,
+            0.00030477,
+            0.0001192,
+            0.00306916,
+            0.00174448,
+            0.00261566,
+            0.00039293,
+        ],
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,6 +22,11 @@ import piquasso as pq
 from pathlib import Path
 
 
+@pytest.fixture(autouse=True)
+def _set_printoptions_for_debugging():
+    np.set_printoptions(suppress=True, linewidth=200)
+
+
 @pytest.fixture
 def generate_symmetric_matrix():
     def func(N):


### PR DESCRIPTION
In the calculation functions for the `FockSimulator`, the auxiliary
modes were passed incorrectly to `embed_matrix`, since the auxiliary
modes were determined from the whole `instruction.modes` instead of just
the loop variable `mode`. This has been fixed.

Equivalence tests have been written accordingly.