### PR TITLE
FIX(tensorflow): Passive linear gradient error

### DIFF
--- a/piquasso/_backends/fock/pure/calculations.py
+++ b/piquasso/_backends/fock/pure/calculations.py
@@ -527,7 +527,7 @@ def _create_linear_passive_gate_gradient_function(
             state_vector_slice = conjugated_state_vector[indices]
 
             order_by.append(indices.reshape(-1))
-            product = np.einsum("ij, jk->ik", matrix, sliced_upstream)
+            product = np.einsum("ji,jk->ik", matrix, sliced_upstream)
             unordered_gradient_by_initial_state.append(product.reshape(-1))
 
             gradient_by_matrix.append(


### PR DESCRIPTION
Simply put, when multiplying a vector with a fix matrix as `M @ v`, its jacobian by `v` is just `M`, but in the forward pass, we have to return `M.T @ upstream` in the custom gradient, but `M @ upstream` has been calculated (if `M`, `v` would be real). The fix amounts to rewriting an einsum string. When calculating the gradient of active transformations, this has been done correctly.