### PR TITLE
FIX(fock/pure): State vector dtype fix

### DIFF
--- a/piquasso/_backends/fock/pure/state.py
+++ b/piquasso/_backends/fock/pure/state.py
@@ -65,7 +65,7 @@ class PureFockState(BaseFockState):
         state_vector_list = self._get_empty_list()
         state_vector_list[0] = 1.0
 
-        self._state_vector = self._np.array(state_vector_list)
+        self._state_vector = self._np.array(state_vector_list, dtype=complex)
 
     @property
     def nonzero_elements(self) -> Generator[Tuple[complex, FockBasis], Any, None]:


### PR DESCRIPTION
After the `Vacuum` instruction, the initial state is inititalized without `dtype` parameter, so it defaulted to `float64`. It haven't caused any errors, because it only happened when a passive gate is applied to a vacuum, which leaves the vacuum invariant, and for active gates it is cast to complex. Still, it is technically incorrect.