### PR TITLE
fix(Kerr): Kerr gate scaling

### DIFF
--- a/piquasso/_backends/fock/general/calculations.py
+++ b/piquasso/_backends/fock/general/calculations.py
@@ -134,16 +134,18 @@ def annihilate(state: FockState, instruction: Instruction, shots: int) -> Result
 
 
 def kerr(state: FockState, instruction: Instruction, shots: int) -> Result:
-    mode = instruction.modes[0]
-    xi = instruction._all_params["xi"]
-    for x in xi:
+    xi_vector = instruction._all_params["xi"]
+
+    for mode_index, mode in enumerate(instruction.modes):
+        xi = xi_vector[mode_index]
+
         for index, (basis, dual_basis) in state._space.operator_basis:
             number = basis[mode]
             dual_number = dual_basis[mode]
 
             coefficient = np.exp(
                 1j
-                * x
+                * xi
                 * (number * (2 * number + 1) - dual_number * (2 * dual_number + 1))
             )
 

--- a/piquasso/_backends/fock/pure/calculations.py
+++ b/piquasso/_backends/fock/pure/calculations.py
@@ -184,14 +184,14 @@ def annihilate(state: PureFockState, instruction: Instruction, shots: int) -> Re
 
 
 def kerr(state: PureFockState, instruction: Instruction, shots: int) -> Result:
-    mode = instruction.modes[0]
-    xi = instruction._all_params["xi"]
+    xi_vector = instruction._all_params["xi"]
 
-    for x in xi:
+    for mode_index, mode in enumerate(instruction.modes):
+        xi = xi_vector[mode_index]
 
         for index, basis in state._space.basis:
             number = basis[mode]
-            coefficient = np.exp(1j * x.squeeze() * number * (2 * number + 1))
+            coefficient = np.exp(1j * xi.squeeze() * number * (2 * number + 1))
             state._state_vector[index] *= coefficient
 
     return Result(state=state)

--- a/piquasso/instructions/gates.py
+++ b/piquasso/instructions/gates.py
@@ -652,16 +652,16 @@ class MomentumDisplacement(_ScalableGaussianGate):
 
 
 class _ScalableFockGates(Gate, _mixins.ScalingMixin):
+    ERROR_MESSAGE_TEMPLATE = (
+        "The instruction {instruction} is not applicable to modes {modes} with the "
+        "specified parameters."
+    )
+
     def __init__(
         self, *, params: dict = None, gamma: np.ndarray = None, xi: np.ndarray = None
     ):
         params = params or {}
         super().__init__(params=params, extra_params=dict(gamma=gamma, xi=xi))
-
-    ERROR_MESSAGE_TEMPLATE = (
-        "The instruction {instruction} is not applicable to modes {modes} with the "
-        "specified parameters."
-    )
 
     def _autoscale(self) -> None:
         gamma = self._extra_params["gamma"]

--- a/tests/api/utils/test_code_generation.py
+++ b/tests/api/utils/test_code_generation.py
@@ -169,3 +169,167 @@ use_torontonian=True, cutoff=6, measurement_cutoff=4)
 result = simulator.execute(program, shots=100)
 """
     )
+
+
+def test_Kerr_scalar_parameter_on_multimode_code_generation():
+    with pq.Program() as program:
+        pq.Q() | pq.Vacuum()
+        pq.Q() | pq.DensityMatrix(ket=(0, 1), bra=(0, 1)) / 4
+
+        pq.Q() | pq.DensityMatrix(ket=(0, 2), bra=(0, 2)) / 4
+        pq.Q() | pq.DensityMatrix(ket=(2, 0), bra=(2, 0)) / 2
+
+        pq.Q() | pq.DensityMatrix(ket=(0, 2), bra=(2, 0)) * np.sqrt(1 / 8)
+        pq.Q() | pq.DensityMatrix(ket=(2, 0), bra=(0, 2)) * np.sqrt(1 / 8)
+
+        pq.Q(0, 1) | pq.Kerr(xi=0.2)
+
+    simulator = pq.FockSimulator(d=2)
+
+    code = pq.as_code(program, simulator, shots=10)
+    code_is_executable(code)
+
+    assert (
+        code
+        == f"""\
+import numpy as np
+import piquasso as pq
+
+
+with pq.Program() as program:
+    pq.Q() | pq.Vacuum()
+    pq.Q() | pq.DensityMatrix(ket=(0, 1), bra=(0, 1), coefficient=0.25)
+    pq.Q() | pq.DensityMatrix(ket=(0, 2), bra=(0, 2), coefficient=0.25)
+    pq.Q() | pq.DensityMatrix(ket=(2, 0), bra=(2, 0), coefficient=0.5)
+    pq.Q() | pq.DensityMatrix(ket=(0, 2), bra=(2, 0), coefficient=0.3535533905932738)
+    pq.Q() | pq.DensityMatrix(ket=(2, 0), bra=(0, 2), coefficient=0.3535533905932738)
+    pq.Q(0, 1) | pq.Kerr(xi=0.2)
+
+simulator = pq.{pq.FockSimulator.__name__}(d=2)
+
+result = simulator.execute(program, shots=10)
+"""
+    )
+
+
+def test_Kerr_vector_parameter_code_generation():
+    with pq.Program() as program:
+        pq.Q() | pq.Vacuum()
+        pq.Q() | pq.DensityMatrix(ket=(0, 1), bra=(0, 1)) / 4
+
+        pq.Q() | pq.DensityMatrix(ket=(0, 2), bra=(0, 2)) / 4
+        pq.Q() | pq.DensityMatrix(ket=(2, 0), bra=(2, 0)) / 2
+
+        pq.Q() | pq.DensityMatrix(ket=(0, 2), bra=(2, 0)) * np.sqrt(1 / 8)
+        pq.Q() | pq.DensityMatrix(ket=(2, 0), bra=(0, 2)) * np.sqrt(1 / 8)
+
+        pq.Q(0, 1) | pq.Kerr(xi=[-0.1, 0.2])
+
+    simulator = pq.FockSimulator(d=2)
+
+    code = pq.as_code(program, simulator, shots=10)
+    code_is_executable(code)
+
+    assert (
+        code
+        == f"""\
+import numpy as np
+import piquasso as pq
+
+
+with pq.Program() as program:
+    pq.Q() | pq.Vacuum()
+    pq.Q() | pq.DensityMatrix(ket=(0, 1), bra=(0, 1), coefficient=0.25)
+    pq.Q() | pq.DensityMatrix(ket=(0, 2), bra=(0, 2), coefficient=0.25)
+    pq.Q() | pq.DensityMatrix(ket=(2, 0), bra=(2, 0), coefficient=0.5)
+    pq.Q() | pq.DensityMatrix(ket=(0, 2), bra=(2, 0), coefficient=0.3535533905932738)
+    pq.Q() | pq.DensityMatrix(ket=(2, 0), bra=(0, 2), coefficient=0.3535533905932738)
+    pq.Q(0, 1) | pq.Kerr(xi=[-0.1, 0.2])
+
+simulator = pq.{pq.FockSimulator.__name__}(d=2)
+
+result = simulator.execute(program, shots=10)
+"""
+    )
+
+
+def test_CubicPhase_vector_parameter_code_generation():
+    with pq.Program() as program:
+        pq.Q() | pq.Vacuum()
+        pq.Q() | pq.DensityMatrix(ket=(0, 1), bra=(0, 1)) / 4
+
+        pq.Q() | pq.DensityMatrix(ket=(0, 2), bra=(0, 2)) / 4
+        pq.Q() | pq.DensityMatrix(ket=(2, 0), bra=(2, 0)) / 2
+
+        pq.Q() | pq.DensityMatrix(ket=(0, 2), bra=(2, 0)) * np.sqrt(1 / 8)
+        pq.Q() | pq.DensityMatrix(ket=(2, 0), bra=(0, 2)) * np.sqrt(1 / 8)
+
+        pq.Q(0, 1) | pq.CubicPhase(gamma=[-0.1, 0.2])
+
+    simulator = pq.FockSimulator(d=2)
+
+    code = pq.as_code(program, simulator, shots=10)
+    code_is_executable(code)
+
+    assert (
+        code
+        == f"""\
+import numpy as np
+import piquasso as pq
+
+
+with pq.Program() as program:
+    pq.Q() | pq.Vacuum()
+    pq.Q() | pq.DensityMatrix(ket=(0, 1), bra=(0, 1), coefficient=0.25)
+    pq.Q() | pq.DensityMatrix(ket=(0, 2), bra=(0, 2), coefficient=0.25)
+    pq.Q() | pq.DensityMatrix(ket=(2, 0), bra=(2, 0), coefficient=0.5)
+    pq.Q() | pq.DensityMatrix(ket=(0, 2), bra=(2, 0), coefficient=0.3535533905932738)
+    pq.Q() | pq.DensityMatrix(ket=(2, 0), bra=(0, 2), coefficient=0.3535533905932738)
+    pq.Q(0, 1) | pq.CubicPhase(gamma=[-0.1, 0.2])
+
+simulator = pq.{pq.FockSimulator.__name__}(d=2)
+
+result = simulator.execute(program, shots=10)
+"""
+    )
+
+
+def test_CubicPhase_scalar_parameter_on_multimode_code_generation():
+    with pq.Program() as program:
+        pq.Q() | pq.Vacuum()
+        pq.Q() | pq.DensityMatrix(ket=(0, 1), bra=(0, 1)) / 4
+
+        pq.Q() | pq.DensityMatrix(ket=(0, 2), bra=(0, 2)) / 4
+        pq.Q() | pq.DensityMatrix(ket=(2, 0), bra=(2, 0)) / 2
+
+        pq.Q() | pq.DensityMatrix(ket=(0, 2), bra=(2, 0)) * np.sqrt(1 / 8)
+        pq.Q() | pq.DensityMatrix(ket=(2, 0), bra=(0, 2)) * np.sqrt(1 / 8)
+
+        pq.Q(0, 1) | pq.CubicPhase(gamma=0.2)
+
+    simulator = pq.FockSimulator(d=2)
+
+    code = pq.as_code(program, simulator, shots=10)
+    code_is_executable(code)
+
+    assert (
+        code
+        == f"""\
+import numpy as np
+import piquasso as pq
+
+
+with pq.Program() as program:
+    pq.Q() | pq.Vacuum()
+    pq.Q() | pq.DensityMatrix(ket=(0, 1), bra=(0, 1), coefficient=0.25)
+    pq.Q() | pq.DensityMatrix(ket=(0, 2), bra=(0, 2), coefficient=0.25)
+    pq.Q() | pq.DensityMatrix(ket=(2, 0), bra=(2, 0), coefficient=0.5)
+    pq.Q() | pq.DensityMatrix(ket=(0, 2), bra=(2, 0), coefficient=0.3535533905932738)
+    pq.Q() | pq.DensityMatrix(ket=(2, 0), bra=(0, 2), coefficient=0.3535533905932738)
+    pq.Q(0, 1) | pq.CubicPhase(gamma=0.2)
+
+simulator = pq.{pq.FockSimulator.__name__}(d=2)
+
+result = simulator.execute(program, shots=10)
+"""
+    )

--- a/tests/backends/test_backend_equivalence.py
+++ b/tests/backends/test_backend_equivalence.py
@@ -1027,25 +1027,22 @@ def test_CubicPhase_equivalence_on_multiple_modes(SimulatorClass):
         pq.FockSimulator,
     ),
 )
-def test_kerr_equivalency(SimulatorClass):
-    with pq.Program() as program_1:
+def test_Kerr_equivalence(SimulatorClass):
+    with pq.Program() as program:
         pq.Q() | pq.Vacuum()
-        pq.Q(0) | pq.Squeezing(r=0.05)
-        pq.Q(0, 1) | pq.Kerr(xi=[-1, 1])
+        pq.Q(0) | pq.Squeezing(r=0.1, phi=np.pi / 5)
+        pq.Q(1) | pq.Squeezing(r=0.2, phi=np.pi / 6)
 
-    with pq.Program() as program_2:
-        pq.Q() | pq.Vacuum()
-        pq.Q(0) | pq.Squeezing(r=0.05)
-        pq.Q(all) | pq.Kerr(xi=[-1, 1])
+        pq.Q(0, 1) | pq.Kerr(xi=[-0.1, 0.2])
 
-    generic_simulator = SimulatorClass(d=2, config=pq.Config(cutoff=10))
+    simulator = SimulatorClass(d=2)
 
-    state_1 = generic_simulator.execute(program_1).state
-    state_2 = generic_simulator.execute(program_2).state
-    fidelity = state_1.fidelity(state_2)
+    state = simulator.execute(program).state
 
-    assert np.isclose(fidelity, 1.0)
-    assert np.isclose(fidelity, state_2.fidelity(state_1))
+    assert is_proportional(
+        state.fock_probabilities,
+        [0.97613795, 0.0, 0.0, 0.00484834, 0.0, 0.01901371, 0.0, 0.0, 0.0, 0.0],
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Some tests were not entirely thorough on the scaling of the `Kerr` and
the `CubicPhase` gates. Additional tests were written, and it turned out
that the `Kerr` gate is not working.

The issue was, that the `kerr` calculation in `FockSimulator` and
`PureFockSimulator` was written in a way that only the first mode was
considered for a multimode calculation. This has been fixed by rewriting
the logic to consider multiple modes.

Several tests were written for testing the scalability of the `Kerr` and
`CubicPhase` gates. Furthermore, the `test_kerr_equivalency` has not
been testing the equivalence between the `FockSimulator` and
`PureFockSimulator`, therefore it has been rewritten to do that.

Additional tests have been written testing the code generation with the
`Kerr` and `CubicPhase` gates.