### PR TITLE
dev(requirements): `flake8` upgrade

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ pytest-profiling~=1.7.0
 pytest-benchmark~=3.4.1
 coverage~=6.3.2
 mypy~=0.942
-flake8~=4.0.1
+flake8~=5.0.4
 nbqa~=1.3.1
 nbmake~=1.3.0
 


### PR DESCRIPTION
The pipeline run resulted in the following error:
```
AttributeError: 'EntryPoints' object has no attribute 'get'
```
It is because `flake8==4.0.1` might used a deprecated endpoint of `importlib_metadata`. Therefore it has been upgraded.

Source:
- https://importlib-metadata.readthedocs.io/en/latest/history.html