### PR TITLE
feat(Config): Ability to disable normalization

### DIFF
--- a/piquasso/_backends/fock/general/state.py
+++ b/piquasso/_backends/fock/general/state.py
@@ -166,6 +166,9 @@ class FockState(BaseFockState):
         Raises:
             RuntimeError: Raised if the current norm of the state is too close to 0.
         """
+        if not self._config.normalize:
+            return
+
         if np.isclose(self.norm, 0):
             raise InvalidState("The norm of the state is 0.")
 

--- a/piquasso/_backends/fock/pure/state.py
+++ b/piquasso/_backends/fock/pure/state.py
@@ -135,6 +135,9 @@ class PureFockState(BaseFockState):
         return probability_map
 
     def normalize(self) -> None:
+        if not self._config.normalize:
+            return
+
         norm = self.norm
 
         if np.isclose(norm, 0):

--- a/piquasso/api/config.py
+++ b/piquasso/api/config.py
@@ -36,6 +36,7 @@ class Config(_mixins.CodeMixin):
         cutoff: int = 4,
         measurement_cutoff: int = 5,
         dtype: type = np.float64,
+        normalize: bool = True,
     ):
         self._original_seed_sequence = seed_sequence
         self.seed_sequence = seed_sequence or int.from_bytes(
@@ -47,6 +48,7 @@ class Config(_mixins.CodeMixin):
         self.cutoff = cutoff
         self.measurement_cutoff = measurement_cutoff
         self.dtype = np.float64 if dtype is float else dtype
+        self.normalize = normalize
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, Config):
@@ -59,6 +61,7 @@ class Config(_mixins.CodeMixin):
             and self.cutoff == other.cutoff
             and self.measurement_cutoff == other.measurement_cutoff
             and self.dtype == other.dtype
+            and self.normalize == other.normalize
         )
 
     def _as_code(self) -> str:
@@ -79,6 +82,8 @@ class Config(_mixins.CodeMixin):
             non_default_params["measurement_cutoff"] = self.measurement_cutoff
         if self.dtype != default_config.dtype:
             non_default_params["dtype"] = "np." + self.dtype.__name__
+        if self.normalize != default_config.normalize:
+            non_default_params["normalize"] = self.normalize
 
         if len(non_default_params) == 0:
             return "pq.Config()"

--- a/tests/backends/fock/pure/test_state.py
+++ b/tests/backends/fock/pure/test_state.py
@@ -147,3 +147,24 @@ def test_mean_position():
     mean = state.mean_position(mode=0)
 
     assert np.allclose(mean, np.sqrt(2 * config.hbar) * alpha_)
+
+
+def test_normalize_if_disabled_in_Config():
+    d = 1
+    cutoff = 3
+
+    alpha_ = 1.0
+
+    with pq.Program() as program:
+        pq.Q(all) | pq.Vacuum()
+
+        pq.Q(all) | pq.Displacement(r=alpha_)
+
+    config = pq.Config(cutoff=cutoff, normalize=False)
+
+    simulator = pq.PureFockSimulator(d=d, config=config)
+
+    state = simulator.execute(program).state
+    norm = state.norm
+
+    assert not np.isclose(norm, 1.0)


### PR DESCRIPTION
Sometimes normalizing the state vector or density matrix is costly to do after every gate, so a boolean config variable called `normalize` has been provided to disable it.