### PR TITLE
feat(fock): `Attenuator` support

### DIFF
--- a/piquasso/_backends/fock/calculations.py
+++ b/piquasso/_backends/fock/calculations.py
@@ -1,0 +1,91 @@
+#
+# Copyright 2021-2022 Budapest Quantum Computing Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+
+from scipy.special import comb
+
+from .state import BaseFockState
+
+from piquasso.api.instruction import Instruction
+from piquasso.api.result import Result
+from piquasso.api.exceptions import InvalidInstruction, InvalidParameter
+
+
+def attenuator(state: BaseFockState, instruction: Instruction, shots: int) -> Result:
+    r"""
+    Performs the deterministic loss or attenuation channel :math:`C` according to the
+    equation
+
+    .. math::
+        C(| n \rangle \langle m |) =
+            \sum_{k = 0}^{\min(n,m)} \tan(\theta)^{2k} \cos(\theta)^{n + m}
+            \sqrt{ {n \choose k} {m \choose k} } | n - k \rangle \langle m - k |.
+    """
+
+    modes = instruction.modes
+
+    if len(modes) != 1:
+        raise InvalidInstruction(
+            f"The instruction should be specified for '{len(modes)}' "
+            f"modes: instruction={instruction}"
+        )
+
+    mean_thermal_excitation = instruction._all_params["mean_thermal_excitation"]
+
+    if not np.isclose(mean_thermal_excitation, 0.0):
+        raise InvalidParameter(
+            "Non-zero mean thermal excitation is not supported in this backend. "
+            f"mean_thermal_excitation={mean_thermal_excitation}"
+        )
+
+    theta = instruction._all_params["theta"]
+
+    space = state._space
+
+    new_state = state._as_mixed()
+
+    new_density_matrix = new_state._get_empty()
+
+    for index, basis in space.operator_basis:
+        coefficient = new_state._density_matrix[index]
+
+        ket = np.asarray(basis.ket)
+        bra = np.asarray(basis.bra)
+
+        n = ket[modes]
+        m = bra[modes]
+
+        common_term = coefficient * np.cos(theta) ** (n + m)
+
+        for k in range(min(n, m) + 1):
+            current_ket = np.copy(ket)
+            current_ket[(modes,)] -= k
+
+            current_bra = np.copy(bra)
+            current_bra[(modes,)] -= k
+
+            current_ket_index = space.index(tuple(current_ket))
+            current_bra_index = space.index(tuple(current_bra))
+
+            current_index = (current_ket_index, current_bra_index)
+
+            new_density_matrix[current_index] += common_term * (
+                np.tan(theta) ** (2 * k) * np.sqrt(comb(n, k) * comb(m, k))
+            )
+
+    new_state._density_matrix = new_density_matrix
+
+    return Result(state=new_state)

--- a/piquasso/_backends/fock/general/simulator.py
+++ b/piquasso/_backends/fock/general/simulator.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 from piquasso.api.simulator import Simulator
-from piquasso.instructions import preparations, gates, measurements
+from piquasso.instructions import preparations, gates, measurements, channels
 
 from .state import FockState
 from .calculations import (
@@ -31,6 +31,8 @@ from .calculations import (
     create,
     annihilate,
 )
+
+from ..calculations import attenuator
 
 
 class FockSimulator(Simulator):
@@ -74,6 +76,9 @@ class FockSimulator(Simulator):
 
     Supported measurements:
         :class:`~piquasso.instructions.measurements.ParticleNumberMeasurement`.
+
+    Supported channels:
+        :class:`~piquasso.instructions.channels.Attenuator`
     """
 
     _instruction_map = {
@@ -97,6 +102,7 @@ class FockSimulator(Simulator):
         gates.Squeezing2: linear,
         gates.GaussianTransform: linear,
         measurements.ParticleNumberMeasurement: particle_number_measurement,
+        channels.Attenuator: attenuator,
     }
 
     _state_class = FockState

--- a/piquasso/_backends/fock/general/state.py
+++ b/piquasso/_backends/fock/general/state.py
@@ -52,6 +52,9 @@ class FockState(BaseFockState):
         self._density_matrix = self._get_empty()
         self._density_matrix[0, 0] = 1.0
 
+    def _as_mixed(self):
+        return self.copy()
+
     @classmethod
     def from_fock_state(cls, state: BaseFockState) -> "FockState":
         """Instantiation using another :class:`BaseFockState` instance.

--- a/piquasso/_backends/fock/pure/simulator.py
+++ b/piquasso/_backends/fock/pure/simulator.py
@@ -30,8 +30,10 @@ from .calculations import (
     annihilate,
 )
 
+from ..calculations import attenuator
+
 from piquasso.api.simulator import Simulator
-from piquasso.instructions import preparations, gates, measurements
+from piquasso.instructions import preparations, gates, measurements, channels
 
 
 class PureFockSimulator(Simulator):
@@ -75,6 +77,9 @@ class PureFockSimulator(Simulator):
 
     Supported measurements:
         :class:`~piquasso.instructions.measurements.ParticleNumberMeasurement`.
+
+    Supported channels:
+        :class:`~piquasso.instructions.channels.Attenuator`
     """
 
     _state_class = PureFockState
@@ -100,4 +105,5 @@ class PureFockSimulator(Simulator):
         gates.Squeezing2: linear,
         gates.GaussianTransform: linear,
         measurements.ParticleNumberMeasurement: particle_number_measurement,
+        channels.Attenuator: attenuator,
     }

--- a/piquasso/_backends/fock/state.py
+++ b/piquasso/_backends/fock/state.py
@@ -49,6 +49,10 @@ class BaseFockState(State, abc.ABC):
     def _get_empty(self) -> np.ndarray:
         pass
 
+    @abc.abstractmethod
+    def _as_mixed(self):
+        pass
+
     @property
     @abc.abstractmethod
     def nonzero_elements(self) -> Generator[Tuple[complex, tuple], Any, None]:

--- a/tests/backends/fock/general/test_channels.py
+++ b/tests/backends/fock/general/test_channels.py
@@ -1,0 +1,78 @@
+#
+# Copyright 2021-2022 Budapest Quantum Computing Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+
+import piquasso as pq
+
+
+def test_Attenuator_with_zero_theta_changes_nothing_on_one_mode_state():
+    with pq.Program() as empty_program:
+        pq.Q() | pq.DensityMatrix(bra=[1], ket=[1]) / 2
+        pq.Q() | pq.DensityMatrix(bra=[2], ket=[2]) / 2
+
+    with pq.Program() as program_with_zero_theta:
+        pq.Q() | pq.DensityMatrix(bra=[1], ket=[1]) / 2
+        pq.Q() | pq.DensityMatrix(bra=[2], ket=[2]) / 2
+
+        pq.Q() | pq.Attenuator(theta=0.0)
+
+    simulator = pq.FockSimulator(d=1, config=pq.Config(cutoff=3))
+
+    empty_state = simulator.execute(empty_program).state
+    lossy_state = simulator.execute(program_with_zero_theta).state
+
+    assert np.allclose(
+        empty_state.fock_probabilities,
+        lossy_state.fock_probabilities,
+    )
+
+
+def test_Attenuator_with_pi_over_2_theta_maps_to_vacuum():
+    with pq.Program() as program_with_zero_theta:
+        pq.Q() | pq.DensityMatrix(bra=[1], ket=[1]) / 2
+        pq.Q() | pq.DensityMatrix(bra=[2], ket=[2]) / 2
+
+        pq.Q() | pq.Attenuator(theta=np.pi / 2)
+
+    simulator = pq.FockSimulator(d=1, config=pq.Config(cutoff=3))
+
+    lossy_state = simulator.execute(program_with_zero_theta).state
+
+    assert np.allclose(
+        lossy_state.fock_probabilities,
+        [1.0, 0.0, 0.0],
+        atol=1e-7,
+    )
+
+
+def test_Attenuator_for_one_particle():
+    theta = np.pi / 5
+
+    transmittivity = np.cos(theta)
+
+    with pq.Program() as program:
+        pq.Q(0, 1) | pq.DensityMatrix(bra=[0, 1], ket=[0, 1])
+
+        pq.Q(1) | pq.Attenuator(theta=theta)
+
+    simulator = pq.FockSimulator(d=2, config=pq.Config(cutoff=2))
+
+    state = simulator.execute(program).state
+
+    assert np.allclose(
+        state.fock_probabilities,
+        [1 - transmittivity**2, 0, transmittivity**2],
+    )

--- a/tests/backends/fock/pure/test_channels.py
+++ b/tests/backends/fock/pure/test_channels.py
@@ -1,0 +1,78 @@
+#
+# Copyright 2021-2022 Budapest Quantum Computing Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+
+import piquasso as pq
+
+
+def test_Attenuator_with_zero_theta_changes_nothing_on_one_mode_state():
+    with pq.Program() as empty_program:
+        pq.Q() | pq.StateVector([1]) / np.sqrt(2)
+        pq.Q() | pq.StateVector([2]) / np.sqrt(2)
+
+    with pq.Program() as program_with_zero_theta:
+        pq.Q() | pq.StateVector([1]) / np.sqrt(2)
+        pq.Q() | pq.StateVector([2]) / np.sqrt(2)
+
+        pq.Q() | pq.Attenuator(theta=0.0)
+
+    simulator = pq.PureFockSimulator(d=1, config=pq.Config(cutoff=3))
+
+    empty_state = simulator.execute(empty_program).state
+    lossy_state = simulator.execute(program_with_zero_theta).state
+
+    assert np.allclose(
+        empty_state.fock_probabilities,
+        lossy_state.fock_probabilities,
+    )
+
+
+def test_Attenuator_with_pi_over_2_theta_maps_to_vacuum():
+    with pq.Program() as program_with_zero_theta:
+        pq.Q() | pq.StateVector([1]) / np.sqrt(2)
+        pq.Q() | pq.StateVector([2]) / np.sqrt(2)
+
+        pq.Q() | pq.Attenuator(theta=np.pi / 2)
+
+    simulator = pq.PureFockSimulator(d=1, config=pq.Config(cutoff=3))
+
+    lossy_state = simulator.execute(program_with_zero_theta).state
+
+    assert np.allclose(
+        lossy_state.fock_probabilities,
+        [1.0, 0.0, 0.0],
+        atol=1e-7,
+    )
+
+
+def test_Attenuator_for_one_particle():
+    theta = np.pi / 5
+
+    transmittivity = np.cos(theta)
+
+    with pq.Program() as program:
+        pq.Q(0, 1) | pq.StateVector([0, 1])
+
+        pq.Q(1) | pq.Attenuator(theta=theta)
+
+    simulator = pq.PureFockSimulator(d=2, config=pq.Config(cutoff=2))
+
+    state = simulator.execute(program).state
+
+    assert np.allclose(
+        state.fock_probabilities,
+        [1 - transmittivity**2, 0, transmittivity**2],
+    )


### PR DESCRIPTION
The support for the `Attenuator` channel for `PureFockSimulator` and
`FockSimulator` has been written in this patch.

The calculation function `attenuator` has been written in a manner that
it works with both simulators, which was easy to achieve since this
channel produces a mixed state (i.e. `FockState`) in general.

Resolves #183