### PR TITLE
feat!(fock): Refactor `FockSpace`

### DIFF
--- a/benchmarks/purefock_interferometer_increasing_modes_benchmark.py
+++ b/benchmarks/purefock_interferometer_increasing_modes_benchmark.py
@@ -38,7 +38,7 @@ def cutoff():
     return 4
 
 
-parameters = [(d, unitary_group.rvs(d)) for d in range(3, 6)]
+parameters = [(d, unitary_group.rvs(d)) for d in range(3, 18)]
 
 
 @pytest.mark.parametrize("d, interferometer", parameters)
@@ -55,7 +55,7 @@ def piquasso_benchmark(benchmark, d, interferometer, cutoff, theta):
         simulator_fock.execute(program)
 
 
-@pytest.mark.parametrize("d, interferometer", parameters)
+@pytest.mark.parametrize("d, interferometer", parameters[:2])
 def strawberryfields_benchmark(benchmark, d, interferometer, cutoff, theta):
     @benchmark
     def func():

--- a/piquasso/_backends/calculator.py
+++ b/piquasso/_backends/calculator.py
@@ -155,17 +155,9 @@ class TensorflowCalculator(_BuiltinCalculator):
         # NOTE: This is not as advanced as `numpy.block`, this function only supports
         # 4 same-length blocks.
 
-        d = len(arrays[0][0])
-
-        output = []
-
-        for i in range(d):
-            output.append(self.np.concatenate([arrays[0][0][i], arrays[0][1][i]]))
-
-        for i in range(d):
-            output.append(self.np.concatenate([arrays[1][0][i], arrays[1][1][i]]))
-
-        return self.np.stack(output)
+        return self._tf.concat(
+            [self._tf.concat(arrays[0], 1), self._tf.concat(arrays[1], 1)], 0
+        )
 
     def scatter(self, indices, updates, shape):
         return self._tf.scatter_nd(indices, updates, shape)

--- a/piquasso/_backends/fock/pure/batch_state.py
+++ b/piquasso/_backends/fock/pure/batch_state.py
@@ -22,7 +22,6 @@ from piquasso.api.exceptions import InvalidState
 from piquasso.api.calculator import BaseCalculator
 
 from piquasso._math.linalg import vector_absolute_square
-from piquasso._math.indices import get_index_in_fock_space
 
 from .state import PureFockState
 
@@ -108,37 +107,6 @@ class BatchPureFockState(PureFockState):
                 "The sum of probabilities is not close to 1.0 for at least one state "
                 "in the batch."
             )
-
-    def _get_mean_position_indices(self, mode):
-        fallback_np = self._calculator.fallback_np
-
-        left_indices = []
-        multipliers = []
-        right_indices = []
-
-        for index, basis in enumerate(self._space):
-            i = basis[mode]
-            basis_array = fallback_np.array(basis)
-
-            if i > 0:
-                basis_array[mode] = i - 1
-                lower_index = get_index_in_fock_space(tuple(basis_array))
-
-                left_indices.append(lower_index)
-                multipliers.append(fallback_np.sqrt(i))
-                right_indices.append(index)
-
-            if sum(basis) + 1 < self._config.cutoff:
-                basis_array[mode] = i + 1
-                upper_index = get_index_in_fock_space(tuple(basis_array))
-
-                left_indices.append(upper_index)
-                multipliers.append(fallback_np.sqrt(i + 1))
-                right_indices.append(index)
-
-        multipliers = fallback_np.array(multipliers)
-
-        return multipliers, left_indices, right_indices
 
     def mean_position(self, mode: int) -> np.ndarray:
         np = self._calculator.np

--- a/piquasso/_backends/fock/state.py
+++ b/piquasso/_backends/fock/state.py
@@ -21,7 +21,7 @@ from piquasso.api.config import Config
 from piquasso.api.state import State
 from piquasso.api.calculator import BaseCalculator
 
-from piquasso._math import fock
+from piquasso._math.fock import get_fock_space_basis
 from piquasso.api.exceptions import InvalidModes
 
 
@@ -30,44 +30,12 @@ class BaseFockState(State, abc.ABC):
         self, *, d: int, calculator: BaseCalculator, config: Optional[Config] = None
     ) -> None:
         super().__init__(calculator=calculator, config=config)
-
-        self._initialize_subspaces(d)
-
-    def _initialize_subspaces(self, d):
-        """
-        NOTE: Calculating the subspaces (the indices, essentially) is a costly
-        calculation, and it is beneficial to have them stored for later purposes
-        """
-        self._space = self._init_subspace(d)
-
-        self._subspace_cache = {
-            1: self._init_subspace(1),
-            2: self._init_subspace(2),
-            d - 1: self._init_subspace(d - 1),
-            d: self._space,
-        }
-
-    def _init_subspace(self, dim):
-        return fock.FockSpace(
-            d=dim,
-            cutoff=self._config.cutoff,
-            calculator=self._calculator,
-            config=self._config,
-        )
-
-    def _get_subspace(self, dim):
-        if dim in self._subspace_cache.keys():
-            return self._subspace_cache[dim]
-
-        subspace = self._init_subspace(dim)
-
-        self._subspace_cache[dim] = subspace
-
-        return subspace
+        self._d = d
+        self._space = get_fock_space_basis(d=d, cutoff=config.cutoff)  # type: ignore
 
     @property
     def d(self) -> int:
-        return self._space.d
+        return self._d
 
     @property
     def norm(self) -> int:

--- a/piquasso/_backends/gaussian/calculations.py
+++ b/piquasso/_backends/gaussian/calculations.py
@@ -427,7 +427,7 @@ def _get_particle_number_choice(
     possible_choices = tuple(range(state._config.measurement_cutoff))
 
     for n in possible_choices:
-        occupation_numbers = previous_sample + (n,)
+        occupation_numbers = np.array(previous_sample + (n,))
 
         hafnian_value = (
             state._calculator.loop_hafnian(B, gamma, occupation_numbers)

--- a/piquasso/_backends/gaussian/probabilities.py
+++ b/piquasso/_backends/gaussian/probabilities.py
@@ -15,7 +15,7 @@
 
 import abc
 
-from typing import List, Tuple
+from typing import Tuple
 
 import numpy as np
 
@@ -33,13 +33,11 @@ class DensityMatrixCalculation(abc.ABC):
         self.calculator = calculator
 
     @abc.abstractmethod
-    def calculate_hafnian(self, reduce_on: Tuple[int, ...]) -> float:
+    def calculate_hafnian(self, reduce_on: np.ndarray) -> float:
         """Calculates the hafnian given a reduction."""
 
-    def get_density_matrix_element(
-        self, bra: Tuple[int, ...], ket: Tuple[int, ...]
-    ) -> float:
-        reduce_on = ket + bra
+    def get_density_matrix_element(self, bra: np.ndarray, ket: np.ndarray) -> float:
+        reduce_on = np.concatenate([ket, bra])
 
         return (
             self._normalization
@@ -47,10 +45,8 @@ class DensityMatrixCalculation(abc.ABC):
             / np.sqrt(np.prod(factorial(reduce_on)))
         )
 
-    def get_density_matrix(
-        self, occupation_numbers: List[Tuple[int, ...]]
-    ) -> np.ndarray:
-        n = len(occupation_numbers)
+    def get_density_matrix(self, occupation_numbers: np.ndarray) -> np.ndarray:
+        n = occupation_numbers.shape[0]
 
         density_matrix = np.empty(shape=(n, n), dtype=complex)
 
@@ -61,7 +57,7 @@ class DensityMatrixCalculation(abc.ABC):
         return density_matrix
 
     def get_particle_number_detection_probabilities(
-        self, occupation_numbers: List[Tuple[int, ...]]
+        self, occupation_numbers: np.ndarray
     ) -> np.ndarray:
         ret_list = []
 
@@ -107,7 +103,7 @@ class NondisplacedDensityMatrixCalculation(DensityMatrixCalculation):
 
         self._normalization: float = 1 / np.sqrt(np.linalg.det(Q))
 
-    def calculate_hafnian(self, reduce_on: Tuple[int, ...]) -> float:
+    def calculate_hafnian(self, reduce_on: np.ndarray) -> float:
         return self.calculator.hafnian(self._A, reduce_on)
 
 
@@ -142,7 +138,7 @@ class DisplacedDensityMatrixCalculation(DensityMatrixCalculation):
             -0.5 * self._gamma @ complex_displacement
         ) / np.sqrt(np.linalg.det(Q))
 
-    def calculate_hafnian(self, reduce_on: Tuple[int, ...]) -> float:
+    def calculate_hafnian(self, reduce_on: np.ndarray) -> float:
         return self.calculator.loop_hafnian(self._A, self._gamma, reduce_on)
 
 

--- a/piquasso/_backends/gaussian/state.py
+++ b/piquasso/_backends/gaussian/state.py
@@ -30,7 +30,7 @@ from piquasso._math.linalg import (
     is_positive_semidefinite,
 )
 from piquasso._math.symplectic import symplectic_form
-from piquasso._math.combinatorics import get_occupation_numbers
+from piquasso._math.fock import get_fock_space_basis
 from piquasso._math.transformations import from_xxpp_to_xpxp_transformation_matrix
 
 from piquasso._math.decompositions import williamson
@@ -791,7 +791,7 @@ class GaussianState(State):
         calculation = self._get_density_matrix_calculation()
 
         return calculation.get_density_matrix(
-            get_occupation_numbers(d=self.d, cutoff=self._config.cutoff)
+            get_fock_space_basis(d=self.d, cutoff=self._config.cutoff)
         )
 
     def wigner_function(
@@ -843,7 +843,7 @@ class GaussianState(State):
         )
 
     def get_particle_detection_probability(
-        self, occupation_number: Tuple[int, ...]
+        self, occupation_number: np.ndarray
     ) -> float:
         if len(occupation_number) != self.d:
             raise PiquassoException(
@@ -863,7 +863,7 @@ class GaussianState(State):
         calculation = self._get_density_matrix_calculation()
 
         return calculation.get_particle_number_detection_probabilities(
-            get_occupation_numbers(d=self.d, cutoff=self._config.cutoff)
+            get_fock_space_basis(d=self.d, cutoff=self._config.cutoff)
         )
 
     def is_pure(self) -> bool:

--- a/piquasso/_math/decompositions.py
+++ b/piquasso/_math/decompositions.py
@@ -268,17 +268,9 @@ def euler(symplectic, calculator):
     np = calculator.np
     d = len(symplectic) // 2
 
-    identity = np.identity(d)
-    zeros = np.zeros(shape=(d, d), dtype=complex)
-
     U_orig, R = calculator.polar(symplectic, side="left")
 
-    K = calculator.block(
-        [
-            [identity, zeros],
-            [zeros, -identity],
-        ],
-    )
+    K = np.diag([1.0] * d + [-1.0] * d)
 
     H_active = 1j * K @ calculator.logm(R)
 

--- a/piquasso/_math/fock.py
+++ b/piquasso/_math/fock.py
@@ -14,10 +14,9 @@
 # limitations under the License.
 
 import functools
-from typing import Tuple, Iterable, Generator, Any, List
+from typing import Tuple
 
 import numpy as np
-from operator import add
 
 from scipy.special import comb
 
@@ -31,6 +30,8 @@ from piquasso._math.gate_matrices import (
     create_single_mode_displacement_matrix,
     create_single_mode_squeezing_matrix,
 )
+from piquasso._math.indices import get_index_in_fock_space
+
 from piquasso.api.calculator import BaseCalculator
 
 
@@ -45,274 +46,138 @@ def cutoff_cardinality(*, cutoff: int, d: int) -> int:
     return comb(d + cutoff - 1, cutoff - 1, exact=True)
 
 
-@functools.lru_cache()
-def symmetric_subspace_cardinality(*, d: int, n: int) -> int:
-    return comb(d + n - 1, n, exact=True)
+def cutoff_cardinality_array(*, cutoff, d):
+    return np.round(comb(d + cutoff - 1, d)).astype(int)
+
+
+def symmetric_subspace_cardinality_array(*, d: int, n: int) -> int:
+    return np.round(comb(d + n - 1, n)).astype(int)
 
 
 @functools.lru_cache(maxsize=None)
-def _create_all_fock_basis_elements(d: int, cutoff: int) -> List[Tuple[int, ...]]:
-    ret = []
-
-    for n in range(cutoff):
-        ret.extend(partitions(boxes=d, particles=n, class_=FockBasis))
+def get_fock_space_basis(d: int, cutoff: int) -> np.ndarray:
+    ret = np.vstack([partitions(boxes=d, particles=n) for n in range(cutoff)])
 
     return ret
 
 
-class FockBasis(tuple):
-    def __str__(self) -> str:
-        return self.display(template="|{}>")
+def get_single_mode_squeezing_operator(
+    r: float,
+    phi: float,
+    calculator: BaseCalculator,
+    config: Config,
+) -> np.ndarray:
+    @calculator.custom_gradient
+    def _single_mode_squeezing_operator(r, phi):
+        r = calculator.maybe_convert_to_numpy(r)
+        phi = calculator.maybe_convert_to_numpy(phi)
 
-    def display(self, template: str = "{}") -> str:
-        return template.format("".join([str(number) for number in self]))
+        matrix = create_single_mode_squeezing_matrix(
+            r,
+            phi,
+            config.cutoff,
+            complex_dtype=config.complex_dtype,
+        )
+        grad = create_single_mode_squeezing_gradient(
+            r,
+            phi,
+            config.cutoff,
+            matrix,
+            calculator,
+        )
+        return matrix, grad
 
-    def display_as_bra(self) -> str:
-        return self.display("<{}|")
-
-    def __repr__(self) -> str:
-        return str(self)
-
-    def __add__(self, other: Iterable) -> "FockBasis":
-        return FockBasis(map(add, self, other))
-
-    __radd__ = __add__
-
-    @property
-    def d(self) -> int:
-        return len(self)
-
-    @property
-    def n(self) -> int:
-        return sum(self)
-
-    @classmethod
-    def create_all(cls, *, d: int, cutoff: int) -> List[Tuple[int, ...]]:
-        return _create_all_fock_basis_elements(d, cutoff)
-
-    def on_modes(self, *, modes: Tuple[int, ...]) -> "FockBasis":
-        return FockBasis(self[mode] for mode in modes)
-
-    def increment_on_modes(self, modes: Tuple[int, ...]) -> "FockBasis":
-        a = [0] * self.d
-        for mode in modes:
-            a[mode] = 1
-
-        return self + a
+    return _single_mode_squeezing_operator(r, phi)
 
 
-class FockOperatorBasis(tuple):
-    def __new__(cls, *, ket: Iterable, bra: Iterable) -> "FockOperatorBasis":
-        return super().__new__(cls, (FockBasis(ket), FockBasis(bra)))  # type: ignore
+def get_single_mode_cubic_phase_operator(
+    gamma: float, config: Config, calculator: BaseCalculator
+) -> np.ndarray:
+    r"""Cubic Phase gate.
 
-    def __str__(self) -> str:
-        return str(self.ket) + self.bra.display_as_bra()
-
-    @property
-    def ket(self) -> FockBasis:
-        return self[0]
-
-    @property
-    def bra(self) -> FockBasis:
-        return self[1]
-
-    def is_diagonal_on_modes(self, modes: Tuple[int, ...]) -> bool:
-        return self.ket.on_modes(modes=modes) == self.bra.on_modes(modes=modes)
-
-
-class FockSpace(tuple):
-    r"""
-    Note, that when you symmetrize a tensor, i.e. use the superoperator
+    The definition of the Cubic Phase gate is
 
     .. math::
-        S: A \otimes B \mapsto A \vee B
+        \operatorname{CP}(\gamma) = e^{i \hat{x}^3 \frac{\gamma}{3 \hbar}}
 
-    on a tensor which is expressed in the regular Fock basis, then the resulting tensor
-    still remains in the regular representation. You have to perform a basis
-    transformation to acquire the symmetrized tensor in the symmetrized representation.
+    The Cubic Phase gate transforms the annihilation operator as
+
+    .. math::
+        \operatorname{CP}^\dagger(\gamma) \hat{a} \operatorname{CP}(\gamma) =
+            \hat{a} + i\frac{\gamma(\hat{a} +\hat{a}^\dagger)^2}{2\sqrt{2/\hbar}}
+
+    It transforms the :math:`\hat{p}` quadrature as follows:
+
+    .. math::
+        \operatorname{CP}^\dagger(\gamma) \hat{p} \operatorname{CP}(\gamma) =
+            \hat{p} + \gamma \hat{x}^2.
+
+    Args:
+        gamma (float): The Cubic Phase parameter.
+        hbar (float): Scaling parameter.
+    Returns:
+        np.ndarray:
+            The resulting transformation, which could be applied to the state.
     """
 
-    def __new__(
-        cls, d: int, cutoff: int, calculator: BaseCalculator, config: Config
-    ) -> "FockSpace":
-        return super().__new__(
-            cls, FockBasis.create_all(d=d, cutoff=cutoff)  # type: ignore
+    np = calculator.np
+
+    annih = np.diag(np.sqrt(np.arange(1, config.cutoff)), 1)
+    position = (annih.T + annih) * np.sqrt(config.hbar / 2)
+    return calculator.expm(
+        1j * calculator.powm(position, 3) * (gamma / (3 * config.hbar))
+    )
+
+
+def operator_basis(space):
+    for index, basis in enumerate(space):
+        for dual_index, dual_basis in enumerate(space):
+            yield (index, dual_index), (basis, dual_basis)
+
+
+def get_creation_operator(
+    modes: Tuple[int, ...], space: np.ndarray, config: Config
+) -> np.ndarray:
+    d = len(space[0])
+    size = cutoff_cardinality(cutoff=config.cutoff, d=d)
+    operator = np.zeros(shape=(size,) * 2, dtype=config.complex_dtype)
+
+    for index, basis in enumerate(space):
+        basis = np.array(basis)
+        basis[modes,] += np.ones_like(modes)
+        dual_index = get_index_in_fock_space(tuple(basis))
+
+        if dual_index < size:
+            operator[dual_index, index] = 1
+
+    return operator
+
+
+def get_annihilation_operator(
+    modes: Tuple[int, ...], space: np.ndarray, config: Config
+) -> np.ndarray:
+    return get_creation_operator(modes, space, config).transpose()
+
+
+def get_single_mode_displacement_operator(r, phi, calculator, config):
+    @calculator.custom_gradient
+    def _single_mode_displacement_operator(r, phi):
+        r = calculator.maybe_convert_to_numpy(r)
+        phi = calculator.maybe_convert_to_numpy(phi)
+
+        matrix = create_single_mode_displacement_matrix(
+            r,
+            phi,
+            config.cutoff,
+            complex_dtype=config.complex_dtype,
         )
-
-    def __init__(
-        self, *, d: int, cutoff: int, calculator: BaseCalculator, config: Config
-    ) -> None:
-        self.d = d
-        self.cutoff = cutoff
-        self.calculator = calculator
-        self.config = config
-        self._calculator = calculator
-
-    def __deepcopy__(self, memo: Any) -> "FockSpace":
-        """
-        This method exists, because `copy.deepcopy` produces errors with classes
-        defining both `__new__` and `__init__`.
-
-        It defines the deepcopy of this object. Since its state (:attr:`d` and
-        :attr:`cutoff`) is immutable, we don't really need to deepcopy this object, we
-        could return with this instance, too.
-        """
-
-        return self
-
-    def get_single_mode_squeezing_operator(
-        self,
-        *,
-        r: float,
-        phi: float,
-    ) -> np.ndarray:
-        @self.calculator.custom_gradient
-        def _single_mode_squeezing_operator(r, phi):
-            r = self.calculator.maybe_convert_to_numpy(r)
-            phi = self.calculator.maybe_convert_to_numpy(phi)
-
-            matrix = create_single_mode_squeezing_matrix(
-                r, phi, self.cutoff, complex_dtype=self.config.complex_dtype
-            )
-            grad = create_single_mode_squeezing_gradient(
-                r,
-                phi,
-                self.cutoff,
-                matrix,
-                self.calculator,
-            )
-            return matrix, grad
-
-        return _single_mode_squeezing_operator(r, phi)
-
-    def get_single_mode_cubic_phase_operator(
-        self, *, gamma: float, hbar: float, calculator: BaseCalculator
-    ) -> np.ndarray:
-        r"""Cubic Phase gate.
-
-        The definition of the Cubic Phase gate is
-
-        .. math::
-            \operatorname{CP}(\gamma) = e^{i \hat{x}^3 \frac{\gamma}{3 \hbar}}
-
-        The Cubic Phase gate transforms the annihilation operator as
-
-        .. math::
-            \operatorname{CP}^\dagger(\gamma) \hat{a} \operatorname{CP}(\gamma) =
-                \hat{a} + i\frac{\gamma(\hat{a} +\hat{a}^\dagger)^2}{2\sqrt{2/\hbar}}
-
-        It transforms the :math:`\hat{p}` quadrature as follows:
-
-        .. math::
-            \operatorname{CP}^\dagger(\gamma) \hat{p} \operatorname{CP}(\gamma) =
-                \hat{p} + \gamma \hat{x}^2.
-
-        Args:
-            gamma (float): The Cubic Phase parameter.
-            hbar (float): Scaling parameter.
-        Returns:
-            np.ndarray:
-                The resulting transformation, which could be applied to the state.
-        """
-
-        np = calculator.np
-
-        annih = np.diag(np.sqrt(np.arange(1, self.cutoff)), 1)
-        position = (annih.T + annih) * np.sqrt(hbar / 2)
-        return calculator.expm(1j * calculator.powm(position, 3) * (gamma / (3 * hbar)))
-
-    @property
-    def cardinality(self) -> int:
-        return cutoff_cardinality(cutoff=self.cutoff, d=self.d)
-
-    @property
-    def basis(self) -> Generator[Tuple[int, FockBasis], Any, None]:
-        yield from enumerate(self)
-
-    @property
-    def operator_basis(
-        self,
-    ) -> Generator[Tuple[Tuple[int, int], FockOperatorBasis], Any, None]:
-        for index, basis in self.basis:
-            for dual_index, dual_basis in self.basis:
-                yield (index, dual_index), FockOperatorBasis(ket=basis, bra=dual_basis)
-
-    def operator_basis_diagonal_on_modes(
-        self, *, modes: Tuple[int, ...]
-    ) -> Generator[Tuple[Tuple[int, int], FockOperatorBasis], Any, None]:
-        yield from [
-            (index, basis)
-            for index, basis in self.operator_basis
-            if basis.is_diagonal_on_modes(modes=modes)
-        ]
-
-    def get_occupied_basis(
-        self, *, modes: Tuple[int, ...], occupation_numbers: Tuple[int, ...]
-    ) -> FockBasis:
-        temp = [0] * self.d
-        for index, mode in enumerate(modes):
-            temp[mode] = occupation_numbers[index]
-
-        return FockBasis(temp)
-
-    def get_projection_operator_indices_for_pure(
-        self, *, subspace_basis: Tuple[int, ...], modes: Tuple[int, ...]
-    ) -> List[int]:
-        return [
-            index
-            for index, basis in self.basis
-            if subspace_basis == basis.on_modes(modes=modes)
-        ]
-
-    def get_projection_operator_indices(
-        self, *, subspace_basis: Tuple[int, ...], modes: Tuple[int, ...]
-    ) -> Tuple[Tuple[int, ...], Tuple[int, ...]]:
-        return tuple(  # type: ignore
-            zip(
-                *[
-                    index
-                    for index, operator_basis in self.operator_basis
-                    if operator_basis.is_diagonal_on_modes(modes=modes)
-                    and subspace_basis == operator_basis.ket.on_modes(modes=modes)
-                ]
-            )
+        grad = create_single_mode_displacement_gradient(
+            r,
+            phi,
+            config.cutoff,
+            matrix,
+            calculator,
         )
+        return matrix, grad
 
-    def get_creation_operator(self, modes: Tuple[int, ...]) -> np.ndarray:
-        operator = np.zeros(
-            shape=(self.cardinality,) * 2, dtype=self.config.complex_dtype
-        )
-
-        for index, basis in enumerate(self):
-            dual_basis = basis.increment_on_modes(modes)
-            try:
-                dual_index = self.index(dual_basis)
-                operator[dual_index, index] = 1
-            except ValueError:
-                # TODO: rethink.
-                continue
-
-        return operator
-
-    def get_annihilation_operator(self, modes: Tuple[int, ...]) -> np.ndarray:
-        return self.get_creation_operator(modes).transpose()
-
-    def get_single_mode_displacement_operator(self, *, r, phi):
-        @self.calculator.custom_gradient
-        def _single_mode_displacement_operator(r, phi):
-            r = self.calculator.maybe_convert_to_numpy(r)
-            phi = self.calculator.maybe_convert_to_numpy(phi)
-
-            matrix = create_single_mode_displacement_matrix(
-                r, phi, self.cutoff, complex_dtype=self.config.complex_dtype
-            )
-            grad = create_single_mode_displacement_gradient(
-                r,
-                phi,
-                self.cutoff,
-                matrix,
-                self.calculator,
-            )
-            return matrix, grad
-
-        return _single_mode_displacement_operator(r, phi)
+    return _single_mode_displacement_operator(r, phi)

--- a/piquasso/_math/indices.py
+++ b/piquasso/_math/indices.py
@@ -15,8 +15,6 @@
 
 from typing import Tuple
 
-import functools
-
 import numpy as np
 
 from scipy.special import comb
@@ -43,8 +41,7 @@ def get_auxiliary_operator_index(
     return auxiliary_rows, auxiliary_modes
 
 
-@functools.lru_cache(maxsize=None)
-def get_index_in_fock_space(element: Tuple[int, ...]) -> int:
+def get_index_in_fock_space(element):
     sum_ = 0
     accumulator = 0
     for i in range(len(element)):
@@ -54,13 +51,34 @@ def get_index_in_fock_space(element: Tuple[int, ...]) -> int:
     return accumulator
 
 
-@functools.lru_cache(maxsize=None)
-def get_index_in_fock_subspace(element: Tuple[int, ...]) -> int:
+def get_index_in_fock_space_array(basis: np.ndarray) -> np.ndarray:
+    sum_ = np.zeros(shape=basis.shape[:-1], dtype=int)
+    accumulator = np.zeros(shape=basis.shape[:-1], dtype=int)
+
+    for i in range(basis.shape[-1]):
+        sum_ += basis[..., -1 - i]
+        accumulator += np.round(comb(sum_ + i, i + 1)).astype(int)
+
+    return accumulator
+
+
+def get_index_in_fock_subspace(element: np.ndarray) -> int:
     sum_ = 0
     accumulator = 0
     for i in range(len(element) - 1):
         sum_ += element[-1 - i]
         accumulator += comb(sum_ + i, i + 1, exact=True)
+
+    return accumulator
+
+
+def get_index_in_fock_subspace_array(basis: np.ndarray) -> np.ndarray:
+    sum_ = np.zeros(shape=basis.shape[:-1], dtype=int)
+    accumulator = np.zeros(shape=basis.shape[:-1], dtype=int)
+
+    for i in range(basis.shape[-1] - 1):
+        sum_ += basis[..., -1 - i]
+        accumulator += np.round(comb(sum_ + i, i + 1)).astype(int)
 
     return accumulator
 

--- a/piquasso/api/calculator.py
+++ b/piquasso/api/calculator.py
@@ -51,11 +51,11 @@ class BaseCalculator(abc.ABC):
     ) -> float:
         raise NotImplementedCalculation()
 
-    def hafnian(self, matrix: numpy.ndarray, reduce_on: Tuple[int, ...]) -> float:
+    def hafnian(self, matrix: numpy.ndarray, reduce_on: numpy.ndarray) -> float:
         raise NotImplementedCalculation()
 
     def loop_hafnian(
-        self, matrix: numpy.ndarray, diagonal: numpy.ndarray, reduce_on: Tuple[int, ...]
+        self, matrix: numpy.ndarray, diagonal: numpy.ndarray, reduce_on: numpy.ndarray
     ) -> float:
         raise NotImplementedCalculation()
 

--- a/piquasso/api/state.py
+++ b/piquasso/api/state.py
@@ -84,7 +84,7 @@ class State(abc.ABC):
 
     @abc.abstractmethod
     def get_particle_detection_probability(
-        self, occupation_number: Tuple[int, ...]
+        self, occupation_number: np.ndarray
     ) -> float:
         """
         Returns the particle number detection probability using the occupation number

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -15,6 +15,8 @@
 
 import pytest
 
+import numpy as np
+
 import piquasso as pq
 from piquasso.api.calculator import BaseCalculator
 
@@ -54,7 +56,9 @@ def FakeState():
 
             self._d = d
 
-        def get_particle_detection_probability(self, occupation_number: tuple) -> float:
+        def get_particle_detection_probability(
+            self, occupation_number: np.ndarray
+        ) -> float:
             """
             NOTE: This needs to be here to be able to instantiate this class.
             """


### PR DESCRIPTION
**Problem**

The logic around `piquasso._math.fock` was quite a bit difficult.

1. The `FockSpace`, `FockBasis`, `FockOperatorBasis` classes overloaded builtin types, which were, frankly, quite unnecessary.

2. The `FockSpace` object is responsible for storing the occupation numbers, in an order which prescribes the ordering of the state vector or the density matrix. However, since calculations depend on `BaseCalculator` and `Config` objects, it was convenient to store these as attributes. This made copying this object a bit involved.

3. Creating a `FockSpace` can be expensive, therefore a caching has been implemented in `BaseFockState`, but this would be unnecessary if one would refactor `FockSpace` into a function and decorate it with `lru_cache`.

4. `FockSpace` is just a tuple of tuples of occupation numbers. However, for most calculations, it is easier and faster to use `np.ndarray`, especially if the calculation can be vectorized.

**Solution**

The `FockSpace`, `FockBasis` and `FockOperatorBasis` classes were deleted. Instead of `FockSpace`, the occupation numbers are stored as a `numpy.ndarray`. This change made lots of calculations vectorizable, hence reducing the need to resort to Python for loops. Hence, where it was possible, these calculations were vectorized.

Caching has also been re-implemented by simply using `lru_cache`.