### PR TITLE
feat(config): `dtype` Universality in `Config` class

### DIFF
--- a/piquasso/_backends/fock/general/state.py
+++ b/piquasso/_backends/fock/general/state.py
@@ -49,7 +49,9 @@ class FockState(BaseFockState):
         self._density_matrix = self._get_empty()
 
     def _get_empty(self) -> np.ndarray:
-        return np.zeros(shape=(self._space.cardinality,) * 2, dtype=complex)
+        return np.zeros(
+            shape=(self._space.cardinality,) * 2, dtype=self._config.complex_dtype
+        )
 
     def reset(self) -> None:
         self._density_matrix = self._get_empty()

--- a/piquasso/_backends/fock/pure/calculations.py
+++ b/piquasso/_backends/fock/pure/calculations.py
@@ -235,15 +235,17 @@ def _calculate_interferometer_gradient_on_fock_space(
             full_kl_grad.append([0] * d)
             for col_index in range(d):
                 subspace_grad = []
-                subspace_grad.append(np.array([[0]], dtype=complex))
-                second_subspace = np.zeros(shape=interferometer.shape, dtype=complex)
+                subspace_grad.append(np.array([[0]], dtype=interferometer.dtype))
+                second_subspace = np.zeros(
+                    shape=interferometer.shape, dtype=interferometer.dtype
+                )
                 second_subspace[row_index, col_index] = 1
                 subspace_grad.append(second_subspace)
 
                 for p in range(2, cutoff):
                     size = indices[p] - indices[p - 1]
                     previous_subspace_grad = subspace_grad[p - 1]
-                    matrix = np.zeros(shape=(size, size), dtype=complex)
+                    matrix = np.zeros(shape=(size, size), dtype=interferometer.dtype)
 
                     subspace_indices = subspace_index_tensor[p - 2]
                     first_subspace_indices = np.asarray(
@@ -315,7 +317,10 @@ def passive_linear(
     )
 
     subspace = FockSpace(
-        d=len(interferometer), cutoff=state._space.cutoff, calculator=calculator
+        d=len(interferometer),
+        cutoff=state._space.cutoff,
+        calculator=calculator,
+        config=state._config,
     )
 
     subspace_transformations = _get_interferometer_on_fock_space(
@@ -416,9 +421,14 @@ def _calculate_index_list_for_appling_interferometer(
     cutoff = space.cutoff
     d = space.d
 
-    subspace = FockSpace(d=len(modes), cutoff=space.cutoff, calculator=calculator)
+    subspace = FockSpace(
+        d=len(modes), cutoff=space.cutoff, calculator=calculator, config=space.config
+    )
     auxiliary_subspace = FockSpace(
-        d=d - len(modes), cutoff=space.cutoff, calculator=calculator
+        d=d - len(modes),
+        cutoff=space.cutoff,
+        calculator=calculator,
+        config=space.config,
     )
 
     indices = [cutoff_cardinality(cutoff=n, d=len(modes)) for n in range(cutoff + 1)]
@@ -561,7 +571,7 @@ def _calculate_state_index_matrix_list(space, auxiliary_subspace, mode):
 def _calculate_state_vector_after_apply_active_gate(
     state_vector, matrix, state_index_matrix_list
 ):
-    new_state_vector = np.empty_like(state_vector, dtype=complex)
+    new_state_vector = np.empty_like(state_vector, dtype=state_vector.dtype)
 
     for state_index_matrix in state_index_matrix_list:
         limit = state_index_matrix.shape[0]
@@ -585,7 +595,7 @@ def _create_linear_active_gate_gradient_function(
         unordered_gradient_by_initial_state = []
         order_by = []
 
-        gradient_by_matrix = tf.zeros(shape=(cutoff, cutoff), dtype=np.complex128)
+        gradient_by_matrix = tf.zeros(shape=(cutoff, cutoff), dtype=state_vector.dtype)
 
         for indices in state_index_matrix_list:
             limit = indices.shape[0]

--- a/piquasso/_backends/fock/pure/state.py
+++ b/piquasso/_backends/fock/pure/state.py
@@ -59,13 +59,17 @@ class PureFockState(BaseFockState):
         return [0.0] * self._space.cardinality
 
     def _get_empty(self) -> np.ndarray:
-        return self._np.zeros(shape=(self._space.cardinality,), dtype=complex)
+        return self._np.zeros(
+            shape=(self._space.cardinality,), dtype=self._config.complex_dtype
+        )
 
     def reset(self) -> None:
         state_vector_list = self._get_empty_list()
         state_vector_list[0] = 1.0
 
-        self._state_vector = self._np.array(state_vector_list, dtype=complex)
+        self._state_vector = self._np.array(
+            state_vector_list, dtype=self._config.complex_dtype
+        )
 
     @property
     def nonzero_elements(self) -> Generator[Tuple[complex, FockBasis], Any, None]:

--- a/piquasso/_backends/fock/state.py
+++ b/piquasso/_backends/fock/state.py
@@ -35,6 +35,7 @@ class BaseFockState(State, abc.ABC):
             d=d,
             cutoff=self._config.cutoff,
             calculator=calculator,
+            config=self._config,
         )
         # NOTE: This is instantiated here, since it is costly to do so, and is needed
         # for several, repeating calculations.
@@ -42,6 +43,7 @@ class BaseFockState(State, abc.ABC):
             d=d - 1,
             cutoff=self._config.cutoff,
             calculator=calculator,
+            config=self._config,
         )
 
     @property
@@ -185,7 +187,9 @@ class BaseFockState(State, abc.ABC):
         X, Y = np.meshgrid(positions, momentums)
         A = 0.5 * g * (X + 1.0j * Y)
 
-        Wlist = np.array([np.zeros(np.shape(A), dtype=complex) for k in range(M)])
+        Wlist = np.array(
+            [np.zeros(np.shape(A), dtype=self._config.complex_dtype) for k in range(M)]
+        )
         Wlist[0] = np.exp(-2.0 * abs(A) ** 2) / np.pi
 
         W = np.real(rho[0, 0]) * np.real(Wlist[0])

--- a/piquasso/_backends/gaussian/calculations.py
+++ b/piquasso/_backends/gaussian/calculations.py
@@ -597,7 +597,7 @@ def deterministic_gaussian_channel(
     mean_vector = state.xpxp_mean_vector
     covariance_matrix = state.xpxp_covariance_matrix
 
-    embedded_X = np.identity(len(mean_vector), dtype=complex)
+    embedded_X = np.identity(len(mean_vector), dtype=state._config.complex_dtype)
     embedded_X[matrix_indices] = X
 
     embedded_Y = np.zeros_like(embedded_X)

--- a/piquasso/_backends/gaussian/state.py
+++ b/piquasso/_backends/gaussian/state.py
@@ -66,9 +66,9 @@ class GaussianState(State):
         vector_shape = (self.d,)
         matrix_shape = vector_shape * 2
 
-        self._m = np.zeros(vector_shape, dtype=complex)
-        self._G = np.zeros(matrix_shape, dtype=complex)
-        self._C = np.zeros(matrix_shape, dtype=complex)
+        self._m = np.zeros(vector_shape, dtype=self._config.complex_dtype)
+        self._G = np.zeros(matrix_shape, dtype=self._config.complex_dtype)
+        self._C = np.zeros(matrix_shape, dtype=self._config.complex_dtype)
 
     @classmethod
     def _from_representation(

--- a/piquasso/_backends/sampling/calculations.py
+++ b/piquasso/_backends/sampling/calculations.py
@@ -94,7 +94,7 @@ def passive_linear(
 def _apply_matrix_on_modes(
     state: SamplingState, matrix: np.ndarray, modes: Tuple[int, ...]
 ) -> None:
-    embedded = np.identity(len(state.interferometer), dtype=complex)
+    embedded = np.identity(len(state.interferometer), dtype=state._config.complex_dtype)
 
     embedded[np.ix_(modes, modes)] = matrix
 

--- a/piquasso/_backends/sampling/state.py
+++ b/piquasso/_backends/sampling/state.py
@@ -50,7 +50,9 @@ class SamplingState(State):
         super().__init__(calculator=calculator, config=config)
 
         self.initial_state: np.ndarray = np.zeros((d,), dtype=int)
-        self.interferometer: np.ndarray = np.diag(np.ones(d, dtype=complex))
+        self.interferometer: np.ndarray = np.diag(
+            np.ones(d, dtype=self._config.complex_dtype)
+        )
 
         self.is_lossy = False
 

--- a/piquasso/_math/gate_matrices.py
+++ b/piquasso/_math/gate_matrices.py
@@ -20,6 +20,7 @@ def create_single_mode_displacement_matrix(
     r: float,
     phi: float,
     cutoff: int,
+    complex_dtype: np.dtype,
 ) -> np.ndarray:
     r"""
     This method generates the Displacement operator following a recursion rule.
@@ -36,9 +37,9 @@ def create_single_mode_displacement_matrix(
         np.ndarray: The constructed Displacement matrix representing the Fock
         operator.
     """
-    fock_indices = np.sqrt(np.arange(cutoff, dtype=complex))
+    fock_indices = np.sqrt(np.arange(cutoff, dtype=complex_dtype))
     displacement = r * np.exp(1j * phi)
-    transformation = np.zeros((cutoff,) * 2, dtype=complex)
+    transformation = np.zeros((cutoff,) * 2, dtype=complex_dtype)
     transformation[0, 0] = np.exp(-0.5 * r**2)
     for row in range(1, cutoff):
         transformation[row, 0] = (
@@ -61,6 +62,7 @@ def create_single_mode_squeezing_matrix(
     r: float,
     phi: float,
     cutoff: int,
+    complex_dtype: np.dtype,
 ) -> np.ndarray:
     """
     This method generates the Squeezing operator following a recursion rule.
@@ -82,10 +84,10 @@ def create_single_mode_squeezing_matrix(
     sechr = 1.0 / np.cosh(r)
     A = np.exp(1j * phi) * np.tanh(r)
 
-    transformation = np.zeros((cutoff,) * 2, dtype=complex)
+    transformation = np.zeros((cutoff,) * 2, dtype=complex_dtype)
     transformation[0, 0] = np.sqrt(sechr)
 
-    fock_indices = np.sqrt(np.arange(cutoff, dtype=complex))
+    fock_indices = np.sqrt(np.arange(cutoff, dtype=complex_dtype))
 
     for index in range(2, cutoff, 2):
         transformation[index, 0] = (

--- a/piquasso/_math/gradients.py
+++ b/piquasso/_math/gradients.py
@@ -26,6 +26,7 @@ def create_single_mode_displacement_gradient(
     cutoff: int,
     transformation: np.ndarray,
     calculator: BaseCalculator,
+    complex_dtype: type,
 ) -> Callable:
     def grad(upstream):
         np = calculator.fallback_np
@@ -34,8 +35,8 @@ def create_single_mode_displacement_gradient(
         epiphi = np.exp(1j * phi)
         eimphi = np.exp(-1j * phi)
 
-        r_grad = np.zeros((cutoff,) * 2, dtype=complex)
-        phi_grad = np.zeros((cutoff,) * 2, dtype=complex)
+        r_grad = np.zeros((cutoff,) * 2, dtype=complex_dtype)
+        phi_grad = np.zeros((cutoff,) * 2, dtype=complex_dtype)
         # NOTE: This algorithm deliberately overindexes the gate matrix.
         for row in range(cutoff):
             for col in range(cutoff):
@@ -65,13 +66,14 @@ def create_single_mode_squeezing_gradient(
     cutoff: int,
     transformation: np.ndarray,
     calculator: BaseCalculator,
+    complex_dtype: type,
 ) -> Callable:
     def grad(upstream):
         np = calculator.fallback_np
         tf = calculator._tf
 
-        r_grad = np.zeros((cutoff,) * 2, dtype=complex)
-        phi_grad = np.zeros((cutoff,) * 2, dtype=complex)
+        r_grad = np.zeros((cutoff,) * 2, dtype=complex_dtype)
+        phi_grad = np.zeros((cutoff,) * 2, dtype=complex_dtype)
         sinhr = np.sinh(r)
         coshr = np.cosh(r)
         sechr = 1 / coshr

--- a/piquasso/_math/hafnian.py
+++ b/piquasso/_math/hafnian.py
@@ -41,8 +41,8 @@ def get_partitions(boxes: int, particles: int) -> List[np.ndarray]:
 
 
 @lru_cache()
-def get_X(d: int) -> np.ndarray:
-    sigma_x = np.array([[0, 1], [1, 0]], dtype=complex)
+def get_X(d: int, complex_dtype: np.dtype) -> np.ndarray:
+    sigma_x = np.array([[0, 1], [1, 0]], dtype=complex_dtype)
     return block_diag(*([sigma_x] * d))
 
 
@@ -105,7 +105,9 @@ def _hafnian(
 def _get_polynom_coefficients(
     A: np.ndarray, indices: List[int], degree: int
 ) -> List[float]:
-    X = get_X(len(indices) // 2)
+    complex_dtype = np.complex64 if A.dtype is np.float32 else np.complex128
+
+    X = get_X(len(indices) // 2, complex_dtype)
 
     eigenvalues = np.linalg.eigvals(X @ A[np.ix_(indices, indices)])
 
@@ -126,7 +128,9 @@ def _get_loop_polynom_coefficients(
 ) -> List[float]:
     AZ = A[np.ix_(indices, indices)]
 
-    X = get_X(len(indices) // 2)
+    complex_dtype = np.complex64 if A.dtype is np.float32 else np.complex128
+
+    X = get_X(len(indices) // 2, complex_dtype)
 
     XAZ = X @ AZ
 

--- a/piquasso/api/config.py
+++ b/piquasso/api/config.py
@@ -35,6 +35,7 @@ class Config(_mixins.CodeMixin):
         use_torontonian: bool = False,
         cutoff: int = 4,
         measurement_cutoff: int = 5,
+        dtype: type = np.float64,
     ):
         self._original_seed_sequence = seed_sequence
         self.seed_sequence = seed_sequence or int.from_bytes(
@@ -45,6 +46,7 @@ class Config(_mixins.CodeMixin):
         self.use_torontonian = use_torontonian
         self.cutoff = cutoff
         self.measurement_cutoff = measurement_cutoff
+        self.dtype = np.float64 if dtype is float else dtype
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, Config):
@@ -56,6 +58,7 @@ class Config(_mixins.CodeMixin):
             and self.use_torontonian == other.use_torontonian
             and self.cutoff == other.cutoff
             and self.measurement_cutoff == other.measurement_cutoff
+            and self.dtype == other.dtype
         )
 
     def _as_code(self) -> str:
@@ -74,6 +77,8 @@ class Config(_mixins.CodeMixin):
             non_default_params["cutoff"] = self.cutoff
         if self.measurement_cutoff != default_config.measurement_cutoff:
             non_default_params["measurement_cutoff"] = self.measurement_cutoff
+        if self.dtype != default_config.dtype:
+            non_default_params["dtype"] = "np." + self.dtype.__name__
 
         if len(non_default_params) == 0:
             return "pq.Config()"
@@ -94,6 +99,15 @@ class Config(_mixins.CodeMixin):
         self._seed_sequence = value
         self.rng = np.random.default_rng(self._seed_sequence)
         random.seed(self._seed_sequence)
+
+    @property
+    def complex_dtype(self):
+        """Returns the complex precision depending on the dtype of the Config class"""
+
+        if self.dtype is np.float64:
+            return np.complex128
+
+        return np.complex64
 
     def copy(self) -> "Config":
         """Returns an exact copy of this config object.

--- a/piquasso/instructions/channels.py
+++ b/piquasso/instructions/channels.py
@@ -172,12 +172,17 @@ class Loss(Gate, _mixins.ScalingMixin):
 
     def _autoscale(self, calculator: BaseCalculator) -> None:
         transmissivity = self._extra_params["transmissivity"]
+
+        complex_dtype = (
+            np.complex128 if transmissivity.dtype is np.float64 else np.complex64
+        )
+
         if transmissivity is None or len(self.modes) == len(transmissivity):
             pass
         elif len(transmissivity) == 1:
             self._extra_params["transmissivity"] = calculator.np.array(
                 [transmissivity[0]] * len(self.modes),
-                dtype=complex,
+                dtype=complex_dtype,
             )
         else:
             raise InvalidParameter(

--- a/piquasso/instructions/gates.py
+++ b/piquasso/instructions/gates.py
@@ -133,7 +133,7 @@ class _ScalableGaussianGate(
         elif len(displacement_vector) == 1:
             self._extra_params["displacement_vector"] = calculator.np.array(
                 [displacement_vector[0]] * len(self.modes),
-                dtype=complex,
+                dtype=displacement_vector.dtype,
             )
         else:
             raise InvalidParameter(

--- a/tests/api/test_config.py
+++ b/tests/api/test_config.py
@@ -54,3 +54,27 @@ def test_eq():
     assert config3 == config3
     assert config1 == config2
     assert not (config1 == config3)
+
+
+def test_as_code():
+    conf_f32 = pq.Config(dtype=np.float32)
+    conf_f64 = pq.Config(dtype=np.float64)
+    conf_f = pq.Config(dtype=float)
+
+    as_code_f32 = conf_f32._as_code()
+    as_code_f64 = conf_f64._as_code()
+    as_code_f = conf_f._as_code()
+
+    assert as_code_f32 == "pq.Config(dtype=np.float32)"
+    assert as_code_f64 == "pq.Config()"
+    assert as_code_f == "pq.Config()"
+
+
+def test_complex_dtype():
+    conf_f32 = pq.Config(dtype=np.float32)
+    conf_f64 = pq.Config(dtype=np.float64)
+    conf_f = pq.Config(dtype=float)
+
+    assert conf_f32.complex_dtype == np.complex64
+    assert conf_f64.complex_dtype == np.complex128
+    assert conf_f.complex_dtype == np.complex128

--- a/tests/api/utils/test_code_generation.py
+++ b/tests/api/utils/test_code_generation.py
@@ -142,6 +142,7 @@ def test_full_config_code_generation():
             use_torontonian=True,
             cutoff=6,
             measurement_cutoff=4,
+            dtype=np.float32,
         ),
     )
 
@@ -163,7 +164,7 @@ with pq.Program() as program:
 
 simulator = pq.{pq.GaussianSimulator.__name__}(
     d=3, config=pq.Config(seed_sequence=0, cache_size=64, hbar=2.5, \
-use_torontonian=True, cutoff=6, measurement_cutoff=4)
+use_torontonian=True, cutoff=6, measurement_cutoff=4, dtype=np.float32)
 )
 
 result = simulator.execute(program, shots=100)


### PR DESCRIPTION
**Problem**
During the simulation `dtype` values were explicitly hard-coded into
certain functions. This could lead to inconsistency, hinders debugging 
and lead to distorted comparisons with Strawberry Fields.

**Solution**
Now the `Config` class has a `dtype` member variable which can have one of
the following values: `np.float32` or `np.float64`. Based on this a
complex `dtype` can be mapped as `np.float32 -> np.complex64` and
`np.float64 -> np.complex128`. For this, a `complex_dtype` property was
added as well.
These values are now propagated to most other calculations as well.