### PR TITLE
perf(tensorflow): Custom gradient for squeezing

### DIFF
--- a/piquasso/_backends/fock/pure/state.py
+++ b/piquasso/_backends/fock/pure/state.py
@@ -195,6 +195,8 @@ class PureFockState(BaseFockState):
             (float, float): A tuple that contains the expectation value and the
                 varianceof of the quadrature operator respectively.
         """
+        np = self._calculator.np
+
         reduced_dm = self.reduced(modes=modes).density_matrix
         annih = np.diag(np.sqrt(np.arange(1, self._config.cutoff)), 1)
         create = annih.T
@@ -206,14 +208,16 @@ class PureFockState(BaseFockState):
         else:
             rotated_quadratures = position
 
-        expctation = np.trace(np.dot(reduced_dm, rotated_quadratures)).real
+        expectation = np.real(np.trace(np.dot(reduced_dm, rotated_quadratures)))
         variance = (
-            np.trace(
-                np.dot(reduced_dm, np.dot(rotated_quadratures, rotated_quadratures))
-            ).real
-            - expctation**2
+            np.real(
+                np.trace(
+                    np.dot(reduced_dm, np.dot(rotated_quadratures, rotated_quadratures))
+                )
+            )
+            - expectation**2
         )
-        return expctation, variance
+        return expectation, variance
 
     def mean_photon_number(self):
         accumulator = 0.0

--- a/piquasso/_math/gate_matrices.py
+++ b/piquasso/_math/gate_matrices.py
@@ -55,3 +55,59 @@ def create_single_mode_displacement_matrix(
             )
 
     return transformation
+
+
+def create_single_mode_squeezing_matrix(
+    r: float,
+    phi: float,
+    cutoff: int,
+) -> np.ndarray:
+    """
+    This method generates the Squeezing operator following a recursion rule.
+    Reference: https://quantum-journal.org/papers/q-2020-11-30-366/.
+
+    Args:
+    r (float): This is the Squeezing amplitude. Typically this value can be
+        negative or positive depending on the desired squeezing direction.
+        Note:
+            Setting :math:`|r|` to higher values will require you to have a higer
+            cuttof dimensions.
+    phi (float): This is the Squeezing angle. Its ranges are
+        :math:`\phi \in [ 0, 2 \pi )`
+
+    Returns:
+        np.ndarray: The constructed Squeezing matrix representing the Fock operator.
+    """
+
+    sechr = 1.0 / np.cosh(r)
+    A = np.exp(1j * phi) * np.tanh(r)
+
+    transformation = np.zeros((cutoff,) * 2, dtype=complex)
+    transformation[0, 0] = np.sqrt(sechr)
+
+    fock_indices = np.sqrt(np.arange(cutoff, dtype=complex))
+
+    for index in range(2, cutoff, 2):
+        transformation[index, 0] = (
+            -fock_indices[index - 1]
+            / fock_indices[index]
+            * (transformation[index - 2, 0] * A)
+        )
+
+    for row in range(0, cutoff):
+        for col in range(1, cutoff):
+            if (row + col) % 2 == 0:
+                transformation[row, col] = (
+                    1
+                    / fock_indices[col]
+                    * (
+                        (fock_indices[row] * transformation[row - 1, col - 1] * sechr)
+                        + (
+                            fock_indices[col - 1]
+                            * A.conj()
+                            * transformation[row, col - 2]
+                        )
+                    )
+                )
+
+    return transformation

--- a/tests/backends/tensorflow/test_gradient.py
+++ b/tests/backends/tensorflow/test_gradient.py
@@ -153,6 +153,28 @@ def test_Squeezing_mean_photon_number_gradient_1_mode():
     assert np.isclose(gradient, 2 * np.sinh(r) * np.cosh(r))
 
 
+def test_Squeezing_mean_photon_number_gradient_1_mode_with_phaseshift():
+    r = 0.1
+    phi = tf.Variable(np.pi / 5)
+
+    simulator = pq.TensorflowPureFockSimulator(d=1, config=pq.Config(cutoff=8))
+
+    with tf.GradientTape() as tape:
+        with pq.Program() as program:
+            pq.Q() | pq.Vacuum()
+
+            pq.Q(0) | pq.Squeezing(r=r, phi=phi)
+
+        state = simulator.execute(program).state
+
+        _, variance = state.quadratures_mean_variance(modes=(0,))
+
+    gradient = tape.jacobian(variance, [phi])
+
+    assert np.isclose(variance, np.cosh(2 * r) - np.sinh(2 * r) * np.cos(phi))
+    assert np.isclose(gradient, np.sinh(2 * r) * np.sin(phi))
+
+
 def test_Beamsplitter_fock_probabilities_gradient_1_particle():
     theta = tf.Variable(np.pi / 3)
 


### PR DESCRIPTION
**Problem**

The squeezing gradient calculation was slow because the computational
graph contained too much nodes. This could be reduced by defining a
custom gradient.
For testing Squeezing with phaseshifting gradient the `quadratures_mean_variance` needed to be compatible with Tensorflow as well.
Additionally a possible bug in Tensorflow arose regarding the `tf.Variable` `dtype`

**Partial solution**

The custom gradient for the single mode squeezing matrix got defined.
For the phaseshift gradient we must take its conjugate when multiplying with the upstream due to Tensorflow implementations.
For `quadratures_mean_variance` the solution was to rewrite the density matrix to a list form.
The `dtype` error is currently resolved by casting the gradient to `float32` at the end of `create_single_mode_squeezing_gradient`

**Sources**

- https://quantum-journal.org/papers/q-2020-11-30-366/
- https://stackoverflow.com/questions/42479024/how-tensorflow-handles-complex-gradient