### PR TITLE
feat(tensorflow): Choose NumPy API in forward pass

### DIFF
--- a/benchmarks/tf_1_mode_cvnn_benchmark.py
+++ b/benchmarks/tf_1_mode_cvnn_benchmark.py
@@ -81,6 +81,7 @@ def test_state_vector_and_jacobian(weights, cutoff, layer_count):
     assert np.allclose(pq_jacobian, sf_jacobian)
 
 
+@tf.function
 def _calculate_piquasso_results(weights, cutoff, layer_count):
     simulator = pq.PureFockSimulator(
         d=1,

--- a/piquasso/_backends/calculator.py
+++ b/piquasso/_backends/calculator.py
@@ -28,6 +28,34 @@ from piquasso.api.calculator import BaseCalculator
 class _BuiltinCalculator(BaseCalculator):
     """Base class for built-in calculators."""
 
+    def accumulator(self, dtype, size, **kwargs):
+        return []
+
+    def write(self, accumulator, index, value):
+        accumulator.append(value)
+
+        return accumulator
+
+    def stack_accumulator(self, accumulator):
+        return self.forward_pass_np.stack(accumulator)
+
+    def read(self, accumulator, index):
+        return accumulator[index]
+
+    def size(self, accumulator):
+        return len(accumulator)
+
+    def decorator(self, func):
+        return func
+
+
+def _noop_custom_gradient(func):
+    def noop_grad(*args, **kwargs):
+        result, _ = func(*args, **kwargs)
+        return result
+
+    return noop_grad
+
 
 class NumpyCalculator(_BuiltinCalculator):
     """The calculations for a simulation using NumPy (and SciPy).
@@ -38,6 +66,7 @@ class NumpyCalculator(_BuiltinCalculator):
     def __init__(self):
         self.np = np
         self.fallback_np = np
+        self.forward_pass_np = np
         self.block_diag = scipy.linalg.block_diag
         self.block = np.block
         self.logm = scipy.linalg.logm
@@ -51,7 +80,11 @@ class NumpyCalculator(_BuiltinCalculator):
         self.hafnian = hafnian_with_reduction
         self.loop_hafnian = loop_hafnian_with_reduction
 
-    def maybe_convert_to_numpy(self, value):
+        self.custom_gradient = _noop_custom_gradient
+
+        self.range = range
+
+    def preprocess_input_for_custom_gradient(self, value):
         return value
 
     def assign(self, array, index, value):
@@ -68,12 +101,8 @@ class NumpyCalculator(_BuiltinCalculator):
 
         return embedded_matrix
 
-    def custom_gradient(self, func):
-        def wrapper(*args, **kwargs):
-            result, _ = func(*args, **kwargs)
-            return result
-
-        return wrapper
+    def gather_along_axis_1(self, array, indices):
+        return array[:, indices]
 
 
 class TensorflowCalculator(_BuiltinCalculator):
@@ -112,7 +141,17 @@ class TensorflowCalculator(_BuiltinCalculator):
         gradient = tape.gradient(mean, [r])
     """
 
-    def __init__(self):
+    def __init__(self, decorate_with=None):
+        """
+        Args:
+            decorate_with (function, optional): A function to decorate calculations
+            with. Currently, only `tf.function` is supported. Specifying this may
+            reduce runtime after the tracing step. See
+            `Better performance with tf.function https://www.tensorflow.org/guide/function`_.
+
+        Raises:
+            ImportError: When TensorFlow is not available.
+        """  # noqa: E501
         try:
             import tensorflow as tf
         except ImportError:
@@ -131,10 +170,67 @@ class TensorflowCalculator(_BuiltinCalculator):
         self._tf = tf
         self.np = tnp
         self.fallback_np = np
+
+        self._decorate_with = decorate_with
+
+        # NOTE: `_decorated_functions` are not copied in `__deepcopy__`, but it is not
+        # necessarily a problem, worst case scenario is a retracing. However, I think
+        # there would be no problem copying `_decorated_functions` as long as the
+        # decorated functions do not depend on local variables outside of the function.
+        # Not doing this, retracing may occur when providing an initial state in
+        # `Program.execute_instructions`. Solving this might be better to avoid using
+        # `deepcopy` and implement `copy` functions for each `State` subclass.
+        self._decorated_functions = dict()
+
+        self.decorator_provided = self._decorate_with is not None
+
+        if self.decorator_provided:
+            self.decorator = self._decorator
+
         self.sqrtm = tf.linalg.sqrtm
 
-    def maybe_convert_to_numpy(self, value):
+        self.range = tf.range
+
+    @property
+    def no_custom_gradient(self):
+        return self.decorator_provided or not self._tf.executing_eagerly()
+
+    @property
+    def forward_pass_np(self):
+        return self.np if self.no_custom_gradient else self.fallback_np
+
+    @property
+    def custom_gradient(self):
+        return (
+            _noop_custom_gradient
+            if self.no_custom_gradient
+            else self._tf.custom_gradient
+        )
+
+    def _decorator(self, func):
+        if func.__name__ in self._decorated_functions:
+            return self._decorated_functions[func.__name__]
+
+        decorated = self._decorate_with(func)
+
+        self._decorated_functions[func.__name__] = decorated
+
+        return decorated
+
+    def _preprocess_input_for_custom_gradient_single(self, value):
         return value.numpy() if self._tf.is_tensor(value) else value
+
+    def preprocess_input_for_custom_gradient(self, value):
+        if self.no_custom_gradient:
+            return value
+
+        if isinstance(value, list):
+            return [
+                self._preprocess_input_for_custom_gradient_single(element)
+                for element in value
+            ]
+
+        return self._preprocess_input_for_custom_gradient_single(value)
 
     def block_diag(self, *arrs):
         block_diagonalized = self._tf.linalg.LinearOperatorBlockDiag(
@@ -147,9 +243,57 @@ class TensorflowCalculator(_BuiltinCalculator):
         return glynn_gray_permanent(matrix, rows, columns, np=self.np)
 
     def assign(self, array, index, value):
-        # NOTE: This is not as advanced as Numpy's indexing, only supports 1D arrays.
+        """
+        NOTE: This method is very limited, and is a bit hacky, since TF does not support
+        item assignment through its NumPy API.
+        """
 
-        return self._tf.tensor_scatter_nd_update(array, [[index]], [value])
+        if isinstance(array, self.fallback_np.ndarray):
+            array[index] = value
+
+            return array
+
+        if isinstance(index, int):
+            return self._tf.tensor_scatter_nd_update(array, [[index]], [value])
+
+        # NOTE: When using `tf.function`, TensorFlow threw the following error:
+        #
+        # TypeError: Tensors in list passed to 'values' of 'ConcatV2' Op have types [int32, int64] that don't all match.  # noqa: E501
+        #
+        # To make it disappear, I had to convert all the indices to `int32`.
+        index = index.astype(self.fallback_np.int32)
+
+        if len(array.shape) == 1:
+            return self._tf.tensor_scatter_nd_update(
+                array, index.reshape(-1, 1), value.reshape(-1)
+            )
+
+        number_of_batches = array.shape[1]
+        int_dtype = index.dtype
+
+        flattened_index = index.reshape(-1)
+
+        indices = self.fallback_np.column_stack(
+            [
+                self.fallback_np.tile(flattened_index, number_of_batches),
+                self.fallback_np.concatenate(
+                    [
+                        self.fallback_np.full(len(flattened_index), i, dtype=int_dtype)
+                        for i in range(number_of_batches)
+                    ]
+                ),
+            ]
+        )
+
+        values = self.np.concatenate(
+            [value[:, :, i].reshape(-1) for i in range(number_of_batches)]
+        )
+
+        return self._tf.tensor_scatter_nd_update(
+            array,
+            indices,
+            values,
+        )
 
     def block(self, arrays):
         # NOTE: This is not as advanced as `numpy.block`, this function only supports
@@ -221,5 +365,80 @@ class TensorflowCalculator(_BuiltinCalculator):
 
         return V, S, self.np.conj(W).T
 
-    def custom_gradient(self, func):
-        return self._tf.custom_gradient(func)
+    def gather_along_axis_1(self, array, indices):
+        """
+        NOTE: Gather along axis 1 was terribly slow in Tensorflow, see
+        https://github.com/tensorflow/ranking/issues/160.
+        """
+
+        np = self.fallback_np
+
+        size = array.shape[0]
+
+        size_range = np.arange(size)
+
+        reshaped_indices = []
+
+        for row in size_range:
+            reshaped_indices.append(
+                np.stack([np.full(indices.shape, row), indices], axis=2)
+            )
+
+        return self._tf.gather_nd(array, np.array(reshaped_indices))
+
+    def accumulator(self, dtype, size, **kwargs):
+        if not self.no_custom_gradient:
+            return super().accumulator(dtype, size, **kwargs)
+
+        return self._tf.TensorArray(dtype=dtype, size=size, **kwargs)
+
+    def write(self, accumulator, index, value):
+        if not self.no_custom_gradient:
+            return super().write(accumulator, index, value)
+
+        return accumulator.write(index, value)
+
+    def stack_accumulator(self, accumulator):
+        if not self.no_custom_gradient:
+            return super().stack_accumulator(accumulator)
+
+        return accumulator.stack()
+
+    def read(self, accumulator, index):
+        if not self.no_custom_gradient:
+            return super().read(accumulator, index)
+
+        return accumulator.read(index)
+
+    def size(self, accumulator):
+        if not self.no_custom_gradient:
+            return super().size(accumulator)
+
+        return accumulator.size()
+
+    def __tf_tracing_type__(self, context):
+        # NOTE: We need to create a `TraceType` for `TensorflowCalculator` to avoid
+        # retracing, but it cannot be defined on module level due to the dependence
+        # on `tensorflow`.
+        # See `https://www.tensorflow.org/guide/function#use_the_tracing_protocol`_.
+
+        class _TrivialTraceType(self._tf.types.experimental.TraceType):
+            def __init__(self, calculator):
+                self.calculator = calculator
+
+            def is_subtype_of(self, other):
+                return True
+
+            def most_specific_common_supertype(self, others):
+                return self
+
+            def placeholder_value(self, placeholder_context=None):
+                return self.calculator
+
+            def __eq__(self, other):
+                return True
+
+            def __hash__(self):
+                return 1
+
+        return _TrivialTraceType(self)

--- a/piquasso/_backends/fock/general/calculations.py
+++ b/piquasso/_backends/fock/general/calculations.py
@@ -67,7 +67,7 @@ def passive_linear(
 
 def _apply_passive_linear(state, interferometer, modes):
     subspace_transformations = _get_interferometer_on_fock_space(
-        interferometer, state._config.cutoff
+        interferometer, state._config.cutoff, state._calculator
     )
 
     _apply_passive_gate_matrix_to_state(state, subspace_transformations, modes)
@@ -116,13 +116,15 @@ def _calculate_density_matrix_after_interferometer(
     return new_density_matrix
 
 
-def _get_interferometer_on_fock_space(interferometer, cutoff):
+def _get_interferometer_on_fock_space(interferometer, cutoff, calculator):
     index_dict = calculate_interferometer_helper_indices(
         d=len(interferometer),
         cutoff=cutoff,
     )
 
-    return calculate_interferometer_on_fock_space(interferometer, index_dict)
+    return calculate_interferometer_on_fock_space(
+        interferometer, index_dict, calculator
+    )
 
 
 def particle_number_measurement(
@@ -241,7 +243,10 @@ def cubic_phase(state: FockState, instruction: Instruction, shots: int) -> Resul
     gamma = instruction._all_params["gamma"]
 
     matrix = get_single_mode_cubic_phase_operator(
-        gamma=gamma, config=state._config, calculator=state._calculator
+        gamma=gamma,
+        cutoff=state._config.cutoff,
+        hbar=state._config.hbar,
+        calculator=state._calculator,
     )
     _apply_active_gate_matrix_to_state(state, matrix, instruction.modes[0])
 
@@ -343,7 +348,11 @@ def displacement(state: FockState, instruction: Instruction, shots: int) -> Resu
     mode = instruction.modes[0]
 
     matrix = get_single_mode_displacement_operator(
-        r=r, phi=phi, calculator=state._calculator, config=state._config
+        r=r,
+        phi=phi,
+        calculator=state._calculator,
+        cutoff=state._config.cutoff,
+        complex_dtype=state._config.complex_dtype,
     )
 
     _apply_active_gate_matrix_to_state(state, matrix, mode=mode)
@@ -362,7 +371,8 @@ def squeezing(state: FockState, instruction: Instruction, shots: int) -> Result:
         r=r,
         phi=phi,
         calculator=state._calculator,
-        config=state._config,
+        cutoff=state._config.cutoff,
+        complex_dtype=state._config.complex_dtype,
     )
 
     _apply_active_gate_matrix_to_state(state, matrix, mode=mode)
@@ -396,7 +406,11 @@ def linear(
 
     for mode, r in zip(instruction.modes, squeezings):
         matrix = get_single_mode_squeezing_operator(
-            r=r, phi=0.0, calculator=state._calculator, config=state._config
+            r=r,
+            phi=0.0,
+            calculator=state._calculator,
+            cutoff=state._config.cutoff,
+            complex_dtype=state._config.complex_dtype,
         )
         _apply_active_gate_matrix_to_state(state, matrix, mode)
 

--- a/piquasso/_backends/fock/pure/calculations/passive_linear.py
+++ b/piquasso/_backends/fock/pure/calculations/passive_linear.py
@@ -45,22 +45,39 @@ def passive_linear(
 
 
 def _apply_passive_linear(state, interferometer, modes, calculator):
-    subspace_transformations = _get_interferometer_on_fock_space(
-        interferometer, state._config.cutoff, calculator
+    wrapped = calculator.decorator(_do_apply_passive_linear)
+
+    state._state_vector = wrapped(
+        state._state_vector,
+        interferometer,
+        state.d,
+        state._config.cutoff,
+        modes,
+        calculator,
     )
 
-    _apply_passive_gate_matrix_to_state(state, subspace_transformations, modes)
+
+def _do_apply_passive_linear(
+    state_vector, interferometer, d, cutoff, modes, calculator
+):
+    subspace_transformations = _get_interferometer_on_fock_space(
+        interferometer, cutoff, calculator
+    )
+
+    return _apply_passive_gate_matrix_to_state(
+        state_vector, subspace_transformations, d, cutoff, modes, calculator
+    )
 
 
 def _get_interferometer_on_fock_space(interferometer, cutoff, calculator):
     def _get_interferometer_with_gradient_callback(interferometer):
-        interferometer = calculator.maybe_convert_to_numpy(interferometer)
+        interferometer = calculator.preprocess_input_for_custom_gradient(interferometer)
         index_dict = calculate_interferometer_helper_indices(
             d=len(interferometer), cutoff=cutoff
         )
 
         subspace_representations = calculate_interferometer_on_fock_space(
-            interferometer, index_dict
+            interferometer, index_dict, calculator
         )
         grad = _calculate_interferometer_gradient_on_fock_space(
             interferometer,
@@ -184,31 +201,32 @@ def _calculate_interferometer_gradient_on_fock_space(
 
 
 def _apply_passive_gate_matrix_to_state(
-    state: PureFockState,
+    state_vector: np.ndarray,
     subspace_transformations: List[np.ndarray],
+    d: int,
+    cutoff: int,
     modes: Tuple[int, ...],
+    calculator: BaseCalculator,
 ) -> None:
-    calculator = state._calculator
-    state_vector = state._state_vector
-
     def _apply_interferometer_matrix(state_vector, subspace_transformations):
-        state_vector = calculator.maybe_convert_to_numpy(state_vector)
+        state_vector = calculator.preprocess_input_for_custom_gradient(state_vector)
 
         subspace_transformations = [
-            calculator.maybe_convert_to_numpy(matrix)
+            calculator.preprocess_input_for_custom_gradient(matrix)
             for matrix in subspace_transformations
         ]
 
         index_list = calculate_index_list_for_appling_interferometer(
             modes,
-            state.d,
-            state._config.cutoff,
+            d,
+            cutoff,
         )
 
         new_state_vector = _calculate_state_vector_after_interferometer(
             state_vector,
             subspace_transformations,
             index_list,
+            calculator,
         )
 
         grad = _create_linear_passive_gate_gradient_function(
@@ -221,14 +239,17 @@ def _apply_passive_gate_matrix_to_state(
 
     wrapped = calculator.custom_gradient(_apply_interferometer_matrix)
 
-    state._state_vector = wrapped(state_vector, subspace_transformations)
+    return wrapped(state_vector, subspace_transformations)
 
 
 def _calculate_state_vector_after_interferometer(
     state_vector: np.ndarray,
     subspace_transformations: List[np.ndarray],
     index_list: List[np.ndarray],
+    calculator: BaseCalculator,
 ) -> np.ndarray:
+    np = calculator.forward_pass_np
+
     new_state_vector = np.empty_like(state_vector)
 
     is_batch = len(state_vector.shape) == 2
@@ -236,8 +257,12 @@ def _calculate_state_vector_after_interferometer(
     einsum_string = "ij,jkl->ikl" if is_batch else "ij,jk->ik"
 
     for n, indices in enumerate(index_list):
-        new_state_vector[indices] = np.einsum(
-            einsum_string, subspace_transformations[n], state_vector[indices]
+        new_state_vector = calculator.assign(
+            new_state_vector,
+            indices,
+            np.einsum(
+                einsum_string, subspace_transformations[n], state_vector[indices]
+            ),
         )
 
     return new_state_vector

--- a/piquasso/_backends/gaussian/calculations.py
+++ b/piquasso/_backends/gaussian/calculations.py
@@ -55,7 +55,12 @@ def passive_linear(
 
 
 def _apply_passive_linear(state, passive_block, modes):
-    state._m[(modes,)] = passive_block @ state._m[modes,]
+    state._m[(modes,)] = (
+        passive_block
+        @ state._m[
+            modes,
+        ]
+    )
     _apply_passive_linear_to_C_and_G(state, passive_block, modes=modes)
 
 
@@ -106,7 +111,9 @@ def linear(
 
 def _apply_linear(state, passive_block, active_block, modes):
     state._m[(modes,)] = passive_block @ state._m[(modes,)] + active_block @ np.conj(
-        state._m[modes,]
+        state._m[
+            modes,
+        ]
     )
 
     _apply_linear_to_C_and_G(state, passive_block, active_block, modes)
@@ -169,7 +176,9 @@ def displacement(state: GaussianState, instruction: Instruction, shots: int) -> 
     r = instruction._all_params["r"]
     phi = instruction._all_params["phi"]
 
-    state._m[modes,] += r * np.exp(1j * phi)
+    state._m[
+        modes,
+    ] += r * np.exp(1j * phi)
 
     return Result(state=state)
 
@@ -206,9 +215,9 @@ def generaldyne_measurement(
     evolved_mean[outer_indices] = evolved_state.xpxp_mean_vector
 
     evolved_cov = np.identity(2 * d) * state._config.hbar
-    evolved_cov[np.ix_(outer_indices, outer_indices)] = (
-        evolved_state.xpxp_covariance_matrix
-    )
+    evolved_cov[
+        np.ix_(outer_indices, outer_indices)
+    ] = evolved_state.xpxp_covariance_matrix
 
     state.xpxp_mean_vector = evolved_mean
     state.xpxp_covariance_matrix = evolved_cov

--- a/piquasso/_math/fock.py
+++ b/piquasso/_math/fock.py
@@ -64,21 +64,26 @@ def get_fock_space_basis(d: int, cutoff: int) -> np.ndarray:
 def get_single_mode_squeezing_operator(
     r: float,
     phi: float,
+    cutoff: int,
+    complex_dtype: np.dtype,
     calculator: BaseCalculator,
-    config: Config,
 ) -> np.ndarray:
     @calculator.custom_gradient
     def _single_mode_squeezing_operator(r, phi):
-        r = calculator.maybe_convert_to_numpy(r)
-        phi = calculator.maybe_convert_to_numpy(phi)
+        r = calculator.preprocess_input_for_custom_gradient(r)
+        phi = calculator.preprocess_input_for_custom_gradient(phi)
 
         matrix = create_single_mode_squeezing_matrix(
-            r, phi, config.cutoff, config.complex_dtype
+            r,
+            phi,
+            cutoff,
+            complex_dtype=complex_dtype,
+            calculator=calculator,
         )
         grad = create_single_mode_squeezing_gradient(
             r,
             phi,
-            config.cutoff,
+            cutoff,
             matrix,
             calculator,
         )
@@ -88,7 +93,7 @@ def get_single_mode_squeezing_operator(
 
 
 def get_single_mode_cubic_phase_operator(
-    gamma: float, config: Config, calculator: BaseCalculator
+    gamma: float, cutoff: int, hbar: float, calculator: BaseCalculator
 ) -> np.ndarray:
     r"""Cubic Phase gate.
 
@@ -119,11 +124,9 @@ def get_single_mode_cubic_phase_operator(
 
     np = calculator.np
 
-    annih = np.diag(np.sqrt(np.arange(1, config.cutoff)), 1)
-    position = (annih.T + annih) * np.sqrt(config.hbar / 2)
-    return calculator.expm(
-        1j * calculator.powm(position, 3) * (gamma / (3 * config.hbar))
-    )
+    annih = np.diag(np.sqrt(np.arange(1, cutoff)), 1)
+    position = (annih.T + annih) * np.sqrt(hbar / 2)
+    return calculator.expm(1j * calculator.powm(position, 3) * (gamma / (3 * hbar)))
 
 
 def operator_basis(space):
@@ -141,7 +144,9 @@ def get_creation_operator(
 
     for index, basis in enumerate(space):
         basis = np.array(basis)
-        basis[modes,] += np.ones_like(modes)
+        basis[
+            modes,
+        ] += np.ones_like(modes)
         dual_index = get_index_in_fock_space(tuple(basis))
 
         if dual_index < size:
@@ -156,21 +161,23 @@ def get_annihilation_operator(
     return get_creation_operator(modes, space, config).transpose()
 
 
-def get_single_mode_displacement_operator(r, phi, calculator, config):
+def get_single_mode_displacement_operator(r, phi, cutoff, complex_dtype, calculator):
     @calculator.custom_gradient
     def _single_mode_displacement_operator(r, phi):
-        r = calculator.maybe_convert_to_numpy(r)
-        phi = calculator.maybe_convert_to_numpy(phi)
+        r = calculator.preprocess_input_for_custom_gradient(r)
+        phi = calculator.preprocess_input_for_custom_gradient(phi)
 
         matrix = create_single_mode_displacement_matrix(
             r,
             phi,
-            config.cutoff,
+            cutoff,
+            complex_dtype,
+            calculator=calculator,
         )
         grad = create_single_mode_displacement_gradient(
             r,
             phi,
-            config.cutoff,
+            cutoff,
             matrix,
             calculator,
         )

--- a/piquasso/_math/linalg.py
+++ b/piquasso/_math/linalg.py
@@ -99,6 +99,8 @@ def assym_reduce(
 def vector_absolute_square(vector, calculator):
     @calculator.custom_gradient
     def _vector_absolute_square(v):
+        np = calculator.forward_pass_np
+
         absolute_square = np.real((v * np.conj(v)))
 
         def _vector_absolute_square_grad(upstream):

--- a/piquasso/api/calculator.py
+++ b/piquasso/api/calculator.py
@@ -30,6 +30,8 @@ class BaseCalculator(abc.ABC):
 
     np: Any
     fallback_np: Any
+    forward_pass_np: Any
+    range: Any
 
     def __deepcopy__(self, memo: Any) -> "BaseCalculator":
         """
@@ -40,9 +42,9 @@ class BaseCalculator(abc.ABC):
 
         return self
 
-    def maybe_convert_to_numpy(self, value):
+    def preprocess_input_for_custom_gradient(self, value):
         """
-        Converts tensorflow objects to numpy objects if applicable.
+        Applies modifications to inputs in custom gradients.
         """
         raise NotImplementedCalculation()
 
@@ -84,4 +86,22 @@ class BaseCalculator(abc.ABC):
         raise NotImplementedCalculation()
 
     def custom_gradient(self, func):
+        raise NotImplementedCalculation()
+
+    def accumulator(self, dtype, size, **kwargs):
+        raise NotImplementedCalculation()
+
+    def write(self, accumulator, index, value):
+        raise NotImplementedCalculation()
+
+    def stack_accumulator(self, accumulator):
+        raise NotImplementedCalculation()
+
+    def read(self, accumulator, index):
+        raise NotImplementedCalculation()
+
+    def size(self, accumulator):
+        raise NotImplementedCalculation()
+
+    def decorator(self, func):
         raise NotImplementedCalculation()

--- a/scripts/cvnn_tf_function_benchmark.py
+++ b/scripts/cvnn_tf_function_benchmark.py
@@ -1,0 +1,101 @@
+import piquasso as pq
+import tensorflow as tf
+
+import time
+
+
+tf.get_logger().setLevel("ERROR")
+
+
+def measure_graph_size(f, *args):
+    g = f.get_concrete_function(*args).graph
+
+    return len(g.as_graph_def().node)
+
+
+def calculate_mean_position(input_, weights, cutoff, d):
+    simulator = pq.PureFockSimulator(
+        d,
+        pq.Config(cutoff=cutoff, normalize=False),
+        calculator=pq.TensorflowCalculator(),
+    )
+
+    with tf.GradientTape() as tape:
+        cvqnn_layers = pq.cvqnn.create_layers(weights)
+
+        preparation = [pq.Vacuum()] + [
+            pq.Displacement(r=input_).on_modes(i) for i in range(d)
+        ]
+
+        program = pq.Program(instructions=preparation + cvqnn_layers.instructions)
+
+        simulator.execute(program)
+
+        final_state = simulator.execute(program).state
+
+        mean_position = final_state.mean_position(0)
+
+    print("_FORWARD FINISH:", time.time() - start_time)
+
+    mean_position_grad = tape.gradient(mean_position, weights)
+
+    print("_BACK FINISH:", time.time() - start_time)
+
+    return mean_position, mean_position_grad
+
+
+if __name__ == "__main__":
+    d = 2
+    cutoff = 3
+    layer_count = 1
+
+    NUMBER_OF_ITERATIONS = 10
+
+    weights = tf.Variable(
+        pq.cvqnn.generate_random_cvqnn_weights(layer_count=layer_count, d=d)
+    )
+
+    decorator = tf.function
+
+    enhanced_calculate_mean_position = decorator(calculate_mean_position)
+    input_ = tf.Variable(0.1)
+
+    start_time = time.time()
+
+    calculate_mean_position(input_, weights, cutoff, d)
+
+    print("VANILLA TIME:", time.time() - start_time)
+    start_time = time.time()
+
+    print("START")
+    start_time = time.time()
+
+    enhanced_calculate_mean_position(input_, weights, cutoff, d)
+
+    print("COMPILATION TIME:", time.time() - start_time)
+    start_time = time.time()
+
+    sum_ = 0.0
+
+    for _ in range(NUMBER_OF_ITERATIONS):
+        input_ = tf.Variable(0.1)
+
+        weigths = tf.Variable(
+            pq.cvqnn.generate_random_cvqnn_weights(layer_count=layer_count, d=d)
+        )
+
+        start_time = time.time()
+        enhanced_calculate_mean_position(input_, weights, cutoff, d)
+        end_time = time.time()
+
+        sum_ += end_time - start_time
+
+    print("AVG RUNTIME:", sum_ / NUMBER_OF_ITERATIONS)
+    start_time = time.time()
+
+    print(
+        "NUMBER OF NODES:",
+        measure_graph_size(
+            enhanced_calculate_mean_position, input_, weights, cutoff, d
+        ),
+    )

--- a/tests/backends/fock/test_gates.py
+++ b/tests/backends/fock/test_gates.py
@@ -18,12 +18,19 @@ import pytest
 import numpy as np
 
 import piquasso as pq
+import tensorflow as tf
 
 from functools import partial
 
-TensorflowPureFockSimulator = partial(
-    pq.PureFockSimulator,
-    calculator=pq.TensorflowCalculator(),
+tf_purefock_simulators = (
+    partial(
+        pq.PureFockSimulator,
+        calculator=pq.TensorflowCalculator(),
+    ),
+    partial(
+        pq.PureFockSimulator,
+        calculator=pq.TensorflowCalculator(decorate_with=tf.function),
+    ),
 )
 
 
@@ -31,7 +38,7 @@ TensorflowPureFockSimulator = partial(
     "SimulatorClass",
     (
         pq.PureFockSimulator,
-        TensorflowPureFockSimulator,
+        *tf_purefock_simulators,
         pq.FockSimulator,
     ),
 )
@@ -59,7 +66,7 @@ def test_squeezing_probabilities(SimulatorClass):
     "SimulatorClass",
     (
         pq.PureFockSimulator,
-        TensorflowPureFockSimulator,
+        *tf_purefock_simulators,
         pq.FockSimulator,
     ),
 )

--- a/tests/backends/tensorflow/test_batch_gradient.py
+++ b/tests/backends/tensorflow/test_batch_gradient.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
+
 import tensorflow as tf
 
 import numpy as np
@@ -20,7 +22,14 @@ import numpy as np
 import piquasso as pq
 
 
-def test_batch_Beamsplitter_mean_position():
+calculators = (
+    pq.TensorflowCalculator(),
+    pq.TensorflowCalculator(decorate_with=tf.function),
+)
+
+
+@pytest.mark.parametrize("calculator", calculators)
+def test_batch_Beamsplitter_mean_position(calculator):
     theta = tf.Variable(np.pi / 3)
 
     with pq.Program() as first_preparation:
@@ -38,7 +47,7 @@ def test_batch_Beamsplitter_mean_position():
             pq.Q() | pq.Beamsplitter(theta=theta, phi=np.pi / 3)
 
         simulator = pq.PureFockSimulator(
-            d=2, config=pq.Config(cutoff=5), calculator=pq.TensorflowCalculator()
+            d=2, config=pq.Config(cutoff=5), calculator=calculator
         )
 
         batch_mean_positions = simulator.execute(batch_program).state.mean_position(0)
@@ -72,7 +81,8 @@ def test_batch_Beamsplitter_mean_position():
     assert np.allclose(batch_gradient[1], second_gradient)
 
 
-def test_batch_Squeezing_mean_position():
+@pytest.mark.parametrize("calculator", calculators)
+def test_batch_Squeezing_mean_position(calculator):
     r = tf.Variable(0.1)
 
     with pq.Program() as first_preparation:
@@ -91,7 +101,7 @@ def test_batch_Squeezing_mean_position():
             pq.Q() | pq.Beamsplitter(theta=np.pi / 3, phi=np.pi / 3)
 
         simulator = pq.PureFockSimulator(
-            d=2, config=pq.Config(cutoff=5), calculator=pq.TensorflowCalculator()
+            d=2, config=pq.Config(cutoff=5), calculator=calculator
         )
 
         batch_mean_positions = simulator.execute(batch_program).state.mean_position(0)
@@ -127,7 +137,8 @@ def test_batch_Squeezing_mean_position():
     assert np.allclose(batch_gradient[1], second_gradient)
 
 
-def test_batch_Displacement_mean_position():
+@pytest.mark.parametrize("calculator", calculators)
+def test_batch_Displacement_mean_position(calculator):
     r = tf.Variable(0.1)
 
     with pq.Program() as first_preparation:
@@ -146,7 +157,7 @@ def test_batch_Displacement_mean_position():
             pq.Q() | pq.Beamsplitter(theta=np.pi / 3, phi=np.pi / 3)
 
         simulator = pq.PureFockSimulator(
-            d=2, config=pq.Config(cutoff=5), calculator=pq.TensorflowCalculator()
+            d=2, config=pq.Config(cutoff=5), calculator=calculator
         )
 
         batch_mean_positions = simulator.execute(batch_program).state.mean_position(0)
@@ -182,7 +193,8 @@ def test_batch_Displacement_mean_position():
     assert np.allclose(batch_gradient[1], second_gradient)
 
 
-def test_batch_Kerr_mean_position():
+@pytest.mark.parametrize("calculator", calculators)
+def test_batch_Kerr_mean_position(calculator):
     xi = tf.Variable(0.1)
 
     with pq.Program() as first_preparation:
@@ -201,7 +213,7 @@ def test_batch_Kerr_mean_position():
             pq.Q() | pq.Beamsplitter(theta=np.pi / 3, phi=np.pi / 3)
 
         simulator = pq.PureFockSimulator(
-            d=2, config=pq.Config(cutoff=5), calculator=pq.TensorflowCalculator()
+            d=2, config=pq.Config(cutoff=5), calculator=calculator
         )
 
         batch_mean_positions = simulator.execute(batch_program).state.mean_position(0)
@@ -237,7 +249,8 @@ def test_batch_Kerr_mean_position():
     assert np.allclose(batch_gradient[1], second_gradient)
 
 
-def test_batch_Phaseshifter_mean_position():
+@pytest.mark.parametrize("calculator", calculators)
+def test_batch_Phaseshifter_mean_position(calculator):
     phi = tf.Variable(np.pi / 5)
 
     with pq.Program() as first_preparation:
@@ -256,7 +269,7 @@ def test_batch_Phaseshifter_mean_position():
             pq.Q() | pq.Beamsplitter(theta=np.pi / 3, phi=np.pi / 3)
 
         simulator = pq.PureFockSimulator(
-            d=2, config=pq.Config(cutoff=5), calculator=pq.TensorflowCalculator()
+            d=2, config=pq.Config(cutoff=5), calculator=calculator
         )
 
         batch_mean_positions = simulator.execute(batch_program).state.mean_position(0)
@@ -292,7 +305,8 @@ def test_batch_Phaseshifter_mean_position():
     assert np.allclose(batch_gradient[1], second_gradient)
 
 
-def test_batch_complex_circuit_mean_position():
+@pytest.mark.parametrize("calculator", calculators)
+def test_batch_complex_circuit_mean_position(calculator):
     theta1 = tf.Variable(np.pi / 3)
     phi1 = tf.Variable(np.pi / 4)
 
@@ -340,7 +354,7 @@ def test_batch_complex_circuit_mean_position():
             pq.Q(1) | pq.Kerr(xi=xi2)
 
         simulator = pq.PureFockSimulator(
-            d=2, config=pq.Config(cutoff=5), calculator=pq.TensorflowCalculator()
+            d=2, config=pq.Config(cutoff=5), calculator=calculator
         )
 
         batch_mean_positions = simulator.execute(batch_program).state.mean_position(0)
@@ -400,7 +414,8 @@ def test_batch_complex_circuit_mean_position():
     assert np.allclose(batch_gradient[:, 1], second_gradient)
 
 
-def test_batch_complex_circuit_mean_position_with_batch_apply():
+@pytest.mark.parametrize("calculator", calculators)
+def test_batch_complex_circuit_mean_position_with_batch_apply(calculator):
     theta1 = tf.Variable(np.pi / 3)
     phi1 = tf.Variable(np.pi / 4)
 
@@ -459,7 +474,7 @@ def test_batch_complex_circuit_mean_position_with_batch_apply():
             pq.Q(1) | pq.Kerr(xi=xi2)
 
         simulator = pq.PureFockSimulator(
-            d=2, config=pq.Config(cutoff=5), calculator=pq.TensorflowCalculator()
+            d=2, config=pq.Config(cutoff=5), calculator=calculator
         )
 
         batch_mean_positions = simulator.execute(batch_program).state.mean_position(0)

--- a/tests/backends/tensorflow/test_gradient.py
+++ b/tests/backends/tensorflow/test_gradient.py
@@ -872,7 +872,9 @@ def test_Displacement_state_vector_gradient():
 
     jacobian = tape.jacobian(state_vector, [r])
 
-    expected_state_vector = np.exp(-(r**2) / 2) * np.array([1, r, r**2 / np.sqrt(2)])
+    expected_state_vector = np.exp(-(r**2) / 2) * np.array(
+        [1, r, r**2 / np.sqrt(2)]
+    )
     expected_jacobian = np.array(
         [
             -r * np.exp(-(r**2) / 2),

--- a/tests/backends/test_backend_equivalence.py
+++ b/tests/backends/test_backend_equivalence.py
@@ -16,6 +16,7 @@
 import pytest
 import numpy as np
 import piquasso as pq
+import tensorflow as tf
 
 import collections
 
@@ -35,9 +36,15 @@ def is_proportional(first, second):
     return np.allclose(first, proportion * second)
 
 
-TensorflowPureFockSimulator = partial(
-    pq.PureFockSimulator,
-    calculator=pq.TensorflowCalculator(),
+tf_purefock_simulators = (
+    partial(
+        pq.PureFockSimulator,
+        calculator=pq.TensorflowCalculator(),
+    ),
+    partial(
+        pq.PureFockSimulator,
+        calculator=pq.TensorflowCalculator(decorate_with=tf.function),
+    ),
 )
 
 
@@ -46,7 +53,7 @@ TensorflowPureFockSimulator = partial(
     (
         pq.GaussianSimulator,
         pq.PureFockSimulator,
-        TensorflowPureFockSimulator,
+        *tf_purefock_simulators,
         pq.FockSimulator,
     ),
 )
@@ -70,7 +77,7 @@ def test_fock_probabilities_should_be_numpy_array_of_floats(SimulatorClass):
     (
         pq.GaussianSimulator,
         pq.PureFockSimulator,
-        TensorflowPureFockSimulator,
+        *tf_purefock_simulators,
         pq.FockSimulator,
     ),
 )
@@ -148,7 +155,7 @@ def test_density_matrix_with_squeezed_state():
     (
         pq.GaussianSimulator,
         pq.PureFockSimulator,
-        TensorflowPureFockSimulator,
+        *tf_purefock_simulators,
         pq.FockSimulator,
     ),
 )
@@ -198,7 +205,7 @@ def test_fock_probabilities_with_displaced_state(SimulatorClass):
     (
         pq.PureFockSimulator,
         pq.FockSimulator,
-        TensorflowPureFockSimulator,
+        *tf_purefock_simulators,
         pq.GaussianSimulator,
     ),
 )
@@ -237,7 +244,7 @@ def test_Displacement_equivalence_on_multiple_modes(SimulatorClass):
     (
         pq.GaussianSimulator,
         pq.PureFockSimulator,
-        TensorflowPureFockSimulator,
+        *tf_purefock_simulators,
         pq.FockSimulator,
     ),
 )
@@ -288,7 +295,7 @@ def test_fock_probabilities_with_displaced_state_with_beamsplitter(SimulatorClas
     (
         pq.GaussianSimulator,
         pq.PureFockSimulator,
-        TensorflowPureFockSimulator,
+        *tf_purefock_simulators,
         pq.FockSimulator,
     ),
 )
@@ -339,7 +346,7 @@ def test_fock_probabilities_with_squeezed_state_with_beamsplitter(SimulatorClass
     (
         pq.GaussianSimulator,
         pq.PureFockSimulator,
-        TensorflowPureFockSimulator,
+        *tf_purefock_simulators,
         pq.FockSimulator,
     ),
 )
@@ -369,7 +376,7 @@ def test_fock_probabilities_with_two_single_mode_squeezings(SimulatorClass):
     (
         pq.GaussianSimulator,
         pq.PureFockSimulator,
-        TensorflowPureFockSimulator,
+        *tf_purefock_simulators,
         pq.FockSimulator,
     ),
 )
@@ -397,7 +404,7 @@ def test_Squeezing_equivalence_on_multiple_modes(SimulatorClass):
     (
         pq.GaussianSimulator,
         pq.PureFockSimulator,
-        TensorflowPureFockSimulator,
+        *tf_purefock_simulators,
         pq.FockSimulator,
     ),
 )
@@ -452,7 +459,7 @@ def test_fock_probabilities_with_two_mode_squeezing(SimulatorClass):
     (
         pq.GaussianSimulator,
         pq.PureFockSimulator,
-        TensorflowPureFockSimulator,
+        *tf_purefock_simulators,
         pq.FockSimulator,
     ),
 )
@@ -503,7 +510,7 @@ def test_fock_probabilities_with_two_mode_squeezing_and_beamsplitter(SimulatorCl
     (
         pq.GaussianSimulator,
         pq.PureFockSimulator,
-        TensorflowPureFockSimulator,
+        *tf_purefock_simulators,
         pq.FockSimulator,
     ),
 )
@@ -551,7 +558,7 @@ def test_fock_probabilities_with_quadratic_phase(SimulatorClass):
     (
         pq.GaussianSimulator,
         pq.PureFockSimulator,
-        TensorflowPureFockSimulator,
+        *tf_purefock_simulators,
         pq.FockSimulator,
     ),
 )
@@ -599,7 +606,7 @@ def test_fock_probabilities_with_position_displacement(SimulatorClass):
     (
         pq.GaussianSimulator,
         pq.PureFockSimulator,
-        TensorflowPureFockSimulator,
+        *tf_purefock_simulators,
         pq.FockSimulator,
     ),
 )
@@ -647,7 +654,7 @@ def test_fock_probabilities_with_momentum_displacement(SimulatorClass):
     (
         pq.GaussianSimulator,
         pq.PureFockSimulator,
-        TensorflowPureFockSimulator,
+        *tf_purefock_simulators,
         pq.FockSimulator,
     ),
 )
@@ -676,7 +683,7 @@ def test_fock_probabilities_with_position_displacement_is_HBAR_independent(
     (
         pq.GaussianSimulator,
         pq.PureFockSimulator,
-        TensorflowPureFockSimulator,
+        *tf_purefock_simulators,
         pq.FockSimulator,
     ),
 )
@@ -705,7 +712,7 @@ def test_fock_probabilities_with_momentum_displacement_is_HBAR_independent(
     (
         pq.GaussianSimulator,
         pq.PureFockSimulator,
-        TensorflowPureFockSimulator,
+        *tf_purefock_simulators,
         pq.FockSimulator,
     ),
 )
@@ -1164,7 +1171,7 @@ def test_fidelity_for_nondisplaced_mixed_states_on_3_modes(SimulatorClass):
     (
         pq.PureFockSimulator,
         pq.FockSimulator,
-        TensorflowPureFockSimulator,
+        *tf_purefock_simulators,
     ),
 )
 def test_cubic_phase_equivalency(SimulatorClass):
@@ -1193,7 +1200,7 @@ def test_cubic_phase_equivalency(SimulatorClass):
     (
         pq.PureFockSimulator,
         pq.FockSimulator,
-        TensorflowPureFockSimulator,
+        *tf_purefock_simulators,
     ),
 )
 def test_CubicPhase_equivalence_on_multiple_modes(SimulatorClass):
@@ -1231,7 +1238,7 @@ def test_CubicPhase_equivalence_on_multiple_modes(SimulatorClass):
     (
         pq.PureFockSimulator,
         pq.FockSimulator,
-        TensorflowPureFockSimulator,
+        *tf_purefock_simulators,
     ),
 )
 def test_Kerr_gate_leaves_fock_probabilities_invariant(SimulatorClass):
@@ -1257,7 +1264,7 @@ def test_Kerr_gate_leaves_fock_probabilities_invariant(SimulatorClass):
     "SimulatorClass",
     (
         pq.PureFockSimulator,
-        TensorflowPureFockSimulator,
+        *tf_purefock_simulators,
     ),
 )
 def test_Kerr_equivalence(SimulatorClass):
@@ -1460,7 +1467,7 @@ def test_Attenuator_raises_InvalidParam_for_non_zero_mean_thermal_excitation(
         pq.PureFockSimulator,
         pq.FockSimulator,
         pq.GaussianSimulator,
-        TensorflowPureFockSimulator,
+        *tf_purefock_simulators,
     ),
 )
 def test_Interferometer_smaller_than_system_size(SimulatorClass):
@@ -1525,4 +1532,64 @@ def test_Interferometer_smaller_than_system_size(SimulatorClass):
             0.0,
             0.00005109,
         ],
+    )
+
+
+@pytest.mark.parametrize(
+    "SimulatorClass",
+    (
+        pq.PureFockSimulator,
+        pq.FockSimulator,
+        pq.GaussianSimulator,
+        *tf_purefock_simulators,
+    ),
+)
+def test_Squeezing_with_zero_parameter(SimulatorClass):
+    config = pq.Config(cutoff=3)
+
+    d = 2
+
+    with pq.Program() as program:
+        pq.Q() | pq.Vacuum()
+
+        pq.Q(0) | pq.Squeezing(r=0.0)
+        pq.Q(1) | pq.Squeezing(r=0.1)
+
+    simulator = SimulatorClass(d=d, config=config)
+
+    state = simulator.execute(program).state
+
+    assert is_proportional(
+        state.fock_probabilities,
+        [0.99505769, 0.0, 0.0, 0.0, 0.0, 0.00494231],
+    )
+
+
+@pytest.mark.parametrize(
+    "SimulatorClass",
+    (
+        pq.PureFockSimulator,
+        pq.FockSimulator,
+        pq.GaussianSimulator,
+        *tf_purefock_simulators,
+    ),
+)
+def test_Displacement_with_zero_parameter(SimulatorClass):
+    config = pq.Config(cutoff=3)
+
+    d = 2
+
+    with pq.Program() as program:
+        pq.Q() | pq.Vacuum()
+
+        pq.Q(0) | pq.Displacement(r=0.0)
+        pq.Q(1) | pq.Displacement(r=0.1)
+
+    simulator = SimulatorClass(d=d, config=config)
+
+    state = simulator.execute(program).state
+
+    assert is_proportional(
+        state.fock_probabilities,
+        [0.99005, 0.0, 0.0099005, 0.0, 0.0, 0.0000495],
     )

--- a/tests/slow/test_tf_function.py
+++ b/tests/slow/test_tf_function.py
@@ -1,0 +1,436 @@
+#
+# Copyright 2021-2024 Budapest Quantum Computing Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import piquasso as pq
+import tensorflow as tf
+
+
+def test_tf_function_cvnn_layer_1_mode_1_layers():
+    d = 1
+    cutoff = 3
+
+    weights = tf.Variable(
+        [[0.20961794, -0.00454663, 0.17257116, -0.00007423, -0.12339027, -0.01005965]]
+    )
+
+    @tf.function
+    def func(weights):
+        simulator = pq.PureFockSimulator(
+            d=d,
+            config=pq.Config(cutoff=cutoff, normalize=False),
+            calculator=pq.TensorflowCalculator(),
+        )
+
+        with tf.GradientTape() as tape:
+            program = pq.cvqnn.create_program(weights)
+
+            state = simulator.execute(program).state
+            mean_position = state.mean_position(0)
+
+        return mean_position, tape.gradient(mean_position, weights)
+
+    mean_position, mean_position_grad = func(weights)
+
+    assert np.allclose(
+        mean_position,
+        -0.00014718642085721634,
+    )
+    assert np.allclose(
+        mean_position_grad,
+        [[0.0, 0.00001151, -0.00000038, 1.9829729, -0.00001934, -0.00001949]],
+    )
+
+
+def test_tf_function_cvnn_layer_2_modes_2_layers():
+    d = 2
+    cutoff = 3
+
+    weights = tf.Variable(
+        [
+            [
+                -0.01496882,
+                -0.00769323,
+                -0.23639019,
+                0.00605814,
+                -0.00198169,
+                -0.00070044,
+                -0.09768252,
+                0.10580704,
+                0.01289619,
+                0.00523546,
+                -0.1072419,
+                -0.06125172,
+                -0.00887781,
+                -0.02219815,
+            ],
+            [
+                -0.15894917,
+                0.15323096,
+                0.02459804,
+                0.00319082,
+                -0.0013642,
+                0.06503896,
+                -0.04608497,
+                -0.04319411,
+                -0.00326043,
+                0.00621172,
+                0.06301634,
+                0.07470028,
+                0.01229031,
+                0.00481799,
+            ],
+        ]
+    )
+
+    @tf.function
+    def func(weights):
+        simulator = pq.PureFockSimulator(
+            d=d,
+            config=pq.Config(cutoff=cutoff, normalize=False),
+            calculator=pq.TensorflowCalculator(),
+        )
+
+        with tf.GradientTape() as tape:
+            program = pq.cvqnn.create_program(weights)
+
+            state = simulator.execute(program).state
+            mean_position = state.mean_position(0)
+
+        return mean_position, tape.gradient(mean_position, weights)
+
+    mean_position, mean_position_grad = func(weights)
+
+    assert np.allclose(
+        mean_position,
+        0.019824614605943112,
+    )
+    assert np.allclose(
+        mean_position_grad,
+        [
+            [
+                0.0,
+                0.0,
+                0.0,
+                -0.00177408,
+                0.00011175,
+                0.00000129,
+                0.00000001,
+                -0.00009018,
+                1.96946914,
+                0.17731823,
+                0.00313927,
+                0.00034899,
+                0.00305477,
+                0.00035107,
+            ],
+            [
+                -0.00771081,
+                -0.00041313,
+                0.00346222,
+                -0.02683549,
+                0.00044953,
+                -0.00797526,
+                0.00006062,
+                0.00336663,
+                1.99442205,
+                -0.00004225,
+                0.00047722,
+                -0.00000408,
+                0.00381727,
+                -0.00000682,
+            ],
+        ],
+    )
+
+
+def test_tf_function_cvnn_layer_1_mode_1_layers_decorate_with_tf_function():
+    d = 1
+    cutoff = 3
+
+    weights = tf.Variable(
+        [[0.20961794, -0.00454663, 0.17257116, -0.00007423, -0.12339027, -0.01005965]]
+    )
+
+    @tf.function
+    def func(weights):
+        simulator = pq.PureFockSimulator(
+            d=d,
+            config=pq.Config(cutoff=cutoff, normalize=False),
+            calculator=pq.TensorflowCalculator(decorate_with=tf.function),
+        )
+
+        with tf.GradientTape() as tape:
+            program = pq.cvqnn.create_program(weights)
+
+            state = simulator.execute(program).state
+            mean_position = state.mean_position(0)
+
+        return mean_position, tape.gradient(mean_position, weights)
+
+    mean_position, mean_position_grad = func(weights)
+
+    assert np.allclose(
+        mean_position,
+        -0.00014718642085721634,
+    )
+    assert np.allclose(
+        mean_position_grad,
+        [[0.0, 0.00001151, -0.00000038, 1.9829729, -0.00001934, -0.00001949]],
+    )
+
+
+def test_tf_function_cvnn_layer_2_modes_2_layers_decorate_with_tf_function():
+    d = 2
+    cutoff = 3
+
+    weights = tf.Variable(
+        [
+            [
+                -0.01496882,
+                -0.00769323,
+                -0.23639019,
+                0.00605814,
+                -0.00198169,
+                -0.00070044,
+                -0.09768252,
+                0.10580704,
+                0.01289619,
+                0.00523546,
+                -0.1072419,
+                -0.06125172,
+                -0.00887781,
+                -0.02219815,
+            ],
+            [
+                -0.15894917,
+                0.15323096,
+                0.02459804,
+                0.00319082,
+                -0.0013642,
+                0.06503896,
+                -0.04608497,
+                -0.04319411,
+                -0.00326043,
+                0.00621172,
+                0.06301634,
+                0.07470028,
+                0.01229031,
+                0.00481799,
+            ],
+        ]
+    )
+
+    @tf.function
+    def func(weights):
+        simulator = pq.PureFockSimulator(
+            d=d,
+            config=pq.Config(cutoff=cutoff, normalize=False),
+            calculator=pq.TensorflowCalculator(decorate_with=tf.function),
+        )
+
+        with tf.GradientTape() as tape:
+            program = pq.cvqnn.create_program(weights)
+
+            state = simulator.execute(program).state
+            mean_position = state.mean_position(0)
+
+        return mean_position, tape.gradient(mean_position, weights)
+
+    mean_position, mean_position_grad = func(weights)
+
+    assert np.allclose(
+        mean_position,
+        0.019824614605943112,
+    )
+    assert np.allclose(
+        mean_position_grad,
+        [
+            [
+                0.0,
+                0.0,
+                0.0,
+                -0.00177408,
+                0.00011175,
+                0.00000129,
+                0.00000001,
+                -0.00009018,
+                1.96946914,
+                0.17731823,
+                0.00313927,
+                0.00034899,
+                0.00305477,
+                0.00035107,
+            ],
+            [
+                -0.00771081,
+                -0.00041313,
+                0.00346222,
+                -0.02683549,
+                0.00044953,
+                -0.00797526,
+                0.00006062,
+                0.00336663,
+                1.99442205,
+                -0.00004225,
+                0.00047722,
+                -0.00000408,
+                0.00381727,
+                -0.00000682,
+            ],
+        ],
+    )
+
+
+def test_tf_function_cvnn_layer_1_mode_1_layers_jit_compile():
+    d = 1
+    cutoff = 3
+
+    weights = tf.Variable(
+        [[0.20961794, -0.00454663, 0.17257116, -0.00007423, -0.12339027, -0.01005965]]
+    )
+
+    @tf.function(jit_compile=True)
+    def func(weights):
+        simulator = pq.PureFockSimulator(
+            d=d,
+            config=pq.Config(cutoff=cutoff, normalize=False),
+            calculator=pq.TensorflowCalculator(
+                decorate_with=tf.function(jit_compile=True)
+            ),
+        )
+
+        with tf.GradientTape() as tape:
+            program = pq.cvqnn.create_program(weights)
+
+            state = simulator.execute(program).state
+            mean_position = state.mean_position(0)
+
+        return mean_position, tape.gradient(mean_position, weights)
+
+    mean_position, mean_position_grad = func(weights)
+
+    assert np.allclose(
+        mean_position,
+        -0.00014718642085721634,
+    )
+    assert np.allclose(
+        mean_position_grad,
+        [[0.0, 0.00001151, -0.00000038, 1.9829729, -0.00001934, -0.00001949]],
+    )
+
+
+def test_tf_function_cvnn_layer_2_modes_2_layers_jit_compile():
+    d = 2
+    cutoff = 3
+
+    weights = tf.Variable(
+        [
+            [
+                -0.01496882,
+                -0.00769323,
+                -0.23639019,
+                0.00605814,
+                -0.00198169,
+                -0.00070044,
+                -0.09768252,
+                0.10580704,
+                0.01289619,
+                0.00523546,
+                -0.1072419,
+                -0.06125172,
+                -0.00887781,
+                -0.02219815,
+            ],
+            [
+                -0.15894917,
+                0.15323096,
+                0.02459804,
+                0.00319082,
+                -0.0013642,
+                0.06503896,
+                -0.04608497,
+                -0.04319411,
+                -0.00326043,
+                0.00621172,
+                0.06301634,
+                0.07470028,
+                0.01229031,
+                0.00481799,
+            ],
+        ]
+    )
+
+    @tf.function(jit_compile=True)
+    def func(weights):
+        simulator = pq.PureFockSimulator(
+            d=d,
+            config=pq.Config(cutoff=cutoff, normalize=False),
+            calculator=pq.TensorflowCalculator(
+                decorate_with=tf.function(jit_compile=True)
+            ),
+        )
+
+        with tf.GradientTape() as tape:
+            program = pq.cvqnn.create_program(weights)
+
+            state = simulator.execute(program).state
+            mean_position = state.mean_position(0)
+
+        return mean_position, tape.gradient(mean_position, weights)
+
+    mean_position, mean_position_grad = func(weights)
+
+    assert np.allclose(
+        mean_position,
+        0.019824614605943112,
+    )
+    assert np.allclose(
+        mean_position_grad,
+        [
+            [
+                0.0,
+                0.0,
+                0.0,
+                -0.00177408,
+                0.00011175,
+                0.00000129,
+                0.00000001,
+                -0.00009018,
+                1.96946914,
+                0.17731823,
+                0.00313927,
+                0.00034899,
+                0.00305477,
+                0.00035107,
+            ],
+            [
+                -0.00771081,
+                -0.00041313,
+                0.00346222,
+                -0.02683549,
+                0.00044953,
+                -0.00797526,
+                0.00006062,
+                0.00336663,
+                1.99442205,
+                -0.00004225,
+                0.00047722,
+                -0.00000408,
+                0.00381727,
+                -0.00000682,
+            ],
+        ],
+    )


### PR DESCRIPTION
`tf.function` requires Piquasso to use Tensorflow's NumPy API in the forward pass. By default, we use regular NumPy for performance reasons, but this patch enables users to run Piquasso inside `tf.function`, which might be faster with JIT compilation enabled. JIT compilation takes some time though, but the compiled function is an order of magnitude faster than the original function decorated with `tf.function` only.

In order to enable Piquasso to use `tf.function` the possibility of avoiding the custom gradient calculations had to be implemented, which is implemented through `calculator.no_custom_gradient`. In the calculations where the gradient has been replaced by a custom one, a different numpy (`calculator.forward_pass_np`) needs to be used, and its value depends on `no_custom_gradient`.

Moreover, some functions might be slow for vague reasons, e.g., it is better to avoid `tf.transpose` and `tf.gather(..., axis=1)`. These functions are avoided where possible. Also, some functions work a bit differently, e.g., `tf.math.pow` handles `0^0` differently than `np.pow`, which is encountered in `gate_matrices.py`.

Furthermore, the compilation time is in correlation with the graph size compiled with Autograph. In order to limit the size of the compiled graph, several things are implemented:

1. `decorate_with`

Decorating some functions in the simulation with `tf.function` during the simulation makes the graph smaller, since consequent calls to this function won't induce retracing. Therefore the possibility to decorate some of these functions got enabled with the `decorate_with` constructor parameter of `TensorflowCalculator`. In it, one can pass the `tf.function` decorator to decorate the functions with, and one may also pass other parameter (like `jit_compile`, `reduce_retracing`).

Since the compiled functions are cached within `TensorflowCalculator`, the instance should be preserved between calculations. Moreover, a custom `_TrivialTraceType` had to be implemented for `TensorflowCalculator` to make AutoGraph avoid retracing.

Moreover, the `no_custom_gradient` needs to be switched on when a decorator is provided.

2. `TensorArray`

`tf.function` does not handle Python for loops well, because each iteration in the for loop is handled independently in Autograph. Therefore, one needs to avoid using for loops as much as possible, and use vectorized computations. If not possible, one can use `TensorArray` instead, which has been implemented in `TensorflowCalculator.accumulator` and in `gate_matrices.py`.

Technically, it could be implemented in other places as well, but it is a bit more challenging, and (hopefully) using `decorate_with` limits the graph size well enough.