### PR TITLE
fix(tests): Displacement parameter followup

### DIFF
--- a/tests/backends/fock/pure/test_state.py
+++ b/tests/backends/fock/pure/test_state.py
@@ -137,7 +137,7 @@ def test_mean_position():
     with pq.Program() as program:
         pq.Q(all) | pq.Vacuum()
 
-        pq.Q(all) | pq.Displacement(alpha=alpha_)
+        pq.Q(all) | pq.Displacement(r=alpha_)
 
     config = pq.Config(cutoff=cutoff)
 

--- a/tests/backends/tensorflow/test_gradient.py
+++ b/tests/backends/tensorflow/test_gradient.py
@@ -544,7 +544,7 @@ def test_mean_position_Displacement_gradient_on_1_mode():
     with pq.Program() as program:
         pq.Q(all) | pq.Vacuum()
 
-        pq.Q(all) | pq.Displacement(alpha=alpha_)
+        pq.Q(all) | pq.Displacement(r=alpha_)
 
     config = pq.Config(cutoff=cutoff)
 
@@ -570,7 +570,7 @@ def test_mean_position_Displacement_and_Squeezing_gradient_on_1_mode():
     with pq.Program() as program:
         pq.Q(all) | pq.Vacuum()
 
-        pq.Q(all) | pq.Displacement(alpha=alpha_)
+        pq.Q(all) | pq.Displacement(r=alpha_)
         pq.Q(all) | pq.Squeezing(r_)
 
     simulator = pq.TensorflowPureFockSimulator(d=d, config=pq.Config(cutoff=cutoff))


### PR DESCRIPTION
The changes in commit `d86a0e8eed77cf26299eaf28c0469c319021f762` are not followed up in the commit `430d8be94a54b36fbf4788d8af0c4d847c1bb773`, unfortunately.