### PR TITLE
perf(fock/pure): Phaseshifter improvement

### DIFF
--- a/piquasso/_backends/fock/pure/calculations.py
+++ b/piquasso/_backends/fock/pure/calculations.py
@@ -355,6 +355,29 @@ def passive_linear(
     return Result(state=state)
 
 
+def phaseshifter(state: PureFockState, instruction: Instruction, shots: int) -> Result:
+    calculator = state._calculator
+    cutoff = state._space.cutoff
+
+    mode = instruction.modes[0]
+
+    phi = instruction._all_params["phi"]
+
+    np = calculator.np
+    eiphi_powers = np.exp(1j * phi * np.arange(cutoff))
+
+    multipliers = []
+
+    for index in range(len(state._state_vector)):
+        n = state._space[index][mode]
+
+        multipliers.append(eiphi_powers[n])
+
+    state._state_vector = state._state_vector * np.array(multipliers)
+
+    return Result(state=state)
+
+
 def _get_normalization(
     probability_map: Mapping[Tuple[int, ...], float], sample: Tuple[int, ...]
 ) -> float:

--- a/piquasso/_backends/fock/pure/simulator.py
+++ b/piquasso/_backends/fock/pure/simulator.py
@@ -20,6 +20,7 @@ from .state import PureFockState
 from .calculations import (
     state_vector_instruction,
     passive_linear,
+    phaseshifter,
     kerr,
     cross_kerr,
     cubic_phase,
@@ -96,7 +97,7 @@ class PureFockSimulator(Simulator):
         preparations.StateVector: state_vector_instruction,
         gates.Interferometer: passive_linear,
         gates.Beamsplitter: passive_linear,
-        gates.Phaseshifter: passive_linear,
+        gates.Phaseshifter: phaseshifter,
         gates.MachZehnder: passive_linear,
         gates.Fourier: passive_linear,
         gates.Kerr: kerr,


### PR DESCRIPTION
It is much faster if there is a distinct `phaseshifter` calculation implemented for the `PureFockSimulator`, since the `passive_linear` calculation is much more complicated due to its generality.