### PR TITLE
fix(sampling): Photon detection with uniform loss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [1.0.1] - 2022-09-05
+
+### Fixed
+
+- `SamplingSimulator` along with `Loss` using uniform transmissivity
+  (transmittance) parameters and `ParticleNumberMeasurement` produced only-zero
+  samples instead of the expected samples.
+
+
 ## [1.0.0] - 2022-04-26
 
 ### Added

--- a/piquasso/__init__.py
+++ b/piquasso/__init__.py
@@ -154,4 +154,4 @@ __all__ = [
     "LossyInterferometer",
 ]
 
-__version__ = "1.0.0"
+__version__ = "1.0.1"

--- a/piquasso/_backends/sampling/calculations.py
+++ b/piquasso/_backends/sampling/calculations.py
@@ -169,6 +169,9 @@ def _get_sampling_simulation_strategy(
     _, singular_values, _ = np.linalg.svd(state.interferometer)
 
     if np.all(np.isclose(singular_values, singular_values[0])):
-        return GeneralizedCliffordsUniformLossesSimulationStrategy(permanent_calculator)
+        uniform_transmission_probability = singular_values[0] ** 2
+        return GeneralizedCliffordsUniformLossesSimulationStrategy(
+            permanent_calculator, uniform_transmission_probability
+        )
 
     return LossyNetworksGeneralizedCliffordsSimulationStrategy(permanent_calculator)

--- a/piquasso/instructions/channels.py
+++ b/piquasso/instructions/channels.py
@@ -144,11 +144,17 @@ class Attenuator(Gate):
 
 
 class Loss(Gate, _mixins.ScalingMixin):
-    """Applies a loss channel to the state.
+    r"""Applies a loss channel to the state.
+
+    The transmissivity is defined by :math:`t = \cos \theta`, where :math:`\theta` is
+    the beamsplitter parameter and the angle between the initial and resulting state.
+    Considering only one particle, :math:`1-t^2` is the probability of losing this
+    particle.
 
     Note:
-        Currently, this instruction can only be used along with
+        - Currently, this instruction can only be used along with
         :class:`~piquasso._backends.sampling.simulator.SamplingSimulator`.
+        - The parameter `transmissivity` is usually called `transmittance`.
     """
 
     def __init__(self, transmissivity: np.ndarray) -> None:

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name="piquasso",
-    version="1.0.0",
+    version="1.0.1",
     packages=find_packages(exclude=["tests.*", "tests", "scripts", "scripts.*"]),
     maintainer="Budapest Quantum Computing Group",
     maintainer_email="kolarovszki@inf.elte.hu",

--- a/tests/backends/sampling/test_channels.py
+++ b/tests/backends/sampling/test_channels.py
@@ -1,0 +1,53 @@
+#
+# Copyright 2021-2022 Budapest Quantum Computing Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+
+import piquasso as pq
+
+
+def test_Loss_uniform():
+    with pq.Program() as program:
+        pq.Q() | pq.StateVector([1, 1, 1, 0, 0])
+
+        pq.Q(all) | pq.Loss(transmissivity=0.9)
+
+    simulator = pq.SamplingSimulator(d=5)
+    state = simulator.execute(program, shots=1).state
+
+    assert state.is_lossy
+
+    singular_values = np.linalg.svd(state.interferometer)[1]
+
+    assert np.allclose(singular_values, [0.9, 0.9, 0.9, 0.9, 0.9])
+
+
+def test_Loss_non_uniform():
+    with pq.Program() as program:
+        pq.Q() | pq.StateVector([1, 1, 1, 0, 0])
+
+        pq.Q(0) | pq.Loss(transmissivity=0.4)
+        pq.Q(1) | pq.Loss(transmissivity=0.5)
+
+    simulator = pq.SamplingSimulator(d=5)
+    state = simulator.execute(program, shots=1).state
+
+    assert state.is_lossy
+
+    singular_values = np.linalg.svd(state.interferometer)[1]
+
+    assert len(singular_values[np.isclose(singular_values, 0.4)]) == 1
+    assert len(singular_values[np.isclose(singular_values, 0.5)]) == 1
+    assert len(singular_values[np.isclose(singular_values, 1.0)]) == 3


### PR DESCRIPTION
**Problem**

The lossy boson sampling with uniform losses produced only zero-array
samples.

**Solution**

It turned out, that the class
`GeneralizedCliffordsUniformLossesSimulationStrategy` has an optional
parameter `transmissivity` and Piquasso is supposed to specify that
parameter.

Some tests have been written testing the singular values of the
interferometer after specifying loss.

The documentation of `pq.Loss` was also unclear about the purpose of
`transmissivity`, it has also been updated.