### PR TITLE
FIX(setup.py): Bumping Blackbird version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
         'theboss==2.0.3; python_version >= "3.7"',
         'numpy>=1.19.5; python_version >= "3.7"',
         'scipy>=1.5.4; python_version >= "3.7"',
-        "quantum-blackbird==0.3.0",
+        "quantum-blackbird==0.5.0",
     ],
     extras_require={
         "tensorflow": "tensorflow",


### PR DESCRIPTION
The package `quantum-blackbird==0.3.0` and `numpy` with versions `1.24.*` are incompatible. To fix this, the version of `quantum-blackbird` in `setup.py` has been bumped to `0.5.0`.