### PR TITLE
fix(gradients): Gradient floating point precision

### DIFF
--- a/piquasso/_math/gradients.py
+++ b/piquasso/_math/gradients.py
@@ -115,13 +115,7 @@ def create_single_mode_squeezing_gradient(
             r_grad_sum = tf.constant(np.real(np.sum(upstream * np.conj(r_grad))))
             phi_grad_sum = tf.constant(np.real(np.sum(upstream * np.conj(phi_grad))))
         else:
-            # NOTE: Possibly Tensorflow bug, cast needed.
-            # cannot compute AddN as input #1(zero-based) was expected to be\
-            #  a double tensor but is a float tensor [Op:AddN].
-            # The bug does not occur with Displacement gradient for unknown reasons.
-            r_grad_sum = tf.cast(
-                tf.math.real(tf.reduce_sum(upstream * tf.math.conj(r_grad))), np.float32
-            )
+            r_grad_sum = tf.math.real(tf.reduce_sum(upstream * tf.math.conj(r_grad)))
             phi_grad_sum = tf.math.real(
                 tf.reduce_sum(upstream * tf.math.conj(phi_grad))
             )


### PR DESCRIPTION
The gradient of the squeezing gate by the amplitude of the squeezing parameter has been cast to `float32`, but it is not needed anymore. It may have been needed due to a type promotion we missed, but it seems that this issue has been resolved now by `207d1f3b3aa28e0b13d1d85c3f5b5d2005f90245`.