### PR TITLE
refact(gates): Delete `_ScalableFockGates`

### DIFF
--- a/piquasso/_backends/fock/general/calculations.py
+++ b/piquasso/_backends/fock/general/calculations.py
@@ -133,7 +133,7 @@ def annihilate(state: FockState, instruction: Instruction, shots: int) -> Result
 
 
 def kerr(state: FockState, instruction: Instruction, shots: int) -> Result:
-    xi_vector = instruction._all_params["xi"]
+    xi_vector = instruction._all_params["xi_vector"]
 
     for mode_index, mode in enumerate(instruction.modes):
         xi = xi_vector[mode_index]
@@ -154,12 +154,12 @@ def kerr(state: FockState, instruction: Instruction, shots: int) -> Result:
 
 
 def cubic_phase(state: FockState, instruction: Instruction, shots: int) -> Result:
-    gamma = instruction._all_params["gamma"]
+    gamma_vector = instruction._all_params["gamma_vector"]
     hbar = state._config.hbar
 
     for index, mode in enumerate(instruction.modes):
         operator = state._space.get_single_mode_cubic_phase_operator(
-            gamma=gamma[index], hbar=hbar
+            gamma=gamma_vector[index], hbar=hbar
         )
         embedded_operator = state._space.embed_matrix(
             operator,

--- a/piquasso/_backends/fock/pure/calculations.py
+++ b/piquasso/_backends/fock/pure/calculations.py
@@ -186,7 +186,7 @@ def annihilate(state: PureFockState, instruction: Instruction, shots: int) -> Re
 
 
 def kerr(state: PureFockState, instruction: Instruction, shots: int) -> Result:
-    xi_vector = instruction._all_params["xi"]
+    xi_vector = instruction._all_params["xi_vector"]
 
     for mode_index, mode in enumerate(instruction.modes):
         xi = xi_vector[mode_index]
@@ -258,12 +258,12 @@ def squeezing(state: PureFockState, instruction: Instruction, shots: int) -> Res
 
 
 def cubic_phase(state: PureFockState, instruction: Instruction, shots: int) -> Result:
-    gamma = instruction._all_params["gamma"]
+    gamma_vector = instruction._all_params["gamma_vector"]
     hbar = state._config.hbar
 
     for index, mode in enumerate(instruction.modes):
         matrix = state._space.get_single_mode_cubic_phase_operator(
-            gamma=gamma[index], hbar=hbar
+            gamma=gamma_vector[index], hbar=hbar
         )
         _apply_subsystem_representation_to_state(
             state, matrix, (mode,), state._get_auxiliary_modes((mode,))

--- a/piquasso/core/_mixins.py
+++ b/piquasso/core/_mixins.py
@@ -80,6 +80,11 @@ class CodeMixin(abc.ABC):
 
 
 class ScalingMixin(abc.ABC):
+    ERROR_MESSAGE_TEMPLATE = (
+        "The instruction {instruction} is not applicable to modes {modes} with the "
+        "specified parameters."
+    )
+
     @abc.abstractmethod
     def _autoscale(self) -> None:
         pass


### PR DESCRIPTION
The class `_ScalableFockGates` got deleted, since this class should not exist. The two subclasses `CubicPhase` and `Kerr` have different parameters, and the current logic inserted e.g. a redundant `"gamma": None` entry in the `Kerr._extra_params`.

Instead, the logic has been separated to the two subclasses `CubicPhase` and `Kerr`.

Also, it is very confusing that there is two `"gamma"` and `"xi"` keys in `CubicPhase` and `Kerr` respectively, precisely one in the `_params` and one in the `_extra_params` attribute. The one in the `_extra_params` attribute got a `_vector` suffix to avoid ambiguity.