### PR TITLE
feat(tensorflow): Choose NumPy API in forward pass

### DIFF
--- a/benchmarks/tf_cvnn_benchmark.py
+++ b/benchmarks/tf_cvnn_benchmark.py
@@ -106,6 +106,7 @@ def _pq_state_vector(weights, cutoff):
     return state.get_tensor_representation()
 
 
+@tf.function(jit_compile=True)
 def _calculate_piquasso_results(weights, cutoff):
     with tf.GradientTape() as tape:
         state_vector = _pq_state_vector(weights, cutoff)

--- a/piquasso/_backends/fock/calculations.py
+++ b/piquasso/_backends/fock/calculations.py
@@ -203,7 +203,7 @@ def calculate_interferometer_helper_indices(space):
     }
 
 
-def calculate_interferometer_on_fock_space(interferometer, index_dict):
+def calculate_interferometer_on_fock_space(interferometer, index_dict, calculator):
     """Calculates finite representation of interferometer in the Fock space.
     The function assumes the knowledge of the 1-particle unitary.
 
@@ -218,6 +218,8 @@ def calculate_interferometer_on_fock_space(interferometer, index_dict):
     Returns:
         numpy.ndarray: Finite representation of interferometer in the Fock space
     """
+
+    np = calculator.forward_pass_np
 
     subspace_representations = []
 

--- a/piquasso/_backends/fock/general/calculations.py
+++ b/piquasso/_backends/fock/general/calculations.py
@@ -57,7 +57,7 @@ def _apply_passive_linear(state, interferometer, modes):
     subspace = state._get_subspace(dim=len(interferometer))
 
     subspace_transformations = _get_interferometer_on_fock_space(
-        interferometer, subspace
+        interferometer, subspace, state._calculator
     )
 
     _apply_passive_gate_matrix_to_state(state, subspace_transformations, modes)
@@ -107,10 +107,12 @@ def _calculate_density_matrix_after_interferometer(
     return new_density_matrix
 
 
-def _get_interferometer_on_fock_space(interferometer, space):
+def _get_interferometer_on_fock_space(interferometer, space, calculator):
     index_dict = calculate_interferometer_helper_indices(space)
 
-    return calculate_interferometer_on_fock_space(interferometer, index_dict)
+    return calculate_interferometer_on_fock_space(
+        interferometer, index_dict, calculator
+    )
 
 
 def particle_number_measurement(

--- a/piquasso/_backends/fock/pure/calculations/__init__.py
+++ b/piquasso/_backends/fock/pure/calculations/__init__.py
@@ -118,14 +118,14 @@ def _apply_active_gate_matrix_to_state(
 
     @calculator.custom_gradient
     def _apply_active_gate_matrix(state_vector, matrix):
-        state_vector = calculator.maybe_convert_to_numpy(state_vector)
-        matrix = calculator.maybe_convert_to_numpy(matrix)
+        state_vector = calculator.preprocess_input_for_custom_gradient(state_vector)
+        matrix = calculator.preprocess_input_for_custom_gradient(matrix)
 
         state_index_matrix_list = calculate_state_index_matrix_list(
             space, auxiliary_subspace, mode
         )
         new_state_vector = _calculate_state_vector_after_apply_active_gate(
-            state_vector, matrix, state_index_matrix_list
+            state_vector, matrix, state_index_matrix_list, calculator
         )
         grad = _create_linear_active_gate_gradient_function(
             state_vector, matrix, state_index_matrix_list, calculator
@@ -136,8 +136,13 @@ def _apply_active_gate_matrix_to_state(
 
 
 def _calculate_state_vector_after_apply_active_gate(
-    state_vector, matrix, state_index_matrix_list
+    state_vector,
+    matrix,
+    state_index_matrix_list,
+    calculator,
 ):
+    np = calculator.forward_pass_np
+
     new_state_vector = np.empty_like(state_vector, dtype=state_vector.dtype)
 
     is_batch = len(state_vector.shape) == 2
@@ -146,8 +151,12 @@ def _calculate_state_vector_after_apply_active_gate(
 
     for state_index_matrix in state_index_matrix_list:
         limit = state_index_matrix.shape[0]
-        new_state_vector[state_index_matrix] = np.einsum(
-            einsum_string, matrix[:limit, :limit], state_vector[state_index_matrix]
+        new_state_vector = calculator.assign(
+            new_state_vector,
+            state_index_matrix,
+            np.einsum(
+                einsum_string, matrix[:limit, :limit], state_vector[state_index_matrix]
+            ),
         )
 
     return new_state_vector

--- a/piquasso/_backends/fock/pure/state.py
+++ b/piquasso/_backends/fock/pure/state.py
@@ -205,8 +205,8 @@ class PureFockState(BaseFockState):
         state_vector = self._state_vector
 
         accumulator = np.dot(
-            (multipliers * np.take(state_vector, left_indices)),
-            np.take(state_vector, right_indices),
+            (multipliers * np.take(state_vector, np.array(left_indices))),
+            np.take(state_vector, np.array(right_indices)),
         )
 
         return np.real(accumulator) * fallback_np.sqrt(self._config.hbar / 2)

--- a/piquasso/_math/fock.py
+++ b/piquasso/_math/fock.py
@@ -168,11 +168,15 @@ class FockSpace(tuple):
     ) -> np.ndarray:
         @self.calculator.custom_gradient
         def _single_mode_squeezing_operator(r, phi):
-            r = self.calculator.maybe_convert_to_numpy(r)
-            phi = self.calculator.maybe_convert_to_numpy(phi)
+            r = self.calculator.preprocess_input_for_custom_gradient(r)
+            phi = self.calculator.preprocess_input_for_custom_gradient(phi)
 
             matrix = create_single_mode_squeezing_matrix(
-                r, phi, self.cutoff, complex_dtype=self.config.complex_dtype
+                r,
+                phi,
+                self.cutoff,
+                complex_dtype=self.config.complex_dtype,
+                calculator=self._calculator,
             )
             grad = create_single_mode_squeezing_gradient(
                 r,
@@ -300,11 +304,15 @@ class FockSpace(tuple):
     def get_single_mode_displacement_operator(self, *, r, phi):
         @self.calculator.custom_gradient
         def _single_mode_displacement_operator(r, phi):
-            r = self.calculator.maybe_convert_to_numpy(r)
-            phi = self.calculator.maybe_convert_to_numpy(phi)
+            r = self.calculator.preprocess_input_for_custom_gradient(r)
+            phi = self.calculator.preprocess_input_for_custom_gradient(phi)
 
             matrix = create_single_mode_displacement_matrix(
-                r, phi, self.cutoff, complex_dtype=self.config.complex_dtype
+                r,
+                phi,
+                self.cutoff,
+                complex_dtype=self.config.complex_dtype,
+                calculator=self._calculator,
             )
             grad = create_single_mode_displacement_gradient(
                 r,

--- a/piquasso/api/calculator.py
+++ b/piquasso/api/calculator.py
@@ -30,6 +30,7 @@ class BaseCalculator(abc.ABC):
 
     np: Any
     fallback_np: Any
+    forward_pass_np: Any
 
     def __deepcopy__(self, memo: Any) -> "BaseCalculator":
         """
@@ -40,9 +41,9 @@ class BaseCalculator(abc.ABC):
 
         return self
 
-    def maybe_convert_to_numpy(self, value):
+    def preprocess_input_for_custom_gradient(self, value):
         """
-        Converts tensorflow objects to numpy objects if applicable.
+        Applies modifications to inputs in custom gradients.
         """
         raise NotImplementedCalculation()
 

--- a/tests/backends/fock/test_gates.py
+++ b/tests/backends/fock/test_gates.py
@@ -21,9 +21,15 @@ import piquasso as pq
 
 from functools import partial
 
-TensorflowPureFockSimulator = partial(
-    pq.PureFockSimulator,
-    calculator=pq.TensorflowCalculator(),
+tf_purefock_simulators = (
+    partial(
+        pq.PureFockSimulator,
+        calculator=pq.TensorflowCalculator(),
+    ),
+    partial(
+        pq.PureFockSimulator,
+        calculator=pq.TensorflowCalculator(no_custom_gradient=True),
+    ),
 )
 
 
@@ -31,7 +37,7 @@ TensorflowPureFockSimulator = partial(
     "SimulatorClass",
     (
         pq.PureFockSimulator,
-        TensorflowPureFockSimulator,
+        *tf_purefock_simulators,
         pq.FockSimulator,
     ),
 )
@@ -59,7 +65,7 @@ def test_squeezing_probabilities(SimulatorClass):
     "SimulatorClass",
     (
         pq.PureFockSimulator,
-        TensorflowPureFockSimulator,
+        *tf_purefock_simulators,
         pq.FockSimulator,
     ),
 )

--- a/tests/backends/tensorflow/test_batch_gradient.py
+++ b/tests/backends/tensorflow/test_batch_gradient.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
+
 import tensorflow as tf
 
 import numpy as np
@@ -20,7 +22,14 @@ import numpy as np
 import piquasso as pq
 
 
-def test_batch_Beamsplitter_mean_position():
+calculators = (
+    pq.TensorflowCalculator(),
+    pq.TensorflowCalculator(no_custom_gradient=True),
+)
+
+
+@pytest.mark.parametrize("calculator", calculators)
+def test_batch_Beamsplitter_mean_position(calculator):
     theta = tf.Variable(np.pi / 3)
 
     with pq.Program() as first_preparation:
@@ -38,7 +47,7 @@ def test_batch_Beamsplitter_mean_position():
             pq.Q() | pq.Beamsplitter(theta=theta, phi=np.pi / 3)
 
         simulator = pq.PureFockSimulator(
-            d=2, config=pq.Config(cutoff=5), calculator=pq.TensorflowCalculator()
+            d=2, config=pq.Config(cutoff=5), calculator=calculator
         )
 
         batch_mean_positions = simulator.execute(batch_program).state.mean_position(0)
@@ -72,7 +81,8 @@ def test_batch_Beamsplitter_mean_position():
     assert np.allclose(batch_gradient[1], second_gradient)
 
 
-def test_batch_Squeezing_mean_position():
+@pytest.mark.parametrize("calculator", calculators)
+def test_batch_Squeezing_mean_position(calculator):
     r = tf.Variable(0.1)
 
     with pq.Program() as first_preparation:
@@ -91,7 +101,7 @@ def test_batch_Squeezing_mean_position():
             pq.Q() | pq.Beamsplitter(theta=np.pi / 3, phi=np.pi / 3)
 
         simulator = pq.PureFockSimulator(
-            d=2, config=pq.Config(cutoff=5), calculator=pq.TensorflowCalculator()
+            d=2, config=pq.Config(cutoff=5), calculator=calculator
         )
 
         batch_mean_positions = simulator.execute(batch_program).state.mean_position(0)
@@ -127,7 +137,8 @@ def test_batch_Squeezing_mean_position():
     assert np.allclose(batch_gradient[1], second_gradient)
 
 
-def test_batch_Displacement_mean_position():
+@pytest.mark.parametrize("calculator", calculators)
+def test_batch_Displacement_mean_position(calculator):
     r = tf.Variable(0.1)
 
     with pq.Program() as first_preparation:
@@ -146,7 +157,7 @@ def test_batch_Displacement_mean_position():
             pq.Q() | pq.Beamsplitter(theta=np.pi / 3, phi=np.pi / 3)
 
         simulator = pq.PureFockSimulator(
-            d=2, config=pq.Config(cutoff=5), calculator=pq.TensorflowCalculator()
+            d=2, config=pq.Config(cutoff=5), calculator=calculator
         )
 
         batch_mean_positions = simulator.execute(batch_program).state.mean_position(0)
@@ -182,7 +193,8 @@ def test_batch_Displacement_mean_position():
     assert np.allclose(batch_gradient[1], second_gradient)
 
 
-def test_batch_Kerr_mean_position():
+@pytest.mark.parametrize("calculator", calculators)
+def test_batch_Kerr_mean_position(calculator):
     xi = tf.Variable(0.1)
 
     with pq.Program() as first_preparation:
@@ -201,7 +213,7 @@ def test_batch_Kerr_mean_position():
             pq.Q() | pq.Beamsplitter(theta=np.pi / 3, phi=np.pi / 3)
 
         simulator = pq.PureFockSimulator(
-            d=2, config=pq.Config(cutoff=5), calculator=pq.TensorflowCalculator()
+            d=2, config=pq.Config(cutoff=5), calculator=calculator
         )
 
         batch_mean_positions = simulator.execute(batch_program).state.mean_position(0)
@@ -237,7 +249,8 @@ def test_batch_Kerr_mean_position():
     assert np.allclose(batch_gradient[1], second_gradient)
 
 
-def test_batch_Phaseshifter_mean_position():
+@pytest.mark.parametrize("calculator", calculators)
+def test_batch_Phaseshifter_mean_position(calculator):
     phi = tf.Variable(np.pi / 5)
 
     with pq.Program() as first_preparation:
@@ -256,7 +269,7 @@ def test_batch_Phaseshifter_mean_position():
             pq.Q() | pq.Beamsplitter(theta=np.pi / 3, phi=np.pi / 3)
 
         simulator = pq.PureFockSimulator(
-            d=2, config=pq.Config(cutoff=5), calculator=pq.TensorflowCalculator()
+            d=2, config=pq.Config(cutoff=5), calculator=calculator
         )
 
         batch_mean_positions = simulator.execute(batch_program).state.mean_position(0)
@@ -292,7 +305,8 @@ def test_batch_Phaseshifter_mean_position():
     assert np.allclose(batch_gradient[1], second_gradient)
 
 
-def test_batch_complex_circuit_mean_position():
+@pytest.mark.parametrize("calculator", calculators)
+def test_batch_complex_circuit_mean_position(calculator):
     theta1 = tf.Variable(np.pi / 3)
     phi1 = tf.Variable(np.pi / 4)
 
@@ -340,7 +354,7 @@ def test_batch_complex_circuit_mean_position():
             pq.Q(1) | pq.Kerr(xi=xi2)
 
         simulator = pq.PureFockSimulator(
-            d=2, config=pq.Config(cutoff=5), calculator=pq.TensorflowCalculator()
+            d=2, config=pq.Config(cutoff=5), calculator=calculator
         )
 
         batch_mean_positions = simulator.execute(batch_program).state.mean_position(0)
@@ -400,7 +414,8 @@ def test_batch_complex_circuit_mean_position():
     assert np.allclose(batch_gradient[:, 1], second_gradient)
 
 
-def test_batch_complex_circuit_mean_position_with_batch_apply():
+@pytest.mark.parametrize("calculator", calculators)
+def test_batch_complex_circuit_mean_position_with_batch_apply(calculator):
     theta1 = tf.Variable(np.pi / 3)
     phi1 = tf.Variable(np.pi / 4)
 
@@ -459,7 +474,7 @@ def test_batch_complex_circuit_mean_position_with_batch_apply():
             pq.Q(1) | pq.Kerr(xi=xi2)
 
         simulator = pq.PureFockSimulator(
-            d=2, config=pq.Config(cutoff=5), calculator=pq.TensorflowCalculator()
+            d=2, config=pq.Config(cutoff=5), calculator=calculator
         )
 
         batch_mean_positions = simulator.execute(batch_program).state.mean_position(0)

--- a/tests/backends/test_backend_equivalence.py
+++ b/tests/backends/test_backend_equivalence.py
@@ -35,9 +35,15 @@ def is_proportional(first, second):
     return np.allclose(first, proportion * second)
 
 
-TensorflowPureFockSimulator = partial(
-    pq.PureFockSimulator,
-    calculator=pq.TensorflowCalculator(),
+tf_purefock_simulators = (
+    partial(
+        pq.PureFockSimulator,
+        calculator=pq.TensorflowCalculator(),
+    ),
+    partial(
+        pq.PureFockSimulator,
+        calculator=pq.TensorflowCalculator(no_custom_gradient=True),
+    ),
 )
 
 
@@ -46,7 +52,7 @@ TensorflowPureFockSimulator = partial(
     (
         pq.GaussianSimulator,
         pq.PureFockSimulator,
-        TensorflowPureFockSimulator,
+        *tf_purefock_simulators,
         pq.FockSimulator,
     ),
 )
@@ -70,7 +76,7 @@ def test_fock_probabilities_should_be_numpy_array_of_floats(SimulatorClass):
     (
         pq.GaussianSimulator,
         pq.PureFockSimulator,
-        TensorflowPureFockSimulator,
+        *tf_purefock_simulators,
         pq.FockSimulator,
     ),
 )
@@ -148,7 +154,7 @@ def test_density_matrix_with_squeezed_state():
     (
         pq.GaussianSimulator,
         pq.PureFockSimulator,
-        TensorflowPureFockSimulator,
+        *tf_purefock_simulators,
         pq.FockSimulator,
     ),
 )
@@ -198,7 +204,7 @@ def test_fock_probabilities_with_displaced_state(SimulatorClass):
     (
         pq.PureFockSimulator,
         pq.FockSimulator,
-        TensorflowPureFockSimulator,
+        *tf_purefock_simulators,
         pq.GaussianSimulator,
     ),
 )
@@ -237,7 +243,7 @@ def test_Displacement_equivalence_on_multiple_modes(SimulatorClass):
     (
         pq.GaussianSimulator,
         pq.PureFockSimulator,
-        TensorflowPureFockSimulator,
+        *tf_purefock_simulators,
         pq.FockSimulator,
     ),
 )
@@ -288,7 +294,7 @@ def test_fock_probabilities_with_displaced_state_with_beamsplitter(SimulatorClas
     (
         pq.GaussianSimulator,
         pq.PureFockSimulator,
-        TensorflowPureFockSimulator,
+        *tf_purefock_simulators,
         pq.FockSimulator,
     ),
 )
@@ -339,7 +345,7 @@ def test_fock_probabilities_with_squeezed_state_with_beamsplitter(SimulatorClass
     (
         pq.GaussianSimulator,
         pq.PureFockSimulator,
-        TensorflowPureFockSimulator,
+        *tf_purefock_simulators,
         pq.FockSimulator,
     ),
 )
@@ -369,7 +375,7 @@ def test_fock_probabilities_with_two_single_mode_squeezings(SimulatorClass):
     (
         pq.GaussianSimulator,
         pq.PureFockSimulator,
-        TensorflowPureFockSimulator,
+        *tf_purefock_simulators,
         pq.FockSimulator,
     ),
 )
@@ -397,7 +403,7 @@ def test_Squeezing_equivalence_on_multiple_modes(SimulatorClass):
     (
         pq.GaussianSimulator,
         pq.PureFockSimulator,
-        TensorflowPureFockSimulator,
+        *tf_purefock_simulators,
         pq.FockSimulator,
     ),
 )
@@ -452,7 +458,7 @@ def test_fock_probabilities_with_two_mode_squeezing(SimulatorClass):
     (
         pq.GaussianSimulator,
         pq.PureFockSimulator,
-        TensorflowPureFockSimulator,
+        *tf_purefock_simulators,
         pq.FockSimulator,
     ),
 )
@@ -503,7 +509,7 @@ def test_fock_probabilities_with_two_mode_squeezing_and_beamsplitter(SimulatorCl
     (
         pq.GaussianSimulator,
         pq.PureFockSimulator,
-        TensorflowPureFockSimulator,
+        *tf_purefock_simulators,
         pq.FockSimulator,
     ),
 )
@@ -551,7 +557,7 @@ def test_fock_probabilities_with_quadratic_phase(SimulatorClass):
     (
         pq.GaussianSimulator,
         pq.PureFockSimulator,
-        TensorflowPureFockSimulator,
+        *tf_purefock_simulators,
         pq.FockSimulator,
     ),
 )
@@ -599,7 +605,7 @@ def test_fock_probabilities_with_position_displacement(SimulatorClass):
     (
         pq.GaussianSimulator,
         pq.PureFockSimulator,
-        TensorflowPureFockSimulator,
+        *tf_purefock_simulators,
         pq.FockSimulator,
     ),
 )
@@ -647,7 +653,7 @@ def test_fock_probabilities_with_momentum_displacement(SimulatorClass):
     (
         pq.GaussianSimulator,
         pq.PureFockSimulator,
-        TensorflowPureFockSimulator,
+        *tf_purefock_simulators,
         pq.FockSimulator,
     ),
 )
@@ -676,7 +682,7 @@ def test_fock_probabilities_with_position_displacement_is_HBAR_independent(
     (
         pq.GaussianSimulator,
         pq.PureFockSimulator,
-        TensorflowPureFockSimulator,
+        *tf_purefock_simulators,
         pq.FockSimulator,
     ),
 )
@@ -705,7 +711,7 @@ def test_fock_probabilities_with_momentum_displacement_is_HBAR_independent(
     (
         pq.GaussianSimulator,
         pq.PureFockSimulator,
-        TensorflowPureFockSimulator,
+        *tf_purefock_simulators,
         pq.FockSimulator,
     ),
 )
@@ -1164,7 +1170,7 @@ def test_fidelity_for_nondisplaced_mixed_states_on_3_modes(SimulatorClass):
     (
         pq.PureFockSimulator,
         pq.FockSimulator,
-        TensorflowPureFockSimulator,
+        *tf_purefock_simulators,
     ),
 )
 def test_cubic_phase_equivalency(SimulatorClass):
@@ -1193,7 +1199,7 @@ def test_cubic_phase_equivalency(SimulatorClass):
     (
         pq.PureFockSimulator,
         pq.FockSimulator,
-        TensorflowPureFockSimulator,
+        *tf_purefock_simulators,
     ),
 )
 def test_CubicPhase_equivalence_on_multiple_modes(SimulatorClass):
@@ -1231,7 +1237,7 @@ def test_CubicPhase_equivalence_on_multiple_modes(SimulatorClass):
     (
         pq.PureFockSimulator,
         pq.FockSimulator,
-        TensorflowPureFockSimulator,
+        *tf_purefock_simulators,
     ),
 )
 def test_Kerr_gate_leaves_fock_probabilities_invariant(SimulatorClass):
@@ -1257,7 +1263,7 @@ def test_Kerr_gate_leaves_fock_probabilities_invariant(SimulatorClass):
     "SimulatorClass",
     (
         pq.PureFockSimulator,
-        TensorflowPureFockSimulator,
+        *tf_purefock_simulators,
     ),
 )
 def test_Kerr_equivalence(SimulatorClass):
@@ -1460,7 +1466,7 @@ def test_Attenuator_raises_InvalidParam_for_non_zero_mean_thermal_excitation(
         pq.PureFockSimulator,
         pq.FockSimulator,
         pq.GaussianSimulator,
-        TensorflowPureFockSimulator,
+        *tf_purefock_simulators,
     ),
 )
 def test_Interferometer_smaller_than_system_size(SimulatorClass):


### PR DESCRIPTION
`tf.function` requires Piquasso to use Tensorflow's NumPy API in the forward pass. By default, we use regular NumPy for performance reasons, but this patch enables users to run Piquasso inside `tf.function`, which might be faster with JIT compilation enabled.

Unfortunately, the JIT compilation is still very slow, and we may need to reduce the number of Python control flows during the calculation.