### PR TITLE
FIX(tensorflow): Array conversion

### DIFF
--- a/piquasso/instructions/gates.py
+++ b/piquasso/instructions/gates.py
@@ -78,6 +78,20 @@ class _GaussianGate(Gate):
             ),
         )
 
+    def _postprocess(self, calculator):
+        np = calculator.np
+
+        passive_block = self._extra_params["passive_block"]
+        active_block = self._extra_params["active_block"]
+        displacement_vector = self._extra_params["displacement_vector"]
+
+        if passive_block is not None:
+            self._extra_params["passive_block"] = np.array(passive_block)
+        if active_block is not None:
+            self._extra_params["active_block"] = np.array(active_block)
+        if displacement_vector is not None:
+            self._extra_params["displacement_vector"] = np.array(displacement_vector)
+
 
 class _ScalableGaussianGate(
     _GaussianGate,

--- a/tests/backends/tensorflow/test_gates.py
+++ b/tests/backends/tensorflow/test_gates.py
@@ -1,0 +1,35 @@
+#
+# Copyright 2021-2023 Budapest Quantum Computing Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import piquasso as pq
+import pytest
+import tensorflow as tf
+
+
+@pytest.mark.monkey
+def test_Interferometer_numpy_array_as_parameter(generate_unitary_matrix):
+    alpha = tf.Variable(0.01)
+    d = 5
+    interferometer = generate_unitary_matrix(d)
+
+    simulator = pq.TensorflowPureFockSimulator(d=d, config=pq.Config(cutoff=3))
+
+    with pq.Program() as program:
+        pq.Q(all) | pq.Vacuum()
+        pq.Q(0) | pq.Displacement(alpha=alpha)
+
+        pq.Q(all) | pq.Interferometer(interferometer)
+
+    simulator.execute(program)


### PR DESCRIPTION
**Problem**

For the interferometer gate when one specified a numpy array as a parameter and the tensorflow backend is used then casting to `tensorflow.EagerTensor` did not happen, resulting in error.

**Solution**

A `_postprocess` method has been written for the `_GaussianGate`.