### PR TITLE
feat(cvqnn): `create_layers`

### DIFF
--- a/piquasso/__init__.py
+++ b/piquasso/__init__.py
@@ -18,6 +18,8 @@
 One can access all the instructions and states from here as attributes.
 """
 
+from piquasso import cvqnn
+
 from piquasso.api.mode import Q
 from piquasso.api.config import Config
 from piquasso.api.instruction import (
@@ -97,6 +99,7 @@ from .instructions.batch import (
 )
 
 
+
 __all__ = [
     # API
     "Program",
@@ -166,6 +169,8 @@ __all__ = [
     # Batch
     "BatchPrepare",
     "BatchApply",
+    # Modules
+    "cvqnn",
 ]
 
 __version__ = "3.0.0"

--- a/piquasso/core/_blackbird.py
+++ b/piquasso/core/_blackbird.py
@@ -19,7 +19,7 @@ from typing import List, Mapping, Optional, Type
 
 import blackbird as bb
 
-from .. import Instruction
+from ..api.instruction import Instruction
 from ..api.exceptions import PiquassoException
 
 

--- a/tests/test_cvqnn.py
+++ b/tests/test_cvqnn.py
@@ -32,6 +32,26 @@ def test_generate_random_cvqnn_weights(layer_count, d):
     assert weights.shape[1] == 4 * d + 2 * (d * (d - 1) + max(1, d - 1))
 
 
+def test_create_layers_yields_valid_program():
+    d = 3
+
+    weights = cvqnn.generate_random_cvqnn_weights(layer_count=10, d=d)
+    layers = cvqnn.create_layers(weights)
+
+    with pq.Program() as program:
+        pq.Q() | pq.Vacuum()
+
+        pq.Q(0) | pq.Displacement(r=0.1, phi=np.pi/5)
+
+        pq.Q() | layers
+
+    simulator = pq.PureFockSimulator(d)
+
+    state = simulator.execute(program).state
+
+    state.validate()
+
+
 def test_create_program_yields_valid_program():
     d = 3
 


### PR DESCRIPTION
In several cases, the CVQNN layers are needed as a subprogram. Moreover, the `cvqnn` module has been included in `piquasso/__init__.py`. Regarding this, a circular import issue has been resolved in `_blackbird.py`.