### PR TITLE
FIX(gaussian): Fix fidelity calculation

### DIFF
--- a/piquasso/_backends/gaussian/state.py
+++ b/piquasso/_backends/gaussian/state.py
@@ -16,7 +16,6 @@
 from typing import Tuple, List
 
 import numpy as np
-from scipy.linalg import sqrtm
 
 from piquasso.api.config import Config
 from piquasso.api.exceptions import InvalidState, InvalidParameter, PiquassoException
@@ -28,7 +27,7 @@ from piquasso._math.linalg import (
     is_symmetric,
     is_positive_semidefinite,
 )
-from piquasso._math.symplectic import symplectic_form, xp_symplectic_form
+from piquasso._math.symplectic import symplectic_form
 from piquasso._math.combinatorics import get_occupation_numbers
 from piquasso._math.transformations import from_xxpp_to_xpxp_transformation_matrix
 
@@ -621,66 +620,99 @@ class GaussianState(State):
         :math:`\rho_1, \rho_2` is given by:
 
         .. math::
-            \operatorname{F}(\rho_1, \rho_2) = \operatorname{Tr}(\sqrt{\sqrt{\rho_1}
-                \rho_2\sqrt{\rho_1}})^2
+            \operatorname{F}(\rho_1, \rho_2) = \left [
+                \operatorname{Tr} \sqrt{\sqrt{\rho_1}
+                \rho_2 \sqrt{\rho_1} }
+            \right ]
 
-        A gaussian state can be represented by its Covariance matrix and the vector of
-        Means. Hence, the above equation can be rewritten as:
+        A Gaussian state can be represented by its covariance matrix and displacement
+        vector.
 
-        .. math::
-            \operatorname{F} = \operatorname{F_0}(V_1, V_2) \exp(
-                -\frac{1}{2} \delta_u^T(V_1 + V_2)^{-1}\delta_u^T)
-
-        where :math:`V` is the :attr:`xpxp_covariance_matrix` of the gaussian state,
-        :math:`\delta_u` is the difference between mean vectors of the two gaussian
-        states represented by :attr:`xpxp_mean_vector`, and :math:`F_0` is given by:
-
-        .. math::
-            \operatorname{F_0} = \sqrt{\det{[2(\sqrt{I +
-                \frac{(V_{aux}\Omega)^-2}{4}} + I)V_{aux}]} \det{[(V_1 + V_2)^{-1}]}}
-
-        where :math:`V_{aux}` is given by
+        Let :math:`\mu_1, \mu_2` be the displacement vectors and
+        :math:`\sigma_1, \sigma_2` be the covariance matrices of the
+        :math:`\rho_1, \rho_2` Gaussian states, respectively. Define
+        :math:`\hat{\sigma} = \frac{\sigma_1 + \sigma_2}{2}` and
+        :math:`\Delta\mu = \mu_2 - \mu_1`.
+        The fidelity can be written as
 
         .. math::
-            \Omega^T (V_1 + V_2)^{-1} (\frac{\Omega}{4} V_2 \Omega V_1)
+            \operatorname{F}(\rho_1, \rho_2) = \operatorname{F_0}(\sigma_1, \sigma_2)
+            \exp \left(
+                -\frac{1}{4} \Delta\mu^T (\hat{\sigma})^{-1} \Delta\mu
+            \right),
 
-        and :math:`\Omega` is a symplectic matrix of shape :math:`2*d \times 2*d`.
-        For more details please check:
-        https://journals.aps.org/prl/abstract/10.1103/PhysRevLett.115.260501.
+        where :math:`F_0` can be written as
+
+        .. math::
+            \operatorname{F_0} = \frac{
+                \prod_{i=1}^d \left [w_i + \sqrt{w_i^2 - 1} \right]
+            }{
+                \sqrt{\det \hat{\sigma}}
+            },
+
+        where :math:`w_i \geq 1` and :math:`\pm w_i` are the eigenvalues of the matrix
+
+        .. math::
+            W := - \frac{i}{2} \Omega^T \hat{\sigma}^{-1} \left(
+                I - \sigma_2 \Omega \sigma_1 \Omega
+            \right)
+
+        and
+
+        .. math::
+            \Omega = \begin{bmatrix}
+                0 & 1 \\-1 & 0
+            \end{bmatrix} \otimes I_{2d \times 2d}.
+
+        References:
+            - `Quantum fidelity for arbitrary Gaussian states <https://journals.aps.org/prl/abstract/10.1103/PhysRevLett.115.260501>`_.
+
+        Note:
+            In this notation :math:`\sqrt{\hbar} \mu_i` is equivalent to
+            :attr:`xpxp_mean_vector` and :math:`\hbar \sigma_i` is equivalent to
+            :attr:`xpxp_covariance_matrix`.
 
         Args:
-            state: A gaussian state
-                :class:`~piquasso._backends.gaussian.state.GaussianState` that can be
-                used to calculate the fidelity aganist it.
+            state: Another :class:`~piquasso._backends.gaussian.state.GaussianState`
+                instance.
 
         Returns:
             float: The calculated fidelity.
-        """
-        mean_1, cov_1 = (
-            self.xpxp_mean_vector,
-            self.xpxp_covariance_matrix / (2 * self._config.hbar),
+        """  # noqa: E501
+        hbar = self._config.hbar
+
+        sigma_1 = self.xpxp_covariance_matrix / hbar
+        sigma_2 = state.xpxp_covariance_matrix / hbar
+
+        sigma_mean = (sigma_1 + sigma_2) / 2
+
+        Omega = symplectic_form(self.d)
+
+        Id = np.identity(2 * self.d)
+
+        W_aux = (
+            -1j
+            / 2
+            * Omega.T
+            @ np.linalg.inv(sigma_mean)
+            @ (Id - sigma_2 @ Omega @ sigma_1 @ Omega)
         )
-        mean_2, cov_2 = (
-            state.xpxp_mean_vector,
-            state.xpxp_covariance_matrix / (2 * state._config.hbar),
+
+        eigenvalues = np.linalg.eigvals(W_aux)
+        positive_eigenvalues = eigenvalues[eigenvalues >= 0]
+
+        F_0 = np.prod(
+            [w + np.sqrt(w**2 - 1) for w in positive_eigenvalues]
+        ) / np.sqrt(np.linalg.det(sigma_mean))
+
+        mu_1 = self.xpxp_mean_vector / np.sqrt(hbar)
+        mu_2 = state.xpxp_mean_vector / np.sqrt(hbar)
+        delta_mu = mu_2 - mu_1
+        displaced_contribition = np.exp(
+            -1 / 2 * delta_mu @ np.linalg.inv(sigma_mean) @ delta_mu
         )
 
-        W = xp_symplectic_form(self.d)
-        ident = np.identity(self.d * 2, dtype=complex)
-
-        sum_cov_inv = np.linalg.inv(cov_1 + cov_2)
-        V_aux = W.T @ sum_cov_inv @ (0.25 * W + cov_2 @ W @ cov_1)
-        delta_mu = (mean_1 - mean_2) / np.sqrt(self._config.hbar)
-
-        f1 = np.exp(-0.5 * delta_mu @ sum_cov_inv @ delta_mu)
-        f_total = (
-            2
-            * (sqrtm(ident + 0.25 * np.linalg.inv(V_aux @ W @ V_aux @ W)) + ident)
-            @ V_aux
-        )
-        f_total = np.sqrt(np.linalg.det(f_total) * np.linalg.det(sum_cov_inv))
-
-        return float((f_total * f1).real)
+        return np.real(displaced_contribition * F_0)
 
     def quadratic_polynomial_expectation(
         self, A: np.ndarray, b: np.ndarray, c: float = 0.0, phi: float = 0.0

--- a/tests/backends/test_backend_equivalence.py
+++ b/tests/backends/test_backend_equivalence.py
@@ -953,7 +953,7 @@ def test_wigner_function_equivalence():
         pq.FockSimulator,
     ),
 )
-def test_fidelity(SimulatorClass):
+def test_fidelity_for_1_mode(SimulatorClass):
     with pq.Program() as program_1:
         pq.Q() | pq.Vacuum()
         pq.Q(0) | pq.Squeezing(r=0.2, phi=-np.pi / 3)
@@ -971,6 +971,140 @@ def test_fidelity(SimulatorClass):
     fidelity = state_1.fidelity(state_2)
 
     assert np.isclose(fidelity, 0.9421652615828)
+    assert np.isclose(fidelity, state_2.fidelity(state_1))
+
+
+@pytest.mark.parametrize(
+    "SimulatorClass",
+    (
+        pq.GaussianSimulator,
+        pq.PureFockSimulator,
+        pq.FockSimulator,
+    ),
+)
+def test_fidelity_for_nondisplaced_states_on_2_modes(SimulatorClass):
+    with pq.Program() as program_1:
+        pq.Q() | pq.Vacuum()
+
+        pq.Q(all) | pq.Squeezing([0.1, 0.2])
+        pq.Q(all) | pq.Beamsplitter(theta=np.pi / 3, phi=np.pi / 7)
+
+    with pq.Program() as program_2:
+        pq.Q() | pq.Vacuum()
+
+        pq.Q(all) | pq.Squeezing([0.3, 0.1])
+        pq.Q(all) | pq.Beamsplitter(theta=np.pi / 4, phi=np.pi / 9)
+
+    simulator = SimulatorClass(d=2, config=pq.Config(cutoff=9))
+
+    state_1 = simulator.execute(program_1).state
+    state_2 = simulator.execute(program_2).state
+    fidelity = state_1.fidelity(state_2)
+
+    assert np.isclose(fidelity, 0.9735085877314046)
+    assert np.isclose(fidelity, state_2.fidelity(state_1))
+
+
+@pytest.mark.parametrize(
+    "SimulatorClass",
+    (
+        pq.GaussianSimulator,
+        pq.PureFockSimulator,
+        pq.FockSimulator,
+    ),
+)
+def test_fidelity_for_displaced_states_on_2_modes(SimulatorClass):
+    with pq.Program() as program_1:
+        pq.Q() | pq.Vacuum()
+
+        pq.Q(all) | pq.Displacement(alpha=[0.4, 0.5])
+        pq.Q(all) | pq.Squeezing([0.1, 0.2])
+        pq.Q(all) | pq.Beamsplitter(theta=np.pi / 3, phi=np.pi / 7)
+
+    with pq.Program() as program_2:
+        pq.Q() | pq.Vacuum()
+
+        pq.Q(all) | pq.Displacement(alpha=[0.5, 0.4])
+        pq.Q(all) | pq.Squeezing([0.3, 0.1])
+        pq.Q(all) | pq.Beamsplitter(theta=np.pi / 4, phi=np.pi / 9)
+
+    simulator = SimulatorClass(d=2, config=pq.Config(cutoff=10))
+
+    state_1 = simulator.execute(program_1).state
+    state_2 = simulator.execute(program_2).state
+    fidelity = state_1.fidelity(state_2)
+
+    assert np.isclose(fidelity, 0.9346675071279842)
+    assert np.isclose(fidelity, state_2.fidelity(state_1))
+
+
+@pytest.mark.parametrize(
+    "SimulatorClass",
+    (
+        pq.GaussianSimulator,
+        pq.PureFockSimulator,
+        pq.FockSimulator,
+    ),
+)
+def test_fidelity_for_nondisplaced_pure_states_on_3_modes(SimulatorClass):
+    with pq.Program() as program_1:
+        pq.Q() | pq.Vacuum()
+
+        pq.Q(all) | pq.Displacement(alpha=[0.04, 0.05, 0.1])
+        pq.Q(all) | pq.Squeezing([0.01, 0.02, 0.03])
+        pq.Q(0, 1) | pq.Beamsplitter(theta=np.pi / 3, phi=np.pi / 7)
+        pq.Q(1, 2) | pq.Beamsplitter(theta=np.pi / 4, phi=np.pi / 9)
+
+    with pq.Program() as program_2:
+        pq.Q() | pq.Vacuum()
+
+        pq.Q(all) | pq.Displacement(alpha=[0.05, 0.04, 0.02])
+        pq.Q(all) | pq.Squeezing([0.03, 0.01, 0.02])
+        pq.Q(0, 1) | pq.Beamsplitter(theta=np.pi / 2, phi=np.pi / 9)
+        pq.Q(1, 2) | pq.Beamsplitter(theta=np.pi / 5, phi=np.pi / 3)
+
+    simulator = SimulatorClass(d=3, config=pq.Config(cutoff=7))
+
+    state_1 = simulator.execute(program_1).state
+    state_2 = simulator.execute(program_2).state
+    fidelity = state_1.fidelity(state_2)
+
+    assert np.isclose(fidelity, 0.9889124929545777)
+    assert np.isclose(fidelity, state_2.fidelity(state_1))
+
+
+@pytest.mark.parametrize(
+    "SimulatorClass",
+    (
+        pq.GaussianSimulator,
+        pq.PureFockSimulator,
+        pq.FockSimulator,
+    ),
+)
+def test_fidelity_for_nondisplaced_mixed_states_on_3_modes(SimulatorClass):
+    with pq.Program() as program_1:
+        pq.Q() | pq.Vacuum()
+
+        pq.Q(all) | pq.Displacement(alpha=[0.04, 0.05, 0.1])
+        pq.Q(all) | pq.Squeezing([0.01, 0.02, 0.03])
+        pq.Q(0, 1) | pq.Beamsplitter(theta=np.pi / 3, phi=np.pi / 7)
+        pq.Q(1, 2) | pq.Beamsplitter(theta=np.pi / 4, phi=np.pi / 9)
+
+    with pq.Program() as program_2:
+        pq.Q() | pq.Vacuum()
+
+        pq.Q(all) | pq.Displacement(alpha=[0.05, 0.04, 0.02])
+        pq.Q(all) | pq.Squeezing([0.03, 0.01, 0.02])
+        pq.Q(0, 1) | pq.Beamsplitter(theta=np.pi / 2, phi=np.pi / 9)
+        pq.Q(1, 2) | pq.Beamsplitter(theta=np.pi / 5, phi=np.pi / 3)
+
+    simulator = SimulatorClass(d=3, config=pq.Config(cutoff=7))
+
+    state_1 = simulator.execute(program_1).state.reduced(modes=(0, 1))
+    state_2 = simulator.execute(program_2).state.reduced(modes=(0, 1))
+    fidelity = state_1.fidelity(state_2)
+
+    assert np.isclose(fidelity, 0.9959871270027937)
     assert np.isclose(fidelity, state_2.fidelity(state_1))
 
 


### PR DESCRIPTION
**Problem**

The `GaussianState.fidelity` method could return values larger than 1 for modes greater than 1.

**Solution**

The fidelity calculation got reimplemented.

During implementation, a different set of equations got used for efficiency.

More tests have been written testing multimode states and mixed states as well.

Sources:
- [Quantum fidelity for arbitrary Gaussian states](https://journals.aps.org/prl/abstract/10.1103/PhysRevLett.115.260501)