### PR TITLE
perf(fock/pure): Faster linear gate application

### DIFF
--- a/benchmarks/purefock_beamsplitter_increasing_cutoff_benchmark.py
+++ b/benchmarks/purefock_beamsplitter_increasing_cutoff_benchmark.py
@@ -36,7 +36,7 @@ def d():
     return 5
 
 
-@pytest.mark.parametrize("cutoff", (3, 4, 5, 6))
+@pytest.mark.parametrize("cutoff", (3, 4, 5, 6, 7, 8))
 def piquasso_benchmark(benchmark, d, cutoff, theta):
     @benchmark
     def func():
@@ -51,7 +51,7 @@ def piquasso_benchmark(benchmark, d, cutoff, theta):
         simulator_fock.execute(program)
 
 
-@pytest.mark.parametrize("cutoff", (3, 4, 5, 6))
+@pytest.mark.parametrize("cutoff", (3, 4, 5, 6, 7, 8))
 def strawberryfields_benchmark(benchmark, d, cutoff, theta):
     @benchmark
     def func():


### PR DESCRIPTION
**Problem**

When applying a passive linear gate to a pure Fock state in `PureFockSimulator`, a lot of redundant calculations may happen, since this is the same algorithm used for more general, active linear gates.

**Solution**

`_apply_subspace_matrix_to_state` got separated into 2 functions:

- `_apply_passive_gate_matrix_to_state`: Applies a passive linear gate matrix to the state. It is written considering that the gate matrix is a block diagonal matrix, so it works with the blocks only. This avoids factoring in the off-diagonal zeros, which happened previously. Note, that in this algorithm one iterates over the auxiliary Fock space (where the gate is not applied) instead of the full Fock space, because it turned out that iterating over all the elements in the state vectors are not efficient, and essentially the same index calculation happend in multiple iterations in the loop.

- `_apply_active_gate_matrix_to_state`: This is the same algorithm, but it has been modified according to the discovery described previously. Namely, that it is redundant to iterate over all the elements in the state, and it is enough to iterate only over the auxiliary space.

Moreover, the maximum cutoff in
`purefock_beamsplitter_increasing_cutoff_benchmark` got increased.