### PR TITLE
FIX(fock): Fidelity precision

### DIFF
--- a/piquasso/_backends/fock/pure/state.py
+++ b/piquasso/_backends/fock/pure/state.py
@@ -224,3 +224,11 @@ class PureFockState(BaseFockState):
             accumulator += number * self._np.abs(self._state_vector[index]) ** 2
 
         return accumulator
+
+    def fidelity(self, state: "BaseFockState") -> float:
+        if isinstance(state, self.__class__):
+            return (
+                np.abs(np.sum(np.conj(state._state_vector) @ self._state_vector)) ** 2
+            )
+
+        return super().fidelity(state)

--- a/piquasso/_backends/fock/state.py
+++ b/piquasso/_backends/fock/state.py
@@ -212,7 +212,7 @@ class BaseFockState(State, abc.ABC):
 
         .. math::
             \operatorname{F}(\rho_1, \rho_2) = \operatorname{Tr}(\sqrt{\sqrt{\rho_1}
-                \rho_2\sqrt{\rho_1}})^2
+                \rho_2\sqrt{\rho_1}})^2 = \operatorname{Tr}(\sqrt{\rho_1 \rho_2})^2 
 
         Args:
             state: Either a :class:`~piquasso._backends.fock.pure.state.PureFockState`
@@ -222,9 +222,5 @@ class BaseFockState(State, abc.ABC):
         Returns:
             float: The calculated fidelity.
         """
-
-        sqrt_density_1 = sqrtm(self.density_matrix)
-        f = sqrtm(sqrt_density_1 @ state.density_matrix @ sqrt_density_1)
-        # Trace norm of the matrix. For more details please check:
-        # https://www.quantiki.org/wiki/trace-norm
-        return float((np.linalg.norm(f, ord="nuc") ** 2).real)
+        geometric_mean = np.sqrt(np.linalg.eigvals(self.density_matrix @ state.density_matrix))
+        return np.abs(np.sum(geometric_mean))**2


### PR DESCRIPTION
**Problem**

In `scipy` version 1.10.0 `sqrtm` returned with an array with type `complex256` but `numpy.linalg` returned with the following error:
```
TypeError: array type complex256 is unsupported in linalg
```
Casting it to `complex128` resulted in inaccurate fidelity values, however.

**Solution**

A less computationally demanding expression for the fidelity is used. For comparison, an expression for the fidelity between pure states have been also implemented.