### PR TITLE
perf(purefock): Active linear gate multiplication

### DIFF
--- a/piquasso/_backends/fock/state.py
+++ b/piquasso/_backends/fock/state.py
@@ -36,6 +36,13 @@ class BaseFockState(State, abc.ABC):
             cutoff=self._config.cutoff,
             calculator=calculator,
         )
+        # NOTE: This is instantiated here, since it is costly to do so, and is needed
+        # for several, repeating calculations.
+        self._auxiliary_subspace = fock.FockSpace(
+            d=d - 1,
+            cutoff=self._config.cutoff,
+            calculator=calculator,
+        )
 
     @property
     def d(self) -> int:


### PR DESCRIPTION
**Problem**

Applying an active linear gate to a pure Fock state vector is costly. It would be a bit faster, if some operations could be done at once, since numpy is generally faster that Python for loops.

**Solution**

1. Since this function is only used for single mode gate matrices, the `modes` parameter got rewritten to `mode`, and the logic is simplified accordingly. The `auxiliary_subspace` got refactored into `BaseFockState`, since it is costly to generate all the occupation numbers for each single-mode gate in the circuit.

2. The occupation numbers got divided into sectors corresponding to different particle numbers. This way, the state vector and matrix can be multiplied at once for each of these sectors, provided that one calculates the correct indices for that (contained in `state_index_matrix`) beforehand. The `state_index_matrix` is used to slice the proper elements from the state vector and to rearrange the state vector after computing all the coefficients.