### PR TITLE
feat(cvqnn): `create_layers`

### DIFF
--- a/piquasso/__init__.py
+++ b/piquasso/__init__.py
@@ -18,6 +18,8 @@
 One can access all the instructions and states from here as attributes.
 """
 
+from piquasso import cvqnn
+
 from piquasso.api.mode import Q
 from piquasso.api.config import Config
 from piquasso.api.instruction import (
@@ -166,6 +168,8 @@ __all__ = [
     # Batch
     "BatchPrepare",
     "BatchApply",
+    # Modules
+    "cvqnn",
 ]
 
 __version__ = "3.0.0"

--- a/piquasso/core/_blackbird.py
+++ b/piquasso/core/_blackbird.py
@@ -19,7 +19,7 @@ from typing import List, Mapping, Optional, Type
 
 import blackbird as bb
 
-from .. import Instruction
+from ..api.instruction import Instruction
 from ..api.exceptions import PiquassoException
 
 

--- a/piquasso/cvqnn.py
+++ b/piquasso/cvqnn.py
@@ -19,18 +19,17 @@ import numpy as np
 
 from dataclasses import dataclass
 
-from piquasso import (
-    Program,
-    Instruction,
-    Vacuum,
+from piquasso.api.program import Program
+from piquasso.api.instruction import Instruction
+from piquasso.api.exceptions import CVQNNException
+from piquasso.instructions.preparations import Vacuum
+from piquasso.instructions.gates import (
     Phaseshifter,
     Beamsplitter,
     Squeezing,
     Displacement,
     Kerr,
 )
-
-from piquasso.api.exceptions import CVQNNException
 
 
 @dataclass
@@ -86,8 +85,22 @@ def generate_random_cvqnn_weights(
     )
 
 
-def create_program(weights: np.ndarray) -> Program:
-    """Creates a `Program` from the specified weights.
+def create_layers(weights: np.ndarray) -> Program:
+    """Creates a subprogram from the specified weights.
+
+    Example usage::
+
+        import piquasso as pq
+
+        weights = pq.cvqnn.generate_random_cvqnn_weights(layer_count=10, d=5)
+
+        cvnn_layers = pq.cvqnn.create_program(weights)
+
+        with pq.Program() as program:
+            for i in range(d):
+                pq.Q(i) | pq.Displacement(r=0.1)
+
+            pq.Q() | cvnn_layers
 
     Args:
         weights (np.ndarray): The CVQNN circuit weights.
@@ -95,6 +108,7 @@ def create_program(weights: np.ndarray) -> Program:
     Returns:
         Program: The program of the CVQNN circuit, ready to be executed.
     """
+
     d = get_number_of_modes(weights.shape[1])
     layer_count = weights.shape[0]
 
@@ -104,7 +118,24 @@ def create_program(weights: np.ndarray) -> Program:
         layer_parameters = _parse_layer(weights[k], d)
         instructions.extend(_instructions_from_layer(layer_parameters, d))
 
-    return Program([Vacuum()] + instructions)
+    return Program(instructions)
+
+
+def create_program(weights: np.ndarray) -> Program:
+    """Creates a `Program` from the specified weights, with vacuum initial state.
+
+    Args:
+        weights (np.ndarray): The CVQNN circuit weights.
+
+    Returns:
+        Program: The program of the CVQNN circuit, ready to be executed.
+    """
+
+    cvqnn_layers = create_layers(weights)
+
+    program = Program(instructions=[Vacuum()] + cvqnn_layers.instructions)
+
+    return program
 
 
 def get_number_of_modes(number_of_parameters: int) -> int:

--- a/tests/test_cvqnn.py
+++ b/tests/test_cvqnn.py
@@ -32,6 +32,26 @@ def test_generate_random_cvqnn_weights(layer_count, d):
     assert weights.shape[1] == 4 * d + 2 * (d * (d - 1) + max(1, d - 1))
 
 
+def test_create_layers_yields_valid_program():
+    d = 3
+
+    weights = cvqnn.generate_random_cvqnn_weights(layer_count=10, d=d)
+    layers = cvqnn.create_layers(weights)
+
+    with pq.Program() as program:
+        pq.Q() | pq.Vacuum()
+
+        pq.Q(0) | pq.Displacement(r=0.1, phi=np.pi / 5)
+
+        pq.Q() | layers
+
+    simulator = pq.PureFockSimulator(d)
+
+    state = simulator.execute(program).state
+
+    state.validate()
+
+
 def test_create_program_yields_valid_program():
     d = 3
 


### PR DESCRIPTION
In several cases, the CVQNN layers are needed as a subprogram. Moreover, the `cvqnn` module has been included in `piquasso/__init__.py`. Regarding this, a circular import issue has been resolved in `_blackbird.py`.