### PR TITLE
perf(tensorflow): `scatter`

### DIFF
--- a/piquasso/_backends/calculator.py
+++ b/piquasso/_backends/calculator.py
@@ -47,11 +47,11 @@ class NumpyCalculator(BaseCalculator):
 
         return array
 
-    def to_dense(self, index_map, dim):
+    def scatter(self, indices, updates, dim):
         embedded_matrix = np.zeros((dim,) * 2, dtype=complex)
+        composite_index = np.array(indices)[:, 0], np.array(indices)[:, 1]
 
-        for index, value in index_map.items():
-            embedded_matrix[index] = value
+        embedded_matrix[composite_index] = np.array(updates)
 
         return embedded_matrix
 

--- a/piquasso/_math/fock.py
+++ b/piquasso/_math/fock.py
@@ -313,7 +313,8 @@ class FockSpace(tuple):
         modes: Tuple[int, ...],
         auxiliary_modes: Tuple[int, ...],
     ) -> np.ndarray:
-        index_map = {}
+        indices = []
+        updates = []
 
         for embedded_index, operator_basis in self.operator_basis_diagonal_on_modes(
             modes=auxiliary_modes
@@ -323,9 +324,10 @@ class FockSpace(tuple):
                 operator_basis.bra.on_modes(modes=modes),
             )
 
-            index_map[embedded_index] = matrix[index][0]
+            indices.append(embedded_index)
+            updates.append(matrix[index][0])
 
-        return self._calculator.to_dense(index_map, dim=self.cardinality)
+        return self._calculator.scatter(indices, updates, dim=self.cardinality)
 
     def get_linear_fock_operator(
         self,

--- a/piquasso/api/calculator.py
+++ b/piquasso/api/calculator.py
@@ -56,7 +56,7 @@ class BaseCalculator(abc.ABC):
     def assign(self, array, index, value):
         raise NotImplementedCalculation()
 
-    def to_dense(self, index_map, dim):
+    def scatter(self, indices, updates, dim):
         raise NotImplementedCalculation()
 
     def embed_in_identity(self, matrix, indices, dim):

--- a/tests/api/test_calculator.py
+++ b/tests/api/test_calculator.py
@@ -80,11 +80,11 @@ def test_BaseCalculator_raises_NotImplementedCalculation_for_assign(
         empty_calculator.assign(dummy_array, index=0, value=3)
 
 
-def test_BaseCalculator_raises_NotImplementedCalculation_for_to_dense(
+def test_BaseCalculator_raises_NotImplementedCalculation_for_scatter(
     empty_calculator,
 ):
     with pytest.raises(NotImplementedCalculation):
-        empty_calculator.to_dense(index_map={(0, 1): 3}, dim=2)
+        empty_calculator.scatter(indices=[], updates=[], dim=2)
 
 
 def test_BaseCalculator_raises_NotImplementedCalculation_for_embed_in_identity(


### PR DESCRIPTION
The `to_dense` method in `TensorflowCalculator` has been rewritten to use `tensorflow.scatter_nd`, since it is faster than basic Python indexing.

The method name got updated to `scatter` and the arguments got updated accordingly.

`NumpyCalculator.to_dense` has been updated similarly. There I couldn't find an exact counterpart to `tensorflow.scatter_nd`, but it is solved with some smart indexing.