### PR TITLE
perf(fock): Recursion rule for interferometer

### DIFF
--- a/benchmarks/purefock_beamsplitter_increasing_cutoff_benchmark.py
+++ b/benchmarks/purefock_beamsplitter_increasing_cutoff_benchmark.py
@@ -1,0 +1,67 @@
+#
+# Copyright 2021-2022 Budapest Quantum Computing Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+import numpy as np
+
+import piquasso as pq
+import strawberryfields as sf
+
+
+pytestmark = pytest.mark.benchmark(
+    group="pure-fock",
+)
+
+
+@pytest.fixture
+def theta():
+    return np.pi / 5
+
+
+@pytest.fixture
+def d():
+    return 5
+
+
+@pytest.mark.parametrize("cutoff", (3, 4, 5, 6))
+def piquasso_benchmark(benchmark, d, cutoff, theta):
+    @benchmark
+    def func():
+        with pq.Program() as program:
+            pq.Q() | pq.Vacuum()
+            pq.Q(1) | pq.Squeezing(0.1)
+            for i in range(d - 1):
+                pq.Q(i, i + 1) | pq.Beamsplitter(theta)
+
+        simulator_fock = pq.PureFockSimulator(d=d, config=pq.Config(cutoff=cutoff))
+
+        simulator_fock.execute(program)
+
+
+@pytest.mark.parametrize("cutoff", (3, 4, 5, 6))
+def strawberryfields_benchmark(benchmark, d, cutoff, theta):
+    @benchmark
+    def func():
+        eng = sf.Engine(backend="fock", backend_options={"cutoff_dim": cutoff})
+
+        circuit = sf.Program(d)
+
+        with circuit.context as q:
+            sf.ops.Sgate(0.1) | q[1]
+            for w in range(d - 1):
+                sf.ops.BSgate(theta) | (q[w], q[w + 1])
+
+        eng.run(circuit).state

--- a/benchmarks/purefock_beamsplitter_increasing_modes_benchmark.py
+++ b/benchmarks/purefock_beamsplitter_increasing_modes_benchmark.py
@@ -1,0 +1,67 @@
+#
+# Copyright 2021-2022 Budapest Quantum Computing Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+import numpy as np
+
+import piquasso as pq
+import strawberryfields as sf
+
+
+pytestmark = pytest.mark.benchmark(
+    group="pure-fock-beamsplitter-increasing-modes",
+)
+
+
+@pytest.fixture
+def theta():
+    return np.pi / 5
+
+
+@pytest.fixture
+def cutoff():
+    return 5
+
+
+@pytest.mark.parametrize("d", (3, 4, 5, 6))
+def piquasso_benchmark(benchmark, d, cutoff, theta):
+    @benchmark
+    def func():
+        with pq.Program() as program:
+            pq.Q() | pq.Vacuum()
+            pq.Q(1) | pq.Squeezing(0.1)
+            for i in range(d - 1):
+                pq.Q(i, i + 1) | pq.Beamsplitter(theta)
+
+        simulator_fock = pq.PureFockSimulator(d=d, config=pq.Config(cutoff=cutoff))
+
+        simulator_fock.execute(program)
+
+
+@pytest.mark.parametrize("d", (3, 4, 5, 6))
+def strawberryfields_benchmark(benchmark, d, cutoff, theta):
+    @benchmark
+    def func():
+        eng = sf.Engine(backend="fock", backend_options={"cutoff_dim": cutoff})
+
+        circuit = sf.Program(d)
+
+        with circuit.context as q:
+            sf.ops.Sgate(0.1) | q[1]
+            for w in range(d - 1):
+                sf.ops.BSgate(theta) | (q[w], q[w + 1])
+
+        eng.run(circuit).state

--- a/benchmarks/purefock_clements_interferometer_comparison_benchmark.py
+++ b/benchmarks/purefock_clements_interferometer_comparison_benchmark.py
@@ -1,0 +1,83 @@
+#
+# Copyright 2021-2022 Budapest Quantum Computing Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+import numpy as np
+
+import piquasso as pq
+from piquasso.decompositions.clements import Clements
+
+from scipy.stats import unitary_group
+
+pytestmark = pytest.mark.benchmark(
+    group="pure-fock-clements-comparison",
+)
+
+
+@pytest.fixture
+def cutoff():
+    return 5
+
+
+d_tuple = (2, 3, 4, 5)
+U_tuple = tuple([unitary_group.rvs(d) for d in d_tuple])
+
+
+@pytest.mark.parametrize("d, U", zip(d_tuple, U_tuple))
+def piquasso_interferometer_benchmark(benchmark, d, cutoff, U):
+    @benchmark
+    def func():
+        with pq.Program() as program:
+            pq.Q() | pq.Vacuum()
+            pq.Q() | pq.Squeezing(r=0.1)
+
+            pq.Q() | pq.Interferometer(U)
+
+        simulator_fock = pq.PureFockSimulator(d=d, config=pq.Config(cutoff=cutoff))
+
+        simulator_fock.execute(program)
+
+
+@pytest.mark.parametrize("d, U", zip(d_tuple, U_tuple))
+def piquasso_clements_benchmark(benchmark, d, cutoff, U):
+
+    decomposition = Clements(U)
+
+    @benchmark
+    def func():
+        with pq.Program() as program:
+            pq.Q() | pq.Vacuum()
+            pq.Q() | pq.Squeezing(r=0.1)
+
+            for operation in decomposition.inverse_operations:
+                pq.Q(operation["modes"][0]) | pq.Phaseshifter(
+                    phi=operation["params"][1]
+                )
+                pq.Q(*operation["modes"]) | pq.Beamsplitter(operation["params"][0], 0.0)
+
+                pq.Q() | pq.Phaseshifter(np.angle(decomposition.diagonals))
+
+            for operation in reversed(decomposition.direct_operations):
+                pq.Q(*operation["modes"]) | pq.Beamsplitter(
+                    operation["params"][0], np.pi
+                )
+                pq.Q(operation["modes"][0]) | pq.Phaseshifter(
+                    phi=-operation["params"][1]
+                )
+
+        simulator_fock = pq.PureFockSimulator(d=d, config=pq.Config(cutoff=cutoff))
+
+        simulator_fock.execute(program)

--- a/benchmarks/purefock_interferometer_increasing_modes_benchmark.py
+++ b/benchmarks/purefock_interferometer_increasing_modes_benchmark.py
@@ -1,0 +1,73 @@
+#
+# Copyright 2021-2022 Budapest Quantum Computing Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+import numpy as np
+
+import piquasso as pq
+import strawberryfields as sf
+
+from scipy.stats import unitary_group
+
+
+pytestmark = pytest.mark.benchmark(
+    group="pure-fock-interferometer-increasing-modes",
+)
+
+
+@pytest.fixture
+def theta():
+    return np.pi / 5
+
+
+@pytest.fixture
+def cutoff():
+    return 4
+
+
+parameters = [(d, unitary_group.rvs(d)) for d in range(3, 6)]
+
+
+@pytest.mark.parametrize("d, interferometer", parameters)
+def piquasso_benchmark(benchmark, d, interferometer, cutoff, theta):
+    @benchmark
+    def func():
+        with pq.Program() as program:
+            pq.Q(all) | pq.StateVector([1] * 3 + [0] * (d - 3))
+
+            pq.Q(all) | pq.Interferometer(interferometer)
+
+        simulator_fock = pq.PureFockSimulator(d=d, config=pq.Config(cutoff=cutoff))
+
+        simulator_fock.execute(program)
+
+
+@pytest.mark.parametrize("d, interferometer", parameters)
+def strawberryfields_benchmark(benchmark, d, interferometer, cutoff, theta):
+    @benchmark
+    def func():
+        eng = sf.Engine(backend="fock", backend_options={"cutoff_dim": cutoff})
+
+        circuit = sf.Program(d)
+
+        with circuit.context as q:
+            sf.ops.Fock(1) | q[0]
+            sf.ops.Fock(1) | q[1]
+            sf.ops.Fock(1) | q[2]
+
+            sf.ops.Interferometer(interferometer) | tuple(q[i] for i in range(d))
+
+        eng.run(circuit)

--- a/piquasso/_math/indices.py
+++ b/piquasso/_math/indices.py
@@ -51,3 +51,10 @@ def get_index_in_fock_space(element: Tuple[int, ...]) -> int:
             for i in range(1, len(element) + 1)
         ]
     )
+
+
+@functools.lru_cache()
+def get_index_in_fock_subspace(element: Tuple[int, ...]) -> int:
+    return sum(
+        [comb(sum(element[-i:]) + i - 1, i, exact=True) for i in range(1, len(element))]
+    )

--- a/tests/_math/test_indices.py
+++ b/tests/_math/test_indices.py
@@ -17,6 +17,7 @@ import pytest
 
 from piquasso._math.indices import (
     get_index_in_fock_space,
+    get_index_in_fock_subspace,
 )
 
 
@@ -68,3 +69,53 @@ def test_get_index_in_fock_space_for_2_particles(vector, index):
 )
 def test_get_index_in_fock_space_for_3_particles(vector, index):
     assert get_index_in_fock_space(vector) == index
+
+
+def test_get_index_in_fock_subspace_for_0_particles():
+    assert get_index_in_fock_subspace((0, 0, 0)) == 0
+
+
+@pytest.mark.parametrize(
+    "vector, index",
+    [
+        ((0, 0, 1), 2),
+        ((0, 1, 0), 1),
+        ((1, 0, 0), 0),
+    ],
+)
+def test_get_index_in_fock_subspace_for_1_particle(vector, index):
+    assert get_index_in_fock_subspace(vector) == index
+
+
+@pytest.mark.parametrize(
+    "vector, index",
+    [
+        ((0, 0, 2), 5),
+        ((0, 1, 1), 4),
+        ((0, 2, 0), 3),
+        ((1, 0, 1), 2),
+        ((1, 1, 0), 1),
+        ((2, 0, 0), 0),
+    ],
+)
+def test_get_index_in_fock_subspace_for_2_particles(vector, index):
+    assert get_index_in_fock_subspace(vector) == index
+
+
+@pytest.mark.parametrize(
+    "vector, index",
+    [
+        ((0, 0, 3), 9),
+        ((0, 1, 2), 8),
+        ((0, 2, 1), 7),
+        ((0, 3, 0), 6),
+        ((1, 0, 2), 5),
+        ((1, 1, 1), 4),
+        ((1, 2, 0), 3),
+        ((2, 0, 1), 2),
+        ((2, 1, 0), 1),
+        ((3, 0, 0), 0),
+    ],
+)
+def test_get_index_in_fock_subspace_for_3_particles(vector, index):
+    assert get_index_in_fock_subspace(vector) == index


### PR DESCRIPTION
Previously, the interferometer matrix on the Fock space was calculated using permanents. However, it is faster to calculate it using a recursion rule cited, therefore it has been reimplemented.

Benchmarks have been written testing against Xanadu's Strawberryfields and against Clements decompositing the interferometer.

Sources:
- [Fast optimization of parametrized quantum optical circuits](https://quantum-journal.org/papers/q-2020-11-30-366/)