### PR TITLE
dev(requirements.txt): Freezing mypy version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ pytest~=7.1.1
 pytest-profiling~=1.7.0
 pytest-benchmark~=3.4.1
 coverage~=6.3.2
-mypy~=0.942
+mypy==0.981
 flake8~=5.0.4
 nbqa~=1.3.1
 nbmake~=1.3.0


### PR DESCRIPTION
`mypy` version is set to 0.981, since for Python 3.10.7 `mypy` and `numpy`
together yields the following error:
```
.tox/py310/lib/python3.10/site-packages/numpy/__init__.pyi:638: error:
Positional-only parameters are only supported in Python 3.8 and greater
```

Source:
- https://github.com/python/mypy/issues/13627