### PR TITLE
chore: MyPy requires `Optional` for `None` default

### DIFF
--- a/piquasso/_backends/fock/general/state.py
+++ b/piquasso/_backends/fock/general/state.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Tuple, Any, Generator, Dict
+from typing import Optional, Tuple, Any, Generator, Dict
 
 import numpy as np
 from piquasso.api.calculator import BaseCalculator
@@ -35,7 +35,7 @@ class FockState(BaseFockState):
     """
 
     def __init__(
-        self, *, d: int, calculator: BaseCalculator, config: Config = None
+        self, *, d: int, calculator: BaseCalculator, config: Optional[Config] = None
     ) -> None:
         """
         Args:

--- a/piquasso/_backends/fock/pure/calculations.py
+++ b/piquasso/_backends/fock/pure/calculations.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Tuple, Mapping
+from typing import Optional, Tuple, Mapping
 
 import random
 import numpy as np
@@ -406,7 +406,7 @@ def _add_occupation_number_basis(  # type: ignore
     state: PureFockState,
     coefficient: complex,
     occupation_numbers: Tuple[int, ...],
-    modes: Tuple[int, ...] = None,
+    modes: Optional[Tuple[int, ...]] = None,
 ) -> None:
     if modes:
         occupation_numbers = state._space.get_occupied_basis(

--- a/piquasso/_backends/fock/pure/state.py
+++ b/piquasso/_backends/fock/pure/state.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Tuple, Generator, Any, Dict
+from typing import Optional, Tuple, Generator, Any, Dict
 
 import numpy as np
 
@@ -41,7 +41,7 @@ class PureFockState(BaseFockState):
     """
 
     def __init__(
-        self, *, d: int, calculator: BaseCalculator, config: Config = None
+        self, *, d: int, calculator: BaseCalculator, config: Optional[Config] = None
     ) -> None:
         """
         Args:

--- a/piquasso/_backends/fock/state.py
+++ b/piquasso/_backends/fock/state.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Tuple, Generator, Any, Dict, List
+from typing import Optional, Tuple, Generator, Any, Dict, List
 
 import abc
 import numpy as np
@@ -27,7 +27,7 @@ from piquasso.api.exceptions import InvalidModes
 
 class BaseFockState(State, abc.ABC):
     def __init__(
-        self, *, d: int, calculator: BaseCalculator, config: Config = None
+        self, *, d: int, calculator: BaseCalculator, config: Optional[Config] = None
     ) -> None:
         super().__init__(calculator=calculator, config=config)
 
@@ -95,7 +95,7 @@ class BaseFockState(State, abc.ABC):
         self,
         positions: List[float],
         momentums: List[float],
-        modes: Tuple[int, ...] = None,
+        modes: Optional[Tuple[int, ...]] = None,
     ) -> np.ndarray:
         r"""
         This method calculates the Wigner function values at the specified position and

--- a/piquasso/_backends/gaussian/state.py
+++ b/piquasso/_backends/gaussian/state.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Tuple, List
+from typing import Optional, Tuple, List
 
 import numpy as np
 
@@ -42,7 +42,7 @@ class GaussianState(State):
     r"""Class to represent a Gaussian state."""
 
     def __init__(
-        self, d: int, calculator: BaseCalculator, config: Config = None
+        self, d: int, calculator: BaseCalculator, config: Optional[Config] = None
     ) -> None:
         """
         Args:
@@ -794,7 +794,7 @@ class GaussianState(State):
         self,
         positions: List[List[float]],
         momentums: List[List[float]],
-        modes: Tuple[int, ...] = None,
+        modes: Optional[Tuple[int, ...]] = None,
     ) -> np.ndarray:
         r"""
         This method calculates the Wigner function values at the specified position and

--- a/piquasso/_backends/sampling/state.py
+++ b/piquasso/_backends/sampling/state.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Tuple, List
+from typing import Optional, Tuple, List
 import numpy as np
 
 from piquasso._math.combinatorics import partitions
@@ -39,7 +39,7 @@ from theboss.boson_sampling_utilities.permanent_calculators.ryser_guan_permanent
 
 class SamplingState(State):
     def __init__(
-        self, d: int, calculator: BaseCalculator, config: Config = None
+        self, d: int, calculator: BaseCalculator, config: Optional[Config] = None
     ) -> None:
         """
         Args:

--- a/piquasso/_math/fock.py
+++ b/piquasso/_math/fock.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 import functools
-from typing import Tuple, Iterable, Generator, Any, List
+from typing import Optional, Tuple, Iterable, Generator, Any, List
 
 import numpy as np
 from operator import add
@@ -462,7 +462,9 @@ class FockSpace(tuple):
             )
         )
 
-    def get_subspace_basis(self, n: int, d: int = None) -> List[Tuple[int, ...]]:
+    def get_subspace_basis(
+        self, n: int, d: Optional[int] = None
+    ) -> List[Tuple[int, ...]]:
         d = d or self.d
         return FockBasis.create_on_particle_subspace(boxes=d, particles=n)
 

--- a/piquasso/api/config.py
+++ b/piquasso/api/config.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any
+from typing import Optional, Any
 
 import os
 import copy
@@ -29,7 +29,7 @@ class Config(_mixins.CodeMixin):
     def __init__(
         self,
         *,
-        seed_sequence: Any = None,
+        seed_sequence: Optional[Any] = None,
         cache_size: int = 32,
         hbar: float = 2.0,
         use_torontonian: bool = False,

--- a/piquasso/api/instruction.py
+++ b/piquasso/api/instruction.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 import typing
-from typing import Tuple, Any, Type, Dict
+from typing import Optional, Tuple, Any, Type, Dict
 
 import numpy as np
 
@@ -38,7 +38,9 @@ class Instruction(_mixins.DictMixin, _mixins.RegisterMixin, _mixins.CodeMixin):
 
     _subclasses: Dict[str, Type["Instruction"]] = {}
 
-    def __init__(self, *, params: dict = None, extra_params: dict = None) -> None:
+    def __init__(
+        self, *, params: Optional[dict] = None, extra_params: Optional[dict] = None
+    ) -> None:
         self._params: dict = params or dict()
 
         self._extra_params: dict = extra_params or dict()

--- a/piquasso/api/simulator.py
+++ b/piquasso/api/simulator.py
@@ -178,7 +178,7 @@ class Simulator(Computer, _mixins.CodeMixin):
     def execute_instructions(
         self,
         instructions: List[Instruction],
-        initial_state: State = None,
+        initial_state: Optional[State] = None,
         shots: int = 1,
     ) -> Result:
         """Executes the specified instruction list.
@@ -231,7 +231,7 @@ class Simulator(Computer, _mixins.CodeMixin):
         return result
 
     def execute(
-        self, program: Program, shots: int = 1, initial_state: State = None
+        self, program: Program, shots: int = 1, initial_state: Optional[State] = None
     ) -> Result:
         """Executes the specified program.
 

--- a/piquasso/instructions/gates.py
+++ b/piquasso/instructions/gates.py
@@ -55,16 +55,17 @@ from piquasso._math.linalg import is_square, is_symmetric, is_invertible
 from piquasso._math.symplectic import complex_symplectic_form, is_symplectic
 
 from piquasso.core import _mixins
+from typing import Optional
 
 
 class _GaussianGate(Gate):
     def __init__(
         self,
         *,
-        params: dict = None,
-        passive_block: np.ndarray = None,
-        active_block: np.ndarray = None,
-        displacement_vector: np.ndarray = None,
+        params: Optional[dict] = None,
+        passive_block: Optional[np.ndarray] = None,
+        active_block: Optional[np.ndarray] = None,
+        displacement_vector: Optional[np.ndarray] = None,
     ):
         params = params or {}
 
@@ -615,7 +616,11 @@ class Displacement(_ScalableGaussianGate):
     """
 
     def __init__(
-        self, *, alpha: complex = None, r: float = None, phi: float = None
+        self,
+        *,
+        alpha: Optional[complex] = None,
+        r: Optional[float] = None,
+        phi: Optional[float] = None,
     ) -> None:
         """
         Args:


### PR DESCRIPTION
The current version of `black` threw the following error:
```
piquasso/_math/fock.py:465: error: Incompatible default for argument "d" (default has type "None", argument has type "int")  [assignment]
piquasso/_math/fock.py:465: note: PEP 484 prohibits implicit Optional. Accordingly, mypy has changed its default to no_implicit_optional=True
piquasso/_math/fock.py:465: note: Use https://github.com/hauntsaninja/no_implicit_optional to automatically upgrade your codebase
```

The error message speaks for itself, so the required changes were made in the codebase.