### PR TITLE
feat(fock): `TensorflowPureFockSimulator`

### DIFF
--- a/piquasso/__init__.py
+++ b/piquasso/__init__.py
@@ -41,6 +41,7 @@ from piquasso._backends.fock import (
     FockSimulator,
     PureFockSimulator,
 )
+from piquasso._backends.tensorflow import TensorflowPureFockSimulator
 
 from .instructions.preparations import (
     Vacuum,
@@ -108,6 +109,7 @@ __all__ = [
     "SamplingSimulator",
     "FockSimulator",
     "PureFockSimulator",
+    "TensorflowPureFockSimulator",
     # States
     "GaussianState",
     "SamplingState",

--- a/piquasso/_backends/calculator.py
+++ b/piquasso/_backends/calculator.py
@@ -13,7 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from piquasso._math.permanent import glynn_gray_permanent
+import scipy
+
+import numpy as np
+
+from piquasso._math.permanent import np_glynn_gray_permanent
 from piquasso._math.hafnian import hafnian_with_reduction, loop_hafnian_with_reduction
 
 from piquasso.api.calculator import BaseCalculator
@@ -23,6 +27,35 @@ class NumpyCalculator(BaseCalculator):
     """The calculations for a simulation using NumPy."""
 
     def __init__(self):
-        self.permanent = glynn_gray_permanent
+        self.np = np
+        self.fallback_np = np
+        self.block_diag = scipy.linalg.block_diag
+        self.block = np.block
+        self.logm = scipy.linalg.logm
+        self.polar = scipy.linalg.polar
+        self.sqrtm = scipy.linalg.sqrtm
+        self.svd = np.linalg.svd
+
+        self.permanent = np_glynn_gray_permanent
         self.hafnian = hafnian_with_reduction
         self.loop_hafnian = loop_hafnian_with_reduction
+
+    def assign(self, array, index, value):
+        array[index] = value
+
+        return array
+
+    def to_dense(self, index_map, dim):
+        embedded_matrix = np.zeros((dim,) * 2, dtype=complex)
+
+        for index, value in index_map.items():
+            embedded_matrix[index] = value
+
+        return embedded_matrix
+
+    def embed_in_identity(self, matrix, indices, dim):
+        embedded_matrix = np.identity(dim, dtype=complex)
+
+        embedded_matrix[indices] = matrix
+
+        return embedded_matrix

--- a/piquasso/_backends/fock/pure/simulator.py
+++ b/piquasso/_backends/fock/pure/simulator.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Type
+
 from .state import PureFockState
 
 from .calculations import (
@@ -33,6 +35,7 @@ from .calculations import (
 from ..calculations import attenuator
 
 from piquasso.api.simulator import Simulator
+from piquasso.api.calculator import BaseCalculator
 from piquasso.instructions import preparations, gates, measurements, channels
 
 from piquasso._backends.calculator import NumpyCalculator
@@ -110,4 +113,4 @@ class PureFockSimulator(Simulator):
         channels.Attenuator: attenuator,
     }
 
-    _calculator_class = NumpyCalculator
+    _calculator_class: Type[BaseCalculator] = NumpyCalculator

--- a/piquasso/_backends/tensorflow/__init__.py
+++ b/piquasso/_backends/tensorflow/__init__.py
@@ -1,0 +1,16 @@
+#
+# Copyright 2021-2022 Budapest Quantum Computing Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .simulator import TensorflowPureFockSimulator  # noqa: F401

--- a/piquasso/_backends/tensorflow/calculator.py
+++ b/piquasso/_backends/tensorflow/calculator.py
@@ -1,0 +1,133 @@
+#
+# Copyright 2021-2022 Budapest Quantum Computing Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as fallback_np
+
+from piquasso.api.calculator import BaseCalculator
+
+from piquasso._math.permanent import glynn_gray_permanent
+
+
+class TensorflowCalculator(BaseCalculator):
+    def __init__(self):
+        try:
+            import tensorflow as tf
+        except ImportError:
+            raise ImportError(
+                "You have invoked a feature which requires 'tensorflow'.\n"
+                "You can install tensorflow via:\n"
+                "\n"
+                "pip install piquasso[tensorflow]"
+            )
+
+        import tensorflow.experimental.numpy as tnp
+        from tensorflow.python.ops.numpy_ops import np_config
+
+        np_config.enable_numpy_behavior()
+
+        self._tf = tf
+        self.np = tnp
+        self.fallback_np = fallback_np
+        self.sqrtm = tf.linalg.sqrtm
+
+    def block_diag(self, *arrs):
+        block_diagonalized = self._tf.linalg.LinearOperatorBlockDiag(
+            [self._tf.linalg.LinearOperatorFullMatrix(arr) for arr in arrs]
+        )
+
+        return block_diagonalized.to_dense()
+
+    def permanent(self, matrix, rows, columns):
+        return glynn_gray_permanent(matrix, rows, columns, np=self.np)
+
+    def assign(self, array, index, value):
+        # NOTE: This is not as advanced as Numpy's indexing, only supports 1D arrays.
+
+        state_vector_list = array.tolist()
+        state_vector_list[index] = value
+
+        return self.np.array(state_vector_list)
+
+    def block(self, arrays):
+        # NOTE: This is not as advanced as `numpy.block`, this function only supports
+        # 4 same-length blocks.
+
+        d = len(arrays[0][0])
+
+        output = []
+
+        for i in range(d):
+            output.append(self.np.concatenate([arrays[0][0][i], arrays[0][1][i]]))
+
+        for i in range(d):
+            output.append(self.np.concatenate([arrays[1][0][i], arrays[1][1][i]]))
+
+        return self.np.stack(output)
+
+    def to_dense(self, index_map, dim):
+        matrix = [[] for _ in range(dim)]
+
+        for row in range(dim):
+            for col in range(dim):
+                index = (row, col)
+                matrix[row].append(index_map.get(index, 0.0))
+
+        return self.np.array(matrix)
+
+    def embed_in_identity(self, matrix, indices, dim):
+        index_map = {}
+
+        small_dim = len(indices[0])
+        for row in range(small_dim):
+            for col in range(small_dim):
+                index = (indices[0][row][col], indices[1][row][col])
+                value = matrix[row, col]
+
+                index_map[index] = value
+
+        for index in range(dim):
+            diagonal_index = (index, index)
+            if diagonal_index not in index_map:
+                index_map[diagonal_index] = 1.0
+
+        return self.to_dense(index_map, dim)
+
+    def logm(self, matrix):
+        # NOTE: Tensorflow 2.0 has matrix logarithm, but it doesn't support gradient.
+        # Therefore we had to implement our own.
+
+        eigenvalues, U = self._tf.linalg.eig(matrix)
+
+        log_eigenvalues = self.np.log(eigenvalues)
+
+        return U @ self.np.diag(log_eigenvalues) @ self._tf.linalg.inv(U)
+
+    def polar(self, matrix, side="right"):
+        P = self._tf.linalg.sqrtm(self.np.conj(matrix) @ matrix.T)
+        Pinv = self._tf.linalg.inv(P)
+
+        if side == "right":
+            U = matrix @ Pinv
+        elif side == "left":
+            U = Pinv @ matrix
+
+        return U, P
+
+    def svd(self, matrix):
+        # NOTE: Tensorflow 2.0 SVD has different return tuple.
+
+        S, V, W = self._tf.linalg.svd(matrix)
+
+        return V, S, self.np.conj(W).T

--- a/piquasso/_backends/tensorflow/simulator.py
+++ b/piquasso/_backends/tensorflow/simulator.py
@@ -1,0 +1,22 @@
+#
+# Copyright 2021-2022 Budapest Quantum Computing Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from piquasso._backends.fock.pure.simulator import PureFockSimulator
+
+from .calculator import TensorflowCalculator
+
+
+class TensorflowPureFockSimulator(PureFockSimulator):
+    _calculator_class = TensorflowCalculator

--- a/piquasso/_math/linalg.py
+++ b/piquasso/_math/linalg.py
@@ -21,9 +21,7 @@ from .validations import all_real_and_positive
 
 
 def is_unitary(matrix: np.ndarray) -> bool:
-    return np.allclose(
-        matrix @ matrix.conjugate().transpose(), np.identity(matrix.shape[0])
-    )
+    return np.allclose(matrix @ np.conj(matrix).T, np.identity(matrix.shape[0]))
 
 
 def is_real(matrix: np.ndarray) -> bool:
@@ -81,3 +79,18 @@ def reduce_(array: np.ndarray, reduce_on: Iterable[int]) -> np.ndarray:
 
 def block_reduce(array: np.ndarray, reduce_on: Tuple[int, ...]) -> np.ndarray:
     return reduce_(array, reduce_on=(reduce_on * 2))
+
+
+def assym_reduce(
+    array: np.ndarray, row_reduce_on: Iterable[int], column_reduce_on: Iterable[int]
+) -> np.ndarray:
+    proper_row_index = []
+    proper_column_index = []
+
+    for index, multiplier in enumerate(row_reduce_on):
+        proper_row_index.extend([index] * multiplier)
+
+    for index, multiplier in enumerate(column_reduce_on):
+        proper_column_index.extend([index] * multiplier)
+
+    return array[np.ix_(proper_column_index, proper_row_index)]

--- a/piquasso/api/calculator.py
+++ b/piquasso/api/calculator.py
@@ -15,9 +15,9 @@
 
 import abc
 
-from typing import Tuple
+from typing import Any, Tuple
 
-import numpy as np
+import numpy
 
 from piquasso.api.exceptions import NotImplementedCalculation
 
@@ -28,15 +28,48 @@ class BaseCalculator(abc.ABC):
     NOTE: Every attribute of this class should be stateless!
     """
 
+    np: Any
+    fallback_np: Any
+
+    def __deepcopy__(self, memo: Any) -> "BaseCalculator":
+        """
+        This method exists, because `copy.deepcopy` could not copy the entire modules
+        and functions, and we don't need to, since every attribute of this class should
+        be stateless.
+        """
+
+        return self
+
     def permanent(
-        self, matrix: np.ndarray, rows: Tuple[int, ...], columns: Tuple[int, ...]
+        self, matrix: numpy.ndarray, rows: Tuple[int, ...], columns: Tuple[int, ...]
     ) -> float:
         raise NotImplementedCalculation()
 
-    def hafnian(self, matrix: np.ndarray, reduce_on: Tuple[int, ...]) -> float:
+    def hafnian(self, matrix: numpy.ndarray, reduce_on: Tuple[int, ...]) -> float:
         raise NotImplementedCalculation()
 
     def loop_hafnian(
-        self, matrix: np.ndarray, diagonal: np.ndarray, reduce_on: Tuple[int, ...]
+        self, matrix: numpy.ndarray, diagonal: numpy.ndarray, reduce_on: Tuple[int, ...]
     ) -> float:
+        raise NotImplementedCalculation()
+
+    def assign(self, array, index, value):
+        raise NotImplementedCalculation()
+
+    def to_dense(self, index_map, dim):
+        raise NotImplementedCalculation()
+
+    def embed_in_identity(self, matrix, indices, dim):
+        raise NotImplementedCalculation()
+
+    def block(self, arrays):
+        raise NotImplementedCalculation()
+
+    def block_diag(self, *arrs):
+        raise NotImplementedCalculation()
+
+    def polar(self, matrix, side="right"):
+        raise NotImplementedCalculation()
+
+    def logm(self, matrix):
         raise NotImplementedCalculation()

--- a/piquasso/api/instruction.py
+++ b/piquasso/api/instruction.py
@@ -21,6 +21,7 @@ import numpy as np
 from .mode import Q
 from piquasso.core import _mixins
 from piquasso.api.exceptions import PiquassoException
+from piquasso.api.calculator import BaseCalculator
 
 if typing.TYPE_CHECKING:
     from piquasso.api.program import Program
@@ -80,6 +81,9 @@ class Instruction(_mixins.DictMixin, _mixins.RegisterMixin, _mixins.CodeMixin):
     def on_modes(self, *modes: int) -> "Instruction":
         self.modes: Tuple[int, ...] = modes
         return self
+
+    def _postprocess(self, calculator: BaseCalculator) -> None:
+        pass
 
     def _apply_to_program_on_register(self, program: "Program", register: Q) -> None:
         program.instructions.append(self.on_modes(*register.modes))

--- a/piquasso/api/simulator.py
+++ b/piquasso/api/simulator.py
@@ -219,6 +219,8 @@ class Simulator(Computer, _mixins.CodeMixin):
             if not hasattr(instruction, "modes") or instruction.modes is tuple():
                 instruction.modes = tuple(range(self.d))
 
+            instruction._postprocess(self._calculator)
+
             if hasattr(instruction, "_autoscale"):
                 instruction._autoscale()  # type: ignore
 

--- a/piquasso/api/state.py
+++ b/piquasso/api/state.py
@@ -43,6 +43,10 @@ class State(abc.ABC):
         self._config = config.copy() if config is not None else self._config_class()
         self._calculator = calculator
 
+    @property
+    def _np(self):
+        return self._calculator.np
+
     def _get_auxiliary_modes(self, modes: Tuple[int, ...]) -> Tuple[int, ...]:
         return tuple(np.delete(np.arange(self.d), modes))
 

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,9 @@ setup(
         'scipy>=1.5.4; python_version >= "3.7"',
         "quantum-blackbird==0.3.0",
     ],
+    extras_require={
+        "tensorflow": "tensorflow",
+    },
     classifiers=[
         "Intended Audience :: Developers",
         "License :: OSI Approved :: Apache Software License",

--- a/tests/_math/test_decompositions.py
+++ b/tests/_math/test_decompositions.py
@@ -26,23 +26,29 @@ from piquasso._math.decompositions import (
     decompose_to_pure_and_mixed,
 )
 
+from piquasso._backends.calculator import NumpyCalculator
+from piquasso._backends.tensorflow.calculator import TensorflowCalculator
 
-def test_takagi_on_real_symmetric_2_by_2_matrix():
+
+@pytest.mark.parametrize("calculator", [NumpyCalculator(), TensorflowCalculator()])
+def test_takagi_on_real_symmetric_2_by_2_matrix(calculator):
     matrix = np.array(
         [
             [1, 2],
             [2, 1],
-        ]
+        ],
+        dtype=complex,
     )
 
-    singular_values, unitary = takagi(matrix)
+    singular_values, unitary = takagi(matrix, calculator)
 
     assert is_unitary(unitary)
     assert np.allclose(np.abs(singular_values), singular_values)
     assert np.allclose(matrix, unitary @ np.diag(singular_values) @ unitary.transpose())
 
 
-def test_takagi_on_complex_symmetric_2_by_2_matrix_with_multiplicities():
+@pytest.mark.parametrize("calculator", [NumpyCalculator(), TensorflowCalculator()])
+def test_takagi_on_complex_symmetric_2_by_2_matrix_with_multiplicities(calculator):
     matrix = np.array(
         [
             [1, 2j],
@@ -51,30 +57,33 @@ def test_takagi_on_complex_symmetric_2_by_2_matrix_with_multiplicities():
         dtype=complex,
     )
 
-    singular_values, unitary = takagi(matrix)
+    singular_values, unitary = takagi(matrix, calculator)
 
     assert is_unitary(unitary)
     assert np.allclose(np.abs(singular_values), singular_values)
     assert np.allclose(matrix, unitary @ np.diag(singular_values) @ unitary.transpose())
 
 
-def test_takagi_on_real_symmetric_3_by_3_matrix():
+@pytest.mark.parametrize("calculator", [NumpyCalculator(), TensorflowCalculator()])
+def test_takagi_on_real_symmetric_3_by_3_matrix(calculator):
     matrix = np.array(
         [
             [1, 2, 3],
             [2, 1, 5],
             [3, 5, 9],
-        ]
+        ],
+        dtype=complex,
     )
 
-    singular_values, unitary = takagi(matrix)
+    singular_values, unitary = takagi(matrix, calculator)
 
     assert is_unitary(unitary)
     assert np.allclose(np.abs(singular_values), singular_values)
     assert np.allclose(matrix, unitary @ np.diag(singular_values) @ unitary.transpose())
 
 
-def test_takagi_on_complex_symmetric_3_by_3_matrix():
+@pytest.mark.parametrize("calculator", [NumpyCalculator(), TensorflowCalculator()])
+def test_takagi_on_complex_symmetric_3_by_3_matrix(calculator):
     matrix = np.array(
         [
             [1, 2, 3j],
@@ -83,7 +92,7 @@ def test_takagi_on_complex_symmetric_3_by_3_matrix():
         ],
     )
 
-    singular_values, unitary = takagi(matrix)
+    singular_values, unitary = takagi(matrix, calculator)
 
     assert is_unitary(unitary)
     assert np.allclose(np.abs(singular_values), singular_values)
@@ -91,7 +100,9 @@ def test_takagi_on_complex_symmetric_3_by_3_matrix():
 
 
 @pytest.mark.monkey
+@pytest.mark.parametrize("calculator", [NumpyCalculator(), TensorflowCalculator()])
 def test_takagi_on_complex_symmetric_6_by_6_matrix_with_multiplicities(
+    calculator,
     generate_unitary_matrix,
 ):
     singular_values = np.array([1, 1, 2, 2, 2, 3], dtype=complex)
@@ -100,7 +111,7 @@ def test_takagi_on_complex_symmetric_6_by_6_matrix_with_multiplicities(
 
     matrix = unitary @ np.diag(singular_values) @ unitary.transpose()
 
-    calculated_singular_values, calculated_unitary = takagi(matrix)
+    calculated_singular_values, calculated_unitary = takagi(matrix, calculator)
 
     assert is_unitary(calculated_unitary)
     assert np.allclose(np.abs(calculated_singular_values), calculated_singular_values)
@@ -114,11 +125,12 @@ def test_takagi_on_complex_symmetric_6_by_6_matrix_with_multiplicities(
 
 @pytest.mark.monkey
 @pytest.mark.parametrize("N", [2, 3, 4, 5, 6])
+@pytest.mark.parametrize("calculator", [NumpyCalculator(), TensorflowCalculator()])
 def test_takagi_on_complex_symmetric_N_by_N_matrix(
-    N, generate_complex_symmetric_matrix
+    N, calculator, generate_complex_symmetric_matrix
 ):
     matrix = generate_complex_symmetric_matrix(N)
-    singular_values, unitary = takagi(matrix)
+    singular_values, unitary = takagi(matrix, calculator)
 
     assert is_unitary(unitary)
     assert np.allclose(np.abs(singular_values), singular_values)

--- a/tests/api/test_calculator.py
+++ b/tests/api/test_calculator.py
@@ -27,7 +27,7 @@ def dummy_matrix():
 
 
 @pytest.fixture
-def dummy_diagonal():
+def dummy_array():
     return np.array([0.0])
 
 
@@ -36,45 +36,97 @@ def dummy_occupation_number():
     return (0,)
 
 
-def test_BaseCalculator_raises_NotImplementedCalculation_for_permanent(
-    dummy_matrix, dummy_occupation_number
-):
-    class PluginCalculator(pq.api.calculator.BaseCalculator):
+@pytest.fixture
+def empty_calculator():
+    class EmptyCalculator(pq.api.calculator.BaseCalculator):
         def __init__(self) -> None:
             super().__init__()
 
-    calculator = PluginCalculator()
+    return EmptyCalculator()
 
+
+def test_BaseCalculator_raises_NotImplementedCalculation_for_permanent(
+    empty_calculator, dummy_matrix, dummy_occupation_number
+):
     with pytest.raises(NotImplementedCalculation):
-        calculator.permanent(
+        empty_calculator.permanent(
             dummy_matrix, dummy_occupation_number, dummy_occupation_number
         )
 
 
 def test_BaseCalculator_raises_NotImplementedCalculation_for_hafnian(
-    dummy_matrix, dummy_occupation_number
+    empty_calculator,
+    dummy_matrix,
+    dummy_occupation_number,
 ):
-    class PluginCalculator(pq.api.calculator.BaseCalculator):
-        def __init__(self) -> None:
-            super().__init__()
-
-    calculator = PluginCalculator()
-
     with pytest.raises(NotImplementedCalculation):
-        calculator.hafnian(dummy_matrix, dummy_occupation_number)
+        empty_calculator.hafnian(dummy_matrix, dummy_occupation_number)
 
 
 def test_BaseCalculator_raises_NotImplementedCalculation_for_loop_hafnian(
-    dummy_matrix, dummy_diagonal, dummy_occupation_number
+    empty_calculator, dummy_matrix, dummy_array, dummy_occupation_number
 ):
-    class PluginCalculator(pq.api.calculator.BaseCalculator):
-        def __init__(self) -> None:
-            super().__init__()
-
-    calculator = PluginCalculator()
-
     with pytest.raises(NotImplementedCalculation):
-        calculator.loop_hafnian(dummy_matrix, dummy_diagonal, dummy_occupation_number)
+        empty_calculator.loop_hafnian(
+            dummy_matrix, dummy_array, dummy_occupation_number
+        )
+
+
+def test_BaseCalculator_raises_NotImplementedCalculation_for_assign(
+    empty_calculator,
+    dummy_array,
+):
+    with pytest.raises(NotImplementedCalculation):
+        empty_calculator.assign(dummy_array, index=0, value=3)
+
+
+def test_BaseCalculator_raises_NotImplementedCalculation_for_to_dense(
+    empty_calculator,
+):
+    with pytest.raises(NotImplementedCalculation):
+        empty_calculator.to_dense(index_map={(0, 1): 3}, dim=2)
+
+
+def test_BaseCalculator_raises_NotImplementedCalculation_for_embed_in_identity(
+    empty_calculator,
+    dummy_matrix,
+):
+    with pytest.raises(NotImplementedCalculation):
+        empty_calculator.embed_in_identity(dummy_matrix, indices=(0, 0), dim=1)
+
+
+def test_BaseCalculator_raises_NotImplementedCalculation_for_block(
+    empty_calculator,
+    dummy_matrix,
+):
+    with pytest.raises(NotImplementedCalculation):
+        empty_calculator.block(
+            [[dummy_matrix, dummy_matrix], [dummy_matrix, dummy_matrix]]
+        )
+
+
+def test_BaseCalculator_raises_NotImplementedCalculation_for_block_diag(
+    empty_calculator,
+    dummy_matrix,
+):
+    with pytest.raises(NotImplementedCalculation):
+        empty_calculator.block_diag(dummy_matrix, dummy_matrix)
+
+
+def test_BaseCalculator_raises_NotImplementedCalculation_for_polar(
+    empty_calculator,
+    dummy_matrix,
+):
+    with pytest.raises(NotImplementedCalculation):
+        empty_calculator.polar(dummy_matrix, side="left")
+
+
+def test_BaseCalculator_raises_NotImplementedCalculation_for_logm(
+    empty_calculator,
+    dummy_matrix,
+):
+    with pytest.raises(NotImplementedCalculation):
+        empty_calculator.logm(dummy_matrix)
 
 
 def test_BaseCalculator_with_overriding_defaults():

--- a/tests/backends/fock/test_gates.py
+++ b/tests/backends/fock/test_gates.py
@@ -20,7 +20,14 @@ import numpy as np
 import piquasso as pq
 
 
-@pytest.mark.parametrize("SimulatorClass", (pq.PureFockSimulator, pq.FockSimulator))
+@pytest.mark.parametrize(
+    "SimulatorClass",
+    (
+        pq.PureFockSimulator,
+        pq.TensorflowPureFockSimulator,
+        pq.FockSimulator,
+    ),
+)
 def test_squeezing_probabilities(SimulatorClass):
     with pq.Program() as program:
         pq.Q() | pq.Vacuum()
@@ -41,7 +48,14 @@ def test_squeezing_probabilities(SimulatorClass):
     )
 
 
-@pytest.mark.parametrize("SimulatorClass", (pq.PureFockSimulator, pq.FockSimulator))
+@pytest.mark.parametrize(
+    "SimulatorClass",
+    (
+        pq.PureFockSimulator,
+        pq.TensorflowPureFockSimulator,
+        pq.FockSimulator,
+    ),
+)
 def test_displacement_probabilities(SimulatorClass):
     with pq.Program() as program:
         pq.Q() | pq.Vacuum()

--- a/tests/backends/tensorflow/test_gradient.py
+++ b/tests/backends/tensorflow/test_gradient.py
@@ -1,0 +1,308 @@
+#
+# Copyright 2021-2022 Budapest Quantum Computing Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import tensorflow as tf
+
+import numpy as np
+
+import piquasso as pq
+
+
+def test_Displacement_mean_photon_number_gradient_1_mode():
+    alpha = tf.Variable(0.43)
+
+    simulator = pq.TensorflowPureFockSimulator(d=1, config=pq.Config(cutoff=6))
+
+    with tf.GradientTape() as tape:
+
+        with pq.Program() as program:
+            pq.Q() | pq.Vacuum()
+
+            pq.Q(0) | pq.Displacement(alpha=alpha)
+
+        state = simulator.execute(program).state
+
+        mean = state.mean_photon_number()
+
+    gradient = tape.gradient(mean, [alpha])
+
+    assert np.isclose(mean, alpha**2)
+    assert np.isclose(gradient, 2 * alpha)
+
+
+def test_Displacement_mean_photon_number_gradient_2_modes():
+    alpha = tf.Variable([0.15, 0.2])
+
+    simulator = pq.TensorflowPureFockSimulator(d=2, config=pq.Config(cutoff=6))
+
+    with tf.GradientTape() as tape:
+        with pq.Program() as program:
+            pq.Q() | pq.Vacuum()
+
+            pq.Q(0, 1) | pq.Displacement(alpha=alpha)
+
+        result = simulator.execute(program)
+
+        state = result.state
+
+        mean = state.mean_photon_number()
+
+    gradient = tape.gradient(mean, [alpha])
+
+    assert np.isclose(mean, sum(alpha**2))
+    assert np.allclose(gradient, 2 * alpha)
+
+
+def test_Displacement_fock_probabilities_jacobian_2_modes():
+    alpha = tf.Variable([0.15, 0.2])
+
+    simulator = pq.TensorflowPureFockSimulator(d=2, config=pq.Config(cutoff=3))
+
+    with tf.GradientTape() as tape:
+        with pq.Program() as program:
+            pq.Q() | pq.Vacuum()
+
+            pq.Q(0, 1) | pq.Displacement(alpha=alpha)
+
+        state = simulator.execute(program).state
+
+        fock_probabilities = state.fock_probabilities
+
+    jacobian = tape.jacobian(fock_probabilities, [alpha])
+
+    expected_fock_probabilities = np.exp(-sum(alpha**2)) * np.array(
+        [
+            1.0,
+            alpha[0] ** 2,
+            alpha[1] ** 2,
+            alpha[0] ** 4 / 2,
+            alpha[0] ** 2 * alpha[1] ** 2,
+            alpha[1] ** 4 / 2,
+        ]
+    )
+
+    expected_jacobian = np.exp(-sum(alpha**2)) * np.array(
+        [
+            -2 * alpha,
+            [
+                2 * alpha[0] * (1 - alpha[0] ** 2),
+                -2 * alpha[1] * alpha[0] ** 2,
+            ],
+            [
+                -2 * alpha[0] * alpha[1] ** 2,
+                2 * alpha[1] * (1 - alpha[1] ** 2),
+            ],
+            [
+                2 * alpha[0] ** 3 - alpha[0] ** 5,
+                -2 * alpha[1] * alpha[0] ** 4 / 2,
+            ],
+            [
+                alpha[1] ** 2 * 2 * alpha[0] * (1 - alpha[0] ** 2),
+                alpha[0] ** 2 * 2 * alpha[1] * (1 - alpha[1] ** 2),
+            ],
+            [
+                -2 * alpha[0] * alpha[1] ** 4 / 2,
+                2 * alpha[1] ** 3 - alpha[1] ** 5,
+            ],
+        ]
+    )
+
+    assert np.allclose(
+        fock_probabilities,
+        expected_fock_probabilities,
+        atol=1e-4,
+    )
+
+    assert np.allclose(
+        jacobian,
+        expected_jacobian,
+        rtol=1e-2,
+    )
+
+
+def test_Squeezing_mean_photon_number_gradient_1_mode():
+    r = tf.Variable(0.1)
+
+    simulator = pq.TensorflowPureFockSimulator(d=1, config=pq.Config(cutoff=8))
+
+    with tf.GradientTape() as tape:
+        with pq.Program() as program:
+            pq.Q() | pq.Vacuum()
+
+            pq.Q(0) | pq.Squeezing(r=r)
+
+        state = simulator.execute(program).state
+
+        mean = state.mean_photon_number()
+
+    gradient = tape.gradient(mean, [r])
+
+    assert np.isclose(mean, np.sinh(r) ** 2)
+    assert np.isclose(gradient, 2 * np.sinh(r) * np.cosh(r))
+
+
+def test_Beamsplitter_fock_probabilities_gradient_1_particle():
+    theta = tf.Variable(np.pi / 3)
+
+    simulator = pq.TensorflowPureFockSimulator(d=2, config=pq.Config(cutoff=2))
+
+    with tf.GradientTape() as tape:
+        with pq.Program() as program:
+            pq.Q(all) | pq.StateVector((1, 0))
+
+            pq.Q(all) | pq.Beamsplitter(theta=theta)
+
+        state = simulator.execute(program).state
+
+        fock_probabilities = state.fock_probabilities
+
+    jacobian = tape.jacobian(fock_probabilities, [theta])
+
+    assert np.allclose(
+        fock_probabilities,
+        [0, np.cos(theta) ** 2, np.sin(theta) ** 2],
+    )
+
+    assert np.allclose(
+        jacobian,
+        [0, -2 * np.cos(theta) * np.sin(theta), 2 * np.cos(theta) * np.sin(theta)],
+    )
+
+
+def test_Phaseshifter_density_matrix_gradient():
+    phi = tf.Variable(np.pi / 3)
+
+    simulator = pq.TensorflowPureFockSimulator(d=1, config=pq.Config(cutoff=2))
+
+    coefficients = [np.sqrt(0.6), np.sqrt(0.4)]
+
+    with tf.GradientTape() as tape:
+        with pq.Program() as program:
+            pq.Q(0) | pq.StateVector([0]) * coefficients[0]
+            pq.Q(0) | pq.StateVector([1]) * coefficients[1]
+
+            pq.Q(0) | pq.Phaseshifter(phi)
+
+        state = simulator.execute(program).state
+
+        density_matrix = state.density_matrix
+
+    jacobian = tape.jacobian(density_matrix, [phi])
+
+    assert np.allclose(
+        density_matrix,
+        [
+            [
+                coefficients[0] ** 2,
+                coefficients[0] * coefficients[1] * np.exp(-1j * phi),
+            ],
+            [
+                coefficients[0] * coefficients[1] * np.exp(1j * phi),
+                coefficients[1] ** 2,
+            ],
+        ],
+    )
+
+    assert np.allclose(
+        jacobian,
+        [
+            [0.0, -np.prod(coefficients) * np.sin(phi)],
+            [-np.prod(coefficients) * np.sin(phi), 0.0],
+        ],
+    )
+
+
+def test_Phaseshifter_density_matrix_gradient_is_zero_at_zero_phaseshift():
+    phi = tf.Variable(0.0)
+
+    simulator = pq.TensorflowPureFockSimulator(d=1, config=pq.Config(cutoff=3))
+
+    with tf.GradientTape() as tape:
+        with pq.Program() as program:
+            pq.Q(0) | pq.StateVector([0]) * np.sqrt(0.5)
+            pq.Q(0) | pq.StateVector([1]) * np.sqrt(0.3)
+            pq.Q(0) | pq.StateVector([2]) * np.sqrt(0.2)
+
+            pq.Q(0) | pq.Phaseshifter(phi)
+
+        state = simulator.execute(program).state
+
+        density_matrix = state.density_matrix
+
+    jacobian = tape.jacobian(density_matrix, [phi])
+
+    assert np.allclose(jacobian, np.zeros_like(jacobian))
+
+
+def test_Interferometer_fock_probabilities():
+    param = tf.Variable(0.0)
+
+    simulator = pq.TensorflowPureFockSimulator(d=2, config=pq.Config(cutoff=3))
+
+    with tf.GradientTape() as tape:
+
+        hamiltonian = tf.stack(
+            [
+                tf.stack([0, tf.exp(param)]),
+                tf.stack([tf.exp(param), 0]),
+            ]
+        )
+
+        j = tf.complex(0.0, 1.0)
+        interferometer = tf.exp(j * hamiltonian)
+
+        with pq.Program() as program:
+            pq.Q(all) | pq.StateVector((1, 0)) / np.sqrt(2)
+            pq.Q(all) | pq.StateVector((1, 1)) / np.sqrt(2)
+
+            pq.Q(all) | pq.Interferometer(interferometer)
+
+        state = simulator.execute(program).state
+
+        density_matrix = state.density_matrix
+
+    jacobian = tape.jacobian(density_matrix, [param])
+
+    assert np.allclose(
+        jacobian,
+        [
+            [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            [0.0, 0.0, -0.42073548, -0.5950098, -0.90929735, -0.5950098],
+            [0.0, -0.42073548, 0.0, 0.0, -0.84147096, 0.0],
+            [0.0, -0.5950098, 0.0, 0.0, -1.1900196, 0.0],
+            [0.0, -0.90929735, -0.84147096, -1.1900196, -1.8185948, -1.1900196],
+            [0.0, -0.5950098, 0.0, 0.0, -1.1900196, 0.0],
+        ],
+    )
+
+
+def test_Squeezing2_mean_photon_number():
+    r = tf.Variable(0.1)
+
+    simulator = pq.TensorflowPureFockSimulator(d=2, config=pq.Config(cutoff=3))
+
+    with tf.GradientTape() as tape:
+        with pq.Program() as program:
+            pq.Q(all) | pq.Vacuum()
+
+            pq.Q(all) | pq.Squeezing2(r=r)
+
+        state = simulator.execute(program).state
+
+        fock_probabilities = state.fock_probabilities
+
+    jacobian = tape.jacobian(fock_probabilities, [r])
+
+    assert np.allclose(jacobian, [-0.19349256, 0.0, 0.0, 0.0, 0.19349256, 0.0])

--- a/tests/backends/tensorflow/test_simulator.py
+++ b/tests/backends/tensorflow/test_simulator.py
@@ -1,0 +1,85 @@
+#
+# Copyright 2021-2022 Budapest Quantum Computing Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+import builtins
+
+import pytest
+
+
+@pytest.fixture
+def raise_ImportError_when_importing_tensorflow():
+    real_import = builtins.__import__
+
+    def fake_import(name, globals, locals, fromlist, level):
+        if name == "tensorflow":
+            raise ImportError()
+
+        return real_import(name, globals, locals, fromlist, level)
+
+    builtins.__import__ = fake_import
+
+    yield
+
+    builtins.__import__ = real_import
+
+
+@pytest.fixture
+def unimport_tensorflow():
+    """
+    Deletes `tensorflow` from `sys.modules`.
+    """
+
+    if "tensorflow" in sys.modules:
+        del sys.modules["tensorflow"]
+
+
+def test_TensorflowPureFockSimulator_imports_tensorflow_if_installed():
+    import piquasso as pq
+
+    pq.TensorflowPureFockSimulator(d=3)
+
+    assert "tensorflow" in sys.modules
+
+
+def test_TensorflowPureFockSimulator_raises_ImportError_if_TensorFlow_not_installed(
+    raise_ImportError_when_importing_tensorflow,
+):
+    import piquasso as pq
+
+    with pytest.raises(ImportError) as error:
+        pq.TensorflowPureFockSimulator(d=3)
+
+    assert error.value.args[0] == (
+        "You have invoked a feature which requires 'tensorflow'.\n"
+        "You can install tensorflow via:\n"
+        "\n"
+        "pip install piquasso[tensorflow]"
+    )
+
+
+def test_importing_Piquasso_does_not_import_tensorflow(unimport_tensorflow):
+    import piquasso as pq  # noqa: F401
+
+    assert "tensorflow" not in sys.modules
+
+
+def test_Piquasso_works_without_TensorFlow(
+    unimport_tensorflow,
+    raise_ImportError_when_importing_tensorflow,
+):
+    import piquasso as pq  # noqa: F401
+
+    assert "tensorflow" not in sys.modules

--- a/tests/backends/test_backend_equivalence.py
+++ b/tests/backends/test_backend_equivalence.py
@@ -17,6 +17,8 @@ import pytest
 import numpy as np
 import piquasso as pq
 
+import collections
+
 from scipy.linalg import polar, sinhm, coshm, expm
 
 
@@ -36,6 +38,7 @@ def is_proportional(first, second):
     (
         pq.GaussianSimulator,
         pq.PureFockSimulator,
+        pq.TensorflowPureFockSimulator,
         pq.FockSimulator,
     ),
 )
@@ -50,7 +53,7 @@ def test_fock_probabilities_should_be_numpy_array_of_floats(SimulatorClass):
 
     probabilities = state.fock_probabilities
 
-    assert isinstance(probabilities, np.ndarray)
+    assert isinstance(probabilities, collections.abc.Iterable)
     assert probabilities.dtype == np.float64
 
 
@@ -59,6 +62,7 @@ def test_fock_probabilities_should_be_numpy_array_of_floats(SimulatorClass):
     (
         pq.GaussianSimulator,
         pq.PureFockSimulator,
+        pq.TensorflowPureFockSimulator,
         pq.FockSimulator,
     ),
 )
@@ -136,6 +140,7 @@ def test_density_matrix_with_squeezed_state():
     (
         pq.GaussianSimulator,
         pq.PureFockSimulator,
+        pq.TensorflowPureFockSimulator,
         pq.FockSimulator,
     ),
 )
@@ -185,6 +190,7 @@ def test_fock_probabilities_with_displaced_state(SimulatorClass):
     (
         pq.PureFockSimulator,
         pq.FockSimulator,
+        pq.TensorflowPureFockSimulator,
         pq.GaussianSimulator,
     ),
 )
@@ -222,6 +228,7 @@ def test_Displacement_equivalence_on_multiple_modes(SimulatorClass):
     (
         pq.GaussianSimulator,
         pq.PureFockSimulator,
+        pq.TensorflowPureFockSimulator,
         pq.FockSimulator,
     ),
 )
@@ -272,6 +279,7 @@ def test_fock_probabilities_with_displaced_state_with_beamsplitter(SimulatorClas
     (
         pq.GaussianSimulator,
         pq.PureFockSimulator,
+        pq.TensorflowPureFockSimulator,
         pq.FockSimulator,
     ),
 )
@@ -322,6 +330,7 @@ def test_fock_probabilities_with_squeezed_state_with_beamsplitter(SimulatorClass
     (
         pq.GaussianSimulator,
         pq.PureFockSimulator,
+        pq.TensorflowPureFockSimulator,
         pq.FockSimulator,
     ),
 )
@@ -351,6 +360,7 @@ def test_fock_probabilities_with_two_single_mode_squeezings(SimulatorClass):
     (
         pq.GaussianSimulator,
         pq.PureFockSimulator,
+        pq.TensorflowPureFockSimulator,
         pq.FockSimulator,
     ),
 )
@@ -377,6 +387,7 @@ def test_Squeezing_equivalence_on_multiple_modes(SimulatorClass):
     (
         pq.GaussianSimulator,
         pq.PureFockSimulator,
+        pq.TensorflowPureFockSimulator,
         pq.FockSimulator,
     ),
 )
@@ -426,6 +437,7 @@ def test_fock_probabilities_with_two_mode_squeezing(SimulatorClass):
     (
         pq.GaussianSimulator,
         pq.PureFockSimulator,
+        pq.TensorflowPureFockSimulator,
         pq.FockSimulator,
     ),
 )
@@ -476,6 +488,7 @@ def test_fock_probabilities_with_two_mode_squeezing_and_beamsplitter(SimulatorCl
     (
         pq.GaussianSimulator,
         pq.PureFockSimulator,
+        pq.TensorflowPureFockSimulator,
         pq.FockSimulator,
     ),
 )
@@ -523,6 +536,7 @@ def test_fock_probabilities_with_quadratic_phase(SimulatorClass):
     (
         pq.GaussianSimulator,
         pq.PureFockSimulator,
+        pq.TensorflowPureFockSimulator,
         pq.FockSimulator,
     ),
 )
@@ -570,6 +584,7 @@ def test_fock_probabilities_with_position_displacement(SimulatorClass):
     (
         pq.GaussianSimulator,
         pq.PureFockSimulator,
+        pq.TensorflowPureFockSimulator,
         pq.FockSimulator,
     ),
 )
@@ -617,6 +632,7 @@ def test_fock_probabilities_with_momentum_displacement(SimulatorClass):
     (
         pq.GaussianSimulator,
         pq.PureFockSimulator,
+        pq.TensorflowPureFockSimulator,
         pq.FockSimulator,
     ),
 )
@@ -645,6 +661,7 @@ def test_fock_probabilities_with_position_displacement_is_HBAR_independent(
     (
         pq.GaussianSimulator,
         pq.PureFockSimulator,
+        pq.TensorflowPureFockSimulator,
         pq.FockSimulator,
     ),
 )
@@ -673,6 +690,7 @@ def test_fock_probabilities_with_momentum_displacement_is_HBAR_independent(
     (
         pq.GaussianSimulator,
         pq.PureFockSimulator,
+        pq.TensorflowPureFockSimulator,
         pq.FockSimulator,
     ),
 )

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ python =
     3.10: py310
 
 [testenv]
+extras = tensorflow
 deps = -rrequirements.txt
 commands =
     flake8
@@ -22,7 +23,7 @@ commands =
     mypy piquasso
     pytest --nbmake docs
     coverage run -m pytest tests -s
-    coverage xml --omit='.tox/*','*/tests/*'
+    coverage xml --omit='.tox/*','*/tests/*','/tmp/*'
     coverage erase
 
 [tox:.package]


### PR DESCRIPTION
A simulator class called `TensorflowPureFockSimulator` has been created,
which supports calculations using Tensorflow.

For this, several calculations had to be rewritten in
`piquasso/_backends/fock/pure/calculations.py`, because in Tensorflow an
`EagerTensor` could not be item assigned. For example, the `squeezing`
and `displacement` calculations had to be rewritten using Python lists.

Also, some modules and functions had to be moved into `BaseCalculator`.
These functions are now implemented in `NumpyCalculator` and in a newly
created `TensorflowCalculator` in a Tensorflow-compatible manner. Most
notably, `numpy` had to be injected, since for Tensorflow calculations
we want to use `tensorflow.experimental.numpy`.

Moreover, the `BaseCalculator` instance had to be injected into some
functions under `piquasso._math` (e.g. `takagi`), since some
calculations are originally non-differentiable by Tensorflow.

The Glyyn-Gray permanent calculation `glynn_gray_permanent` had to be
moved from `theboss` under `piquasso._math.permanent`, since one
couldn't inject the `numpy` module in the original code.

`TensorflowPureFockSimulator` has been tested by computing gradients for
different simulations.

**NOTE**

Only the linear gates get supported in this patch.