### PR TITLE
feat(tensorflow): Enabling `tf.function`

### DIFF
--- a/benchmarks/tf_1_mode_cvnn_benchmark.py
+++ b/benchmarks/tf_1_mode_cvnn_benchmark.py
@@ -81,6 +81,7 @@ def test_state_vector_and_jacobian(weights, cutoff, layer_count):
     assert np.allclose(pq_jacobian, sf_jacobian)
 
 
+@tf.function
 def _calculate_piquasso_results(weights, cutoff, layer_count):
     simulator = pq.PureFockSimulator(
         d=1,

--- a/piquasso/_backends/fock/general/calculations.py
+++ b/piquasso/_backends/fock/general/calculations.py
@@ -67,7 +67,7 @@ def passive_linear(
 
 def _apply_passive_linear(state, interferometer, modes):
     subspace_transformations = _get_interferometer_on_fock_space(
-        interferometer, state._config.cutoff
+        interferometer, state._config.cutoff, state._calculator
     )
 
     _apply_passive_gate_matrix_to_state(state, subspace_transformations, modes)
@@ -116,13 +116,15 @@ def _calculate_density_matrix_after_interferometer(
     return new_density_matrix
 
 
-def _get_interferometer_on_fock_space(interferometer, cutoff):
+def _get_interferometer_on_fock_space(interferometer, cutoff, calculator):
     index_dict = calculate_interferometer_helper_indices(
         d=len(interferometer),
         cutoff=cutoff,
     )
 
-    return calculate_interferometer_on_fock_space(interferometer, index_dict)
+    return calculate_interferometer_on_fock_space(
+        interferometer, index_dict, calculator
+    )
 
 
 def particle_number_measurement(
@@ -241,7 +243,10 @@ def cubic_phase(state: FockState, instruction: Instruction, shots: int) -> Resul
     gamma = instruction._all_params["gamma"]
 
     matrix = get_single_mode_cubic_phase_operator(
-        gamma=gamma, config=state._config, calculator=state._calculator
+        gamma=gamma,
+        cutoff=state._config.cutoff,
+        hbar=state._config.hbar,
+        calculator=state._calculator,
     )
     _apply_active_gate_matrix_to_state(state, matrix, instruction.modes[0])
 
@@ -343,7 +348,11 @@ def displacement(state: FockState, instruction: Instruction, shots: int) -> Resu
     mode = instruction.modes[0]
 
     matrix = get_single_mode_displacement_operator(
-        r=r, phi=phi, calculator=state._calculator, config=state._config
+        r=r,
+        phi=phi,
+        calculator=state._calculator,
+        cutoff=state._config.cutoff,
+        complex_dtype=state._config.complex_dtype,
     )
 
     _apply_active_gate_matrix_to_state(state, matrix, mode=mode)
@@ -362,7 +371,8 @@ def squeezing(state: FockState, instruction: Instruction, shots: int) -> Result:
         r=r,
         phi=phi,
         calculator=state._calculator,
-        config=state._config,
+        cutoff=state._config.cutoff,
+        complex_dtype=state._config.complex_dtype,
     )
 
     _apply_active_gate_matrix_to_state(state, matrix, mode=mode)
@@ -396,7 +406,11 @@ def linear(
 
     for mode, r in zip(instruction.modes, squeezings):
         matrix = get_single_mode_squeezing_operator(
-            r=r, phi=0.0, calculator=state._calculator, config=state._config
+            r=r,
+            phi=0.0,
+            calculator=state._calculator,
+            cutoff=state._config.cutoff,
+            complex_dtype=state._config.complex_dtype,
         )
         _apply_active_gate_matrix_to_state(state, matrix, mode)
 

--- a/piquasso/_backends/fock/pure/calculations/__init__.py
+++ b/piquasso/_backends/fock/pure/calculations/__init__.py
@@ -45,6 +45,7 @@ from piquasso.instructions import gates
 
 from piquasso.api.result import Result
 from piquasso.api.instruction import Instruction
+from piquasso.api.calculator import BaseCalculator
 
 
 def particle_number_measurement(
@@ -121,35 +122,38 @@ def _get_projected_state_vector(
 
 
 def _apply_active_gate_matrix_to_state(
-    state: PureFockState,
+    state_vector: np.ndarray,
     matrix: np.ndarray,
+    d: int,
+    cutoff: int,
     mode: int,
+    calculator: BaseCalculator,
 ) -> None:
-    calculator = state._calculator
-    state_vector = state._state_vector
-
     @calculator.custom_gradient
     def _apply_active_gate_matrix(state_vector, matrix):
-        state_vector = calculator.maybe_convert_to_numpy(state_vector)
-        matrix = calculator.maybe_convert_to_numpy(matrix)
+        state_vector = calculator.preprocess_input_for_custom_gradient(state_vector)
+        matrix = calculator.preprocess_input_for_custom_gradient(matrix)
 
-        state_index_matrix_list = calculate_state_index_matrix_list(
-            state.d, state._config.cutoff, mode
-        )
+        state_index_matrix_list = calculate_state_index_matrix_list(d, cutoff, mode)
         new_state_vector = _calculate_state_vector_after_apply_active_gate(
-            state_vector, matrix, state_index_matrix_list
+            state_vector, matrix, state_index_matrix_list, calculator
         )
         grad = _create_linear_active_gate_gradient_function(
             state_vector, matrix, state_index_matrix_list, calculator
         )
         return new_state_vector, grad
 
-    state._state_vector = _apply_active_gate_matrix(state_vector, matrix)
+    return _apply_active_gate_matrix(state_vector, matrix)
 
 
 def _calculate_state_vector_after_apply_active_gate(
-    state_vector, matrix, state_index_matrix_list
+    state_vector,
+    matrix,
+    state_index_matrix_list,
+    calculator,
 ):
+    np = calculator.forward_pass_np
+
     new_state_vector = np.empty_like(state_vector, dtype=state_vector.dtype)
 
     is_batch = len(state_vector.shape) == 2
@@ -158,8 +162,12 @@ def _calculate_state_vector_after_apply_active_gate(
 
     for state_index_matrix in state_index_matrix_list:
         limit = state_index_matrix.shape[0]
-        new_state_vector[state_index_matrix] = np.einsum(
-            einsum_string, matrix[:limit, :limit], state_vector[state_index_matrix]
+        new_state_vector = calculator.assign(
+            new_state_vector,
+            state_index_matrix,
+            np.einsum(
+                einsum_string, matrix[:limit, :limit], state_vector[state_index_matrix]
+            ),
         )
 
     return new_state_vector
@@ -302,29 +310,69 @@ def cross_kerr(state: PureFockState, instruction: Instruction, shots: int) -> Re
 
 
 def displacement(state: PureFockState, instruction: Instruction, shots: int) -> Result:
+    calculator = state._calculator
+
     r = instruction._all_params["r"]
     phi = instruction._all_params["phi"]
 
-    matrix = get_single_mode_displacement_operator(
-        r=r, phi=phi, calculator=state._calculator, config=state._config
+    wrapped_get_matrix = calculator.decorator(get_single_mode_displacement_operator)
+
+    matrix = wrapped_get_matrix(
+        r=r,
+        phi=phi,
+        cutoff=state._config.cutoff,
+        complex_dtype=state._config.complex_dtype,
+        calculator=calculator,
     )
 
-    _apply_active_gate_matrix_to_state(state, matrix, instruction.modes[0])
+    wrapped_apply = calculator.decorator(_apply_active_gate_matrix_to_state)
+
+    state._state_vector = wrapped_apply(
+        state._state_vector,
+        matrix,
+        state.d,
+        state._config.cutoff,
+        instruction.modes[0],
+        calculator,
+    )
 
     state.normalize()
 
     return Result(state=state)
 
 
-def squeezing(state: PureFockState, instruction: Instruction, shots: int) -> Result:
-    matrix = get_single_mode_squeezing_operator(
-        r=instruction._all_params["r"],
-        phi=instruction._all_params["phi"],
-        calculator=state._calculator,
-        config=state._config,
+def _apply_squeezing(state, r, phi, mode):
+    calculator = state._calculator
+
+    wrapped_get_matrix = calculator.decorator(get_single_mode_squeezing_operator)
+
+    matrix = wrapped_get_matrix(
+        r=r,
+        phi=phi,
+        cutoff=state._config.cutoff,
+        complex_dtype=state._config.complex_dtype,
+        calculator=calculator,
     )
 
-    _apply_active_gate_matrix_to_state(state, matrix, instruction.modes[0])
+    wrapped_apply = calculator.decorator(_apply_active_gate_matrix_to_state)
+
+    state._state_vector = wrapped_apply(
+        state._state_vector,
+        matrix,
+        state.d,
+        state._config.cutoff,
+        mode,
+        calculator=calculator,
+    )
+
+
+def squeezing(state: PureFockState, instruction: Instruction, shots: int) -> Result:
+    _apply_squeezing(
+        state,
+        r=instruction._all_params["r"],
+        phi=instruction._all_params["phi"],
+        mode=instruction.modes[0],
+    )
 
     state.normalize()
 
@@ -332,12 +380,29 @@ def squeezing(state: PureFockState, instruction: Instruction, shots: int) -> Res
 
 
 def cubic_phase(state: PureFockState, instruction: Instruction, shots: int) -> Result:
+    calculator = state._calculator
+
     gamma = instruction._all_params["gamma"]
 
-    matrix = get_single_mode_cubic_phase_operator(
-        gamma=gamma, config=state._config, calculator=state._calculator
+    wrapped_get_matrix = calculator.decorator(get_single_mode_cubic_phase_operator)
+
+    matrix = wrapped_get_matrix(
+        gamma=gamma,
+        cutoff=state._config.cutoff,
+        hbar=state._config.hbar,
+        calculator=calculator,
     )
-    _apply_active_gate_matrix_to_state(state, matrix, instruction.modes[0])
+
+    wrapped_apply = calculator.decorator(_apply_active_gate_matrix_to_state)
+
+    state._state_vector = wrapped_apply(
+        state._state_vector,
+        matrix,
+        state.d,
+        state._config.cutoff,
+        instruction.modes[0],
+        calculator,
+    )
 
     state.normalize()
 
@@ -367,10 +432,7 @@ def linear(
     _apply_passive_linear(state, unitary_first, modes, calculator)
 
     for mode, r in zip(instruction.modes, squeezings):
-        matrix = get_single_mode_squeezing_operator(
-            r=r, phi=0.0, calculator=state._calculator, config=state._config
-        )
-        _apply_active_gate_matrix_to_state(state, matrix, mode)
+        _apply_squeezing(state, r=r, phi=0.0, mode=mode)
 
     _apply_passive_linear(state, unitary_last, modes, calculator)
 

--- a/piquasso/_backends/fock/pure/calculations/passive_linear.py
+++ b/piquasso/_backends/fock/pure/calculations/passive_linear.py
@@ -45,22 +45,39 @@ def passive_linear(
 
 
 def _apply_passive_linear(state, interferometer, modes, calculator):
-    subspace_transformations = _get_interferometer_on_fock_space(
-        interferometer, state._config.cutoff, calculator
+    wrapped = calculator.decorator(_do_apply_passive_linear)
+
+    state._state_vector = wrapped(
+        state._state_vector,
+        interferometer,
+        state.d,
+        state._config.cutoff,
+        modes,
+        calculator,
     )
 
-    _apply_passive_gate_matrix_to_state(state, subspace_transformations, modes)
+
+def _do_apply_passive_linear(
+    state_vector, interferometer, d, cutoff, modes, calculator
+):
+    subspace_transformations = _get_interferometer_on_fock_space(
+        interferometer, cutoff, calculator
+    )
+
+    return _apply_passive_gate_matrix_to_state(
+        state_vector, subspace_transformations, d, cutoff, modes, calculator
+    )
 
 
 def _get_interferometer_on_fock_space(interferometer, cutoff, calculator):
     def _get_interferometer_with_gradient_callback(interferometer):
-        interferometer = calculator.maybe_convert_to_numpy(interferometer)
+        interferometer = calculator.preprocess_input_for_custom_gradient(interferometer)
         index_dict = calculate_interferometer_helper_indices(
             d=len(interferometer), cutoff=cutoff
         )
 
         subspace_representations = calculate_interferometer_on_fock_space(
-            interferometer, index_dict
+            interferometer, index_dict, calculator
         )
         grad = _calculate_interferometer_gradient_on_fock_space(
             interferometer,
@@ -184,31 +201,32 @@ def _calculate_interferometer_gradient_on_fock_space(
 
 
 def _apply_passive_gate_matrix_to_state(
-    state: PureFockState,
+    state_vector: np.ndarray,
     subspace_transformations: List[np.ndarray],
+    d: int,
+    cutoff: int,
     modes: Tuple[int, ...],
+    calculator: BaseCalculator,
 ) -> None:
-    calculator = state._calculator
-    state_vector = state._state_vector
-
     def _apply_interferometer_matrix(state_vector, subspace_transformations):
-        state_vector = calculator.maybe_convert_to_numpy(state_vector)
+        state_vector = calculator.preprocess_input_for_custom_gradient(state_vector)
 
         subspace_transformations = [
-            calculator.maybe_convert_to_numpy(matrix)
+            calculator.preprocess_input_for_custom_gradient(matrix)
             for matrix in subspace_transformations
         ]
 
         index_list = calculate_index_list_for_appling_interferometer(
             modes,
-            state.d,
-            state._config.cutoff,
+            d,
+            cutoff,
         )
 
         new_state_vector = _calculate_state_vector_after_interferometer(
             state_vector,
             subspace_transformations,
             index_list,
+            calculator,
         )
 
         grad = _create_linear_passive_gate_gradient_function(
@@ -221,14 +239,17 @@ def _apply_passive_gate_matrix_to_state(
 
     wrapped = calculator.custom_gradient(_apply_interferometer_matrix)
 
-    state._state_vector = wrapped(state_vector, subspace_transformations)
+    return wrapped(state_vector, subspace_transformations)
 
 
 def _calculate_state_vector_after_interferometer(
     state_vector: np.ndarray,
     subspace_transformations: List[np.ndarray],
     index_list: List[np.ndarray],
+    calculator: BaseCalculator,
 ) -> np.ndarray:
+    np = calculator.forward_pass_np
+
     new_state_vector = np.empty_like(state_vector)
 
     is_batch = len(state_vector.shape) == 2
@@ -236,8 +257,12 @@ def _calculate_state_vector_after_interferometer(
     einsum_string = "ij,jkl->ikl" if is_batch else "ij,jk->ik"
 
     for n, indices in enumerate(index_list):
-        new_state_vector[indices] = np.einsum(
-            einsum_string, subspace_transformations[n], state_vector[indices]
+        new_state_vector = calculator.assign(
+            new_state_vector,
+            indices,
+            np.einsum(
+                einsum_string, subspace_transformations[n], state_vector[indices]
+            ),
         )
 
     return new_state_vector

--- a/piquasso/_math/gate_matrices.py
+++ b/piquasso/_math/gate_matrices.py
@@ -19,11 +19,15 @@ from functools import lru_cache
 
 from scipy.special import factorial
 
+from piquasso.api.calculator import BaseCalculator
+
 
 def create_single_mode_displacement_matrix(
     r: float,
     phi: float,
     cutoff: int,
+    complex_dtype: np.dtype,
+    calculator: BaseCalculator,
 ) -> np.ndarray:
     r"""
     This method generates the Displacement operator following a recursion rule.
@@ -40,24 +44,42 @@ def create_single_mode_displacement_matrix(
         np.ndarray: The constructed Displacement matrix representing the Fock
         operator.
     """
-    cutoff_range = np.arange(cutoff)
-    sqrt_indices = np.sqrt(cutoff_range)
-    denominator = 1 / np.sqrt(factorial(cutoff_range))
+    np = calculator.forward_pass_np
+    fallback_np = calculator.fallback_np
+
+    cutoff_range = fallback_np.arange(cutoff)
+    sqrt_indices = fallback_np.sqrt(cutoff_range)
+    denominator = 1 / fallback_np.sqrt(factorial(cutoff_range))
 
     displacement = r * np.exp(1j * phi)
     displacement_conj = np.conj(displacement)
-    columns = []
 
-    columns.append(np.power(displacement, cutoff_range) * denominator)
+    matrix = calculator.accumulator(dtype=complex_dtype, size=cutoff)
 
-    roll_index = np.arange(-1, cutoff - 1)
+    # NOTE: Tensorflow does not implement the NumPy API correctly, since in
+    # tensorflow `np.power(0.0j, 0.0)` results in `nan+nanj`, whereas in NumPy it
+    # is just 1. Instead of redefining `power` we just add a small `epsilon`, which
+    # magically yields the correct result.
+    epsilon = 10e-100
+    previous_element = np.power(displacement + epsilon, cutoff_range) * denominator
 
-    for _ in range(cutoff - 1):
-        columns.append(
-            sqrt_indices * columns[-1][roll_index] - displacement_conj * columns[-1]
+    matrix = calculator.write_to_accumulator(matrix, 0, previous_element)
+
+    roll_index = fallback_np.arange(-1, cutoff - 1)
+
+    for i in calculator.range(1, cutoff):
+        previous_element = (
+            sqrt_indices * previous_element[roll_index]
+            - displacement_conj * previous_element
         )
 
-    return np.exp(-0.5 * r**2) * np.column_stack(columns) * denominator
+        matrix = calculator.write_to_accumulator(matrix, i, previous_element)
+
+    return (
+        np.exp(-0.5 * r**2)
+        * calculator.transpose(calculator.stack_accumulator(matrix))
+        * denominator
+    )
 
 
 @lru_cache
@@ -77,7 +99,11 @@ def _double_factorial_array(cutoff):
 
 
 def create_single_mode_squeezing_matrix(
-    r: float, phi: float, cutoff: int, complex_dtype: np.dtype
+    r: float,
+    phi: float,
+    cutoff: int,
+    complex_dtype: np.dtype,
+    calculator: BaseCalculator,
 ) -> np.ndarray:
     """
     This method generates the Squeezing operator following a recursion rule.
@@ -96,32 +122,49 @@ def create_single_mode_squeezing_matrix(
         np.ndarray: The constructed Squeezing matrix representing the Fock operator.
     """
 
+    np = calculator.forward_pass_np
+    fallback_np = calculator.fallback_np
+
     sechr = 1.0 / np.cosh(r)
     A = np.exp(1j * phi) * np.tanh(r)
     Aconj = np.conj(A)
-    sqrt_indices = np.sqrt(np.arange(cutoff))
+    sqrt_indices = np.sqrt(fallback_np.arange(cutoff))
     sechr_sqrt_indices = sechr * sqrt_indices
     A_conj_sqrt_indices = Aconj * sqrt_indices
 
-    first_row_nonzero = np.sqrt(_double_factorial_array(cutoff)) * np.power(
-        -A, np.arange(0, (cutoff + 1) // 2)
+    # NOTE: Tensorflow does not implement the NumPy API correctly, since in
+    # tensorflow `np.power(0.0j, 0.0)` results in `nan+nanj`, whereas in NumPy it
+    # is just 1. Instead of redefining `power` we just add a small `epsilon`, which
+    # magically yields the correct result.
+    epsilon = 10e-100
+    first_row_nonzero = fallback_np.sqrt(_double_factorial_array(cutoff)) * np.power(
+        -(A + epsilon), fallback_np.arange(0, (cutoff + 1) // 2)
     )
 
     first_row = np.zeros(shape=cutoff, dtype=complex_dtype)
-    first_row[np.arange(0, cutoff, 2)] = first_row_nonzero
+    first_row = calculator.assign(
+        first_row, fallback_np.arange(0, cutoff, 2), first_row_nonzero
+    )
 
-    roll_index = np.arange(-1, cutoff - 1)
+    roll_index = fallback_np.arange(-1, cutoff - 1)
     second_row = sechr_sqrt_indices * first_row[roll_index]
 
-    columns = [first_row, second_row]
+    matrix = calculator.accumulator(dtype=complex_dtype, size=cutoff)
 
-    for col in range(2, cutoff):
-        columns.append(
-            (
-                sechr_sqrt_indices * columns[-1][roll_index]
-                + A_conj_sqrt_indices[col - 1] * columns[-2]
-            )
-            / sqrt_indices[col]
-        )
+    matrix = calculator.write_to_accumulator(matrix, 0, first_row)
+    matrix = calculator.write_to_accumulator(matrix, 1, second_row)
 
-    return np.sqrt(sechr) * np.column_stack(columns)
+    previous_previous = first_row
+    previous = second_row
+
+    for col in calculator.range(2, cutoff):
+        current = (
+            sechr_sqrt_indices * previous[roll_index]
+            + A_conj_sqrt_indices[col - 1] * previous_previous
+        ) / sqrt_indices[col]
+
+        matrix = calculator.write_to_accumulator(matrix, col, current)
+        previous_previous = previous
+        previous = current
+
+    return np.sqrt(sechr) * calculator.transpose(calculator.stack_accumulator(matrix))

--- a/piquasso/_math/linalg.py
+++ b/piquasso/_math/linalg.py
@@ -99,6 +99,8 @@ def assym_reduce(
 def vector_absolute_square(vector, calculator):
     @calculator.custom_gradient
     def _vector_absolute_square(v):
+        np = calculator.forward_pass_np
+
         absolute_square = np.real((v * np.conj(v)))
 
         def _vector_absolute_square_grad(upstream):

--- a/piquasso/api/calculator.py
+++ b/piquasso/api/calculator.py
@@ -30,6 +30,8 @@ class BaseCalculator(abc.ABC):
 
     np: Any
     fallback_np: Any
+    forward_pass_np: Any
+    range: Any
 
     def __deepcopy__(self, memo: Any) -> "BaseCalculator":
         """
@@ -40,9 +42,9 @@ class BaseCalculator(abc.ABC):
 
         return self
 
-    def maybe_convert_to_numpy(self, value):
+    def preprocess_input_for_custom_gradient(self, value):
         """
-        Converts tensorflow objects to numpy objects if applicable.
+        Applies modifications to inputs in custom gradients.
         """
         raise NotImplementedCalculation()
 
@@ -84,4 +86,22 @@ class BaseCalculator(abc.ABC):
         raise NotImplementedCalculation()
 
     def custom_gradient(self, func):
+        raise NotImplementedCalculation()
+
+    def accumulator(self, dtype, size, **kwargs):
+        raise NotImplementedCalculation()
+
+    def write_to_accumulator(self, accumulator, index, value):
+        raise NotImplementedCalculation()
+
+    def stack_accumulator(self, accumulator):
+        raise NotImplementedCalculation()
+
+    def decorator(self, func):
+        raise NotImplementedCalculation()
+
+    def gather_along_axis_1(self, array, indices):
+        raise NotImplementedCalculation()
+
+    def transpose(self, matrix):
         raise NotImplementedCalculation()

--- a/scripts/cvnn_mean_position_benchmark.py
+++ b/scripts/cvnn_mean_position_benchmark.py
@@ -1,0 +1,109 @@
+#
+# Copyright 2021-2024 Budapest Quantum Computing Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import piquasso as pq
+import tensorflow as tf
+
+import time
+
+
+tf.get_logger().setLevel("ERROR")
+
+
+def measure_graph_size(f, *args):
+    if not hasattr(f, "get_concrete_function"):
+        return 0
+
+    g = f.get_concrete_function(*args).graph
+
+    return len(g.as_graph_def().node)
+
+
+def calculate_mean_position(weights, cutoff, d, calculator):
+    simulator = pq.PureFockSimulator(
+        d,
+        pq.Config(cutoff=cutoff, normalize=False),
+        calculator=calculator,
+    )
+
+    with tf.GradientTape() as tape:
+        cvqnn_layers = pq.cvqnn.create_layers(weights)
+
+        preparation = [pq.Vacuum()]
+
+        program = pq.Program(instructions=preparation + cvqnn_layers.instructions)
+
+        final_state = simulator.execute(program).state
+
+        mean_position = final_state.mean_position(0)
+
+    print("_FORWARD FINISH:", time.time() - start_time)
+
+    mean_position_grad = tape.gradient(mean_position, weights)
+
+    print("_BACK FINISH:", time.time() - start_time)
+
+    return mean_position, mean_position_grad
+
+
+if __name__ == "__main__":
+    d = 2
+    layer_count = 5
+    cutoff = 10
+
+    NUMBER_OF_ITERATIONS = 5
+
+    weights = tf.Variable(
+        pq.cvqnn.generate_random_cvqnn_weights(layer_count=layer_count, d=d)
+    )
+
+    decorator = tf.function(jit_compile=True)
+
+    calculator = pq.TensorflowCalculator(decorate_with=decorator)
+
+    enhanced_calculate_mean_position = decorator(calculate_mean_position)
+
+    print("START")
+    start_time = time.time()
+
+    enhanced_calculate_mean_position(weights, cutoff, d, calculator)
+
+    print("COMPILATION TIME:", time.time() - start_time)
+
+    print(
+        "GRAPH SIZE:",
+        measure_graph_size(
+            enhanced_calculate_mean_position, weights, cutoff, d, calculator
+        ),
+    )
+
+    sum_ = 0.0
+
+    for i in range(NUMBER_OF_ITERATIONS):
+        weights = tf.Variable(
+            pq.cvqnn.generate_random_cvqnn_weights(layer_count=layer_count, d=d)
+        )
+
+        start_time = time.time()
+        result = enhanced_calculate_mean_position(weights, cutoff, d, calculator)
+        end_time = time.time()
+
+        runtime = end_time - start_time
+
+        print(f"{i}. runtime={runtime},\t result={result[0].numpy()}")
+
+        sum_ += runtime
+
+    print("AVERAGE RUNTIME:", sum_ / NUMBER_OF_ITERATIONS)

--- a/scripts/cvnn_state_learning_benchmark.py
+++ b/scripts/cvnn_state_learning_benchmark.py
@@ -18,8 +18,6 @@ Some of the code has been copyied from
 `https://strawberryfields.ai/photonics/demos/run_gate_synthesis.html`.
 """
 
-import pytest
-
 import numpy as np
 
 import tensorflow as tf
@@ -28,72 +26,23 @@ import strawberryfields as sf
 import piquasso as pq
 from piquasso import cvqnn
 
+import time
 
+
+tf.get_logger().setLevel("ERROR")
 np.set_printoptions(suppress=True, linewidth=200)
 
 
-@pytest.fixture
-def cutoff():
-    return 20
+def measure_graph_size(f, *args):
+    if not hasattr(f, "get_concrete_function"):
+        return 0
+
+    g = f.get_concrete_function(*args).graph
+
+    return len(g.as_graph_def().node)
 
 
-@pytest.fixture
-def layer_count():
-    return 3
-
-
-@pytest.fixture
-def d():
-    return 2
-
-
-@pytest.fixture
-def weights(layer_count, d):
-    active_sd = 0.01
-    passive_sd = 0.1
-
-    M = int(d * (d - 1)) + max(1, d - 1)
-
-    int1_weights = tf.random.normal(shape=[layer_count, M], stddev=passive_sd)
-    s_weights = tf.random.normal(shape=[layer_count, d], stddev=active_sd)
-    int2_weights = tf.random.normal(shape=[layer_count, M], stddev=passive_sd)
-    dr_weights = tf.random.normal(shape=[layer_count, d], stddev=active_sd)
-    dp_weights = tf.random.normal(shape=[layer_count, d], stddev=passive_sd)
-    k_weights = tf.random.normal(shape=[layer_count, d], stddev=active_sd)
-
-    weights = tf.cast(
-        tf.concat(
-            [int1_weights, s_weights, int2_weights, dr_weights, dp_weights, k_weights],
-            axis=1,
-        ),
-        dtype=tf.float64,
-    )
-
-    weights = tf.Variable(weights)
-
-    return weights
-
-
-def piquasso_benchmark(benchmark, weights, cutoff):
-    calculator = pq.TensorflowCalculator(decorate_with=tf.function)
-    benchmark(lambda: _calculate_piquasso_results(weights, cutoff, calculator))
-
-
-def strawberryfields_benchmark(benchmark, weights, cutoff):
-    benchmark(lambda: _calculate_strawberryfields_results(weights, cutoff))
-
-
-def test_state_vector_and_jacobian(weights, cutoff):
-    pq_state_vector, pq_jacobian = _calculate_piquasso_results(
-        weights, cutoff, pq.TensorflowCalculator(decorate_with=tf.function)
-    )
-    sf_state_vector, sf_jacobian = _calculate_strawberryfields_results(weights, cutoff)
-
-    assert np.sum(np.abs(pq_state_vector - sf_state_vector) ** 2) < 1e-10
-    assert np.sum(np.abs(pq_jacobian - sf_jacobian) ** 2) < 1e-10
-
-
-def _pq_state_vector(weights, cutoff, calculator):
+def _pq_loss(weights, cutoff, calculator):
     d = cvqnn.get_number_of_modes(weights.shape[1])
 
     simulator = pq.PureFockSimulator(
@@ -104,17 +53,23 @@ def _pq_state_vector(weights, cutoff, calculator):
 
     program = cvqnn.create_program(weights)
 
-    state = simulator.execute(program).state
+    state_vector = simulator.execute(program).state._state_vector
 
-    return state.get_tensor_representation()
+    return tf.math.reduce_mean(
+        (
+            tf.ones_like(state_vector) / np.sqrt(len(state_vector))
+            - tf.math.real(state_vector)
+        )
+        ** 2
+    )
 
 
-@tf.function
+@tf.function(jit_compile=True)
 def _calculate_piquasso_results(weights, cutoff, calculator):
     with tf.GradientTape() as tape:
-        state_vector = _pq_state_vector(weights, cutoff, calculator)
+        loss = _pq_loss(weights, cutoff, calculator)
 
-    return state_vector, tape.jacobian(state_vector, weights)
+    return loss, tape.gradient(loss, weights)
 
 
 def _calculate_strawberryfields_results(weights, cutoff):
@@ -140,8 +95,15 @@ def _calculate_strawberryfields_results(weights, cutoff):
 
         state = eng.run(qnn, args=mapping).state
         state_vector = state.ket()
+        loss = tf.math.reduce_mean(
+            (
+                tf.ones_like(state_vector) / np.sqrt(len(state_vector))
+                - tf.math.real(state_vector)
+            )
+            ** 2
+        )
 
-    return state_vector, tape.jacobian(state_vector, weights)
+    return loss, tape.gradient(loss, weights)
 
 
 def _sf_interferometer(params, q):
@@ -187,3 +149,60 @@ def _sf_layer(params, q):
     for i in range(N):
         sf.ops.Dgate(dr[i], dp[i]) | q[i]
         sf.ops.Kgate(k[i]) | q[i]
+
+
+if __name__ == "__main__":
+    d = 2
+    layer_count = 5
+    cutoff = 10
+
+    NUMBER_OF_ITERATIONS = 10
+
+    weights = tf.Variable(
+        pq.cvqnn.generate_random_cvqnn_weights(layer_count=layer_count, d=d)
+    )
+
+    calculator = pq.TensorflowCalculator(decorate_with=tf.function(jit_compile=True))
+
+    start_time = time.time()
+    _calculate_piquasso_results(
+        weights,
+        cutoff,
+        calculator,
+    )
+    print("PQ COMPILE TIME:", time.time() - start_time)
+    print(
+        "GRAPH SIZE:",
+        measure_graph_size(
+            _calculate_piquasso_results,
+            weights,
+            cutoff,
+            calculator,
+        ),
+    )
+
+    for i in range(NUMBER_OF_ITERATIONS):
+        weights = tf.Variable(
+            pq.cvqnn.generate_random_cvqnn_weights(layer_count=layer_count, d=d)
+        )
+        start_time = time.time()
+        print(f"{i:} ", end="")
+        _calculate_piquasso_results(weights, cutoff, calculator)
+        print("PQ RUNTIME:", time.time() - start_time)
+
+    weights = tf.Variable(
+        pq.cvqnn.generate_random_cvqnn_weights(layer_count=layer_count, d=d)
+    )
+
+    start_time = time.time()
+    _calculate_strawberryfields_results(weights, cutoff)
+    print("SF COMPILE TIME:", time.time() - start_time)
+
+    for i in range(10):
+        weights = tf.Variable(
+            pq.cvqnn.generate_random_cvqnn_weights(layer_count=layer_count, d=d)
+        )
+        print(f"{i:} ", end="")
+        start_time = time.time()
+        _calculate_strawberryfields_results(weights, cutoff)
+        print("SF RUNTIME:", time.time() - start_time)

--- a/tests/api/test_calculator.py
+++ b/tests/api/test_calculator.py
@@ -128,6 +128,43 @@ def test_BaseCalculator_raises_NotImplementedCalculation_for_powm(
         empty_calculator.powm(dummy_matrix, 42)
 
 
+def test_BaseCalculator_raises_NotImplementedCalculation_for_accumulator(
+    empty_calculator,
+):
+    with pytest.raises(NotImplementedCalculation):
+        empty_calculator.accumulator(dtype=complex, size=5)
+
+
+def test_BaseCalculator_raises_NotImplementedCalculation_for_write_to_accumulator(
+    empty_calculator,
+):
+    with pytest.raises(NotImplementedCalculation):
+        empty_calculator.write_to_accumulator(accumulator=[], index=0, value=1)
+
+
+def test_BaseCalculator_raises_NotImplementedCalculation_for_stack_accumulator(
+    empty_calculator,
+):
+    with pytest.raises(NotImplementedCalculation):
+        empty_calculator.stack_accumulator(accumulator=[])
+
+
+def test_BaseCalculator_raises_NotImplementedCalculation_gather_along_axis_1(
+    empty_calculator, dummy_matrix
+):
+    with pytest.raises(NotImplementedCalculation):
+        empty_calculator.gather_along_axis_1(
+            array=dummy_matrix, indices=[[1, 2], [3, 4]]
+        )
+
+
+def test_BaseCalculator_raises_NotImplementedCalculation_transpose(
+    empty_calculator, dummy_matrix
+):
+    with pytest.raises(NotImplementedCalculation):
+        empty_calculator.transpose(matrix=dummy_matrix)
+
+
 def test_BaseCalculator_with_overriding_defaults():
     """
     NOTE: This test basically tests Python itself, but it is left here for us to

--- a/tests/backends/fock/test_gates.py
+++ b/tests/backends/fock/test_gates.py
@@ -18,12 +18,19 @@ import pytest
 import numpy as np
 
 import piquasso as pq
+import tensorflow as tf
 
 from functools import partial
 
-TensorflowPureFockSimulator = partial(
-    pq.PureFockSimulator,
-    calculator=pq.TensorflowCalculator(),
+tf_purefock_simulators = (
+    partial(
+        pq.PureFockSimulator,
+        calculator=pq.TensorflowCalculator(),
+    ),
+    partial(
+        pq.PureFockSimulator,
+        calculator=pq.TensorflowCalculator(decorate_with=tf.function),
+    ),
 )
 
 
@@ -31,7 +38,7 @@ TensorflowPureFockSimulator = partial(
     "SimulatorClass",
     (
         pq.PureFockSimulator,
-        TensorflowPureFockSimulator,
+        *tf_purefock_simulators,
         pq.FockSimulator,
     ),
 )
@@ -59,7 +66,7 @@ def test_squeezing_probabilities(SimulatorClass):
     "SimulatorClass",
     (
         pq.PureFockSimulator,
-        TensorflowPureFockSimulator,
+        *tf_purefock_simulators,
         pq.FockSimulator,
     ),
 )

--- a/tests/backends/tensorflow/test_batch_gradient.py
+++ b/tests/backends/tensorflow/test_batch_gradient.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
+
 import tensorflow as tf
 
 import numpy as np
@@ -20,7 +22,14 @@ import numpy as np
 import piquasso as pq
 
 
-def test_batch_Beamsplitter_mean_position():
+calculators = (
+    pq.TensorflowCalculator(),
+    pq.TensorflowCalculator(decorate_with=tf.function),
+)
+
+
+@pytest.mark.parametrize("calculator", calculators)
+def test_batch_Beamsplitter_mean_position(calculator):
     theta = tf.Variable(np.pi / 3)
 
     with pq.Program() as first_preparation:
@@ -38,7 +47,7 @@ def test_batch_Beamsplitter_mean_position():
             pq.Q() | pq.Beamsplitter(theta=theta, phi=np.pi / 3)
 
         simulator = pq.PureFockSimulator(
-            d=2, config=pq.Config(cutoff=5), calculator=pq.TensorflowCalculator()
+            d=2, config=pq.Config(cutoff=5), calculator=calculator
         )
 
         batch_mean_positions = simulator.execute(batch_program).state.mean_position(0)
@@ -72,7 +81,8 @@ def test_batch_Beamsplitter_mean_position():
     assert np.allclose(batch_gradient[1], second_gradient)
 
 
-def test_batch_Squeezing_mean_position():
+@pytest.mark.parametrize("calculator", calculators)
+def test_batch_Squeezing_mean_position(calculator):
     r = tf.Variable(0.1)
 
     with pq.Program() as first_preparation:
@@ -91,7 +101,7 @@ def test_batch_Squeezing_mean_position():
             pq.Q() | pq.Beamsplitter(theta=np.pi / 3, phi=np.pi / 3)
 
         simulator = pq.PureFockSimulator(
-            d=2, config=pq.Config(cutoff=5), calculator=pq.TensorflowCalculator()
+            d=2, config=pq.Config(cutoff=5), calculator=calculator
         )
 
         batch_mean_positions = simulator.execute(batch_program).state.mean_position(0)
@@ -127,7 +137,8 @@ def test_batch_Squeezing_mean_position():
     assert np.allclose(batch_gradient[1], second_gradient)
 
 
-def test_batch_Displacement_mean_position():
+@pytest.mark.parametrize("calculator", calculators)
+def test_batch_Displacement_mean_position(calculator):
     r = tf.Variable(0.1)
 
     with pq.Program() as first_preparation:
@@ -146,7 +157,7 @@ def test_batch_Displacement_mean_position():
             pq.Q() | pq.Beamsplitter(theta=np.pi / 3, phi=np.pi / 3)
 
         simulator = pq.PureFockSimulator(
-            d=2, config=pq.Config(cutoff=5), calculator=pq.TensorflowCalculator()
+            d=2, config=pq.Config(cutoff=5), calculator=calculator
         )
 
         batch_mean_positions = simulator.execute(batch_program).state.mean_position(0)
@@ -182,7 +193,8 @@ def test_batch_Displacement_mean_position():
     assert np.allclose(batch_gradient[1], second_gradient)
 
 
-def test_batch_Kerr_mean_position():
+@pytest.mark.parametrize("calculator", calculators)
+def test_batch_Kerr_mean_position(calculator):
     xi = tf.Variable(0.1)
 
     with pq.Program() as first_preparation:
@@ -201,7 +213,7 @@ def test_batch_Kerr_mean_position():
             pq.Q() | pq.Beamsplitter(theta=np.pi / 3, phi=np.pi / 3)
 
         simulator = pq.PureFockSimulator(
-            d=2, config=pq.Config(cutoff=5), calculator=pq.TensorflowCalculator()
+            d=2, config=pq.Config(cutoff=5), calculator=calculator
         )
 
         batch_mean_positions = simulator.execute(batch_program).state.mean_position(0)
@@ -237,7 +249,8 @@ def test_batch_Kerr_mean_position():
     assert np.allclose(batch_gradient[1], second_gradient)
 
 
-def test_batch_Phaseshifter_mean_position():
+@pytest.mark.parametrize("calculator", calculators)
+def test_batch_Phaseshifter_mean_position(calculator):
     phi = tf.Variable(np.pi / 5)
 
     with pq.Program() as first_preparation:
@@ -256,7 +269,7 @@ def test_batch_Phaseshifter_mean_position():
             pq.Q() | pq.Beamsplitter(theta=np.pi / 3, phi=np.pi / 3)
 
         simulator = pq.PureFockSimulator(
-            d=2, config=pq.Config(cutoff=5), calculator=pq.TensorflowCalculator()
+            d=2, config=pq.Config(cutoff=5), calculator=calculator
         )
 
         batch_mean_positions = simulator.execute(batch_program).state.mean_position(0)
@@ -292,7 +305,8 @@ def test_batch_Phaseshifter_mean_position():
     assert np.allclose(batch_gradient[1], second_gradient)
 
 
-def test_batch_complex_circuit_mean_position():
+@pytest.mark.parametrize("calculator", calculators)
+def test_batch_complex_circuit_mean_position(calculator):
     theta1 = tf.Variable(np.pi / 3)
     phi1 = tf.Variable(np.pi / 4)
 
@@ -340,7 +354,7 @@ def test_batch_complex_circuit_mean_position():
             pq.Q(1) | pq.Kerr(xi=xi2)
 
         simulator = pq.PureFockSimulator(
-            d=2, config=pq.Config(cutoff=5), calculator=pq.TensorflowCalculator()
+            d=2, config=pq.Config(cutoff=5), calculator=calculator
         )
 
         batch_mean_positions = simulator.execute(batch_program).state.mean_position(0)
@@ -400,7 +414,8 @@ def test_batch_complex_circuit_mean_position():
     assert np.allclose(batch_gradient[:, 1], second_gradient)
 
 
-def test_batch_complex_circuit_mean_position_with_batch_apply():
+@pytest.mark.parametrize("calculator", calculators)
+def test_batch_complex_circuit_mean_position_with_batch_apply(calculator):
     theta1 = tf.Variable(np.pi / 3)
     phi1 = tf.Variable(np.pi / 4)
 
@@ -459,7 +474,7 @@ def test_batch_complex_circuit_mean_position_with_batch_apply():
             pq.Q(1) | pq.Kerr(xi=xi2)
 
         simulator = pq.PureFockSimulator(
-            d=2, config=pq.Config(cutoff=5), calculator=pq.TensorflowCalculator()
+            d=2, config=pq.Config(cutoff=5), calculator=calculator
         )
 
         batch_mean_positions = simulator.execute(batch_program).state.mean_position(0)

--- a/tests/backends/test_backend_equivalence.py
+++ b/tests/backends/test_backend_equivalence.py
@@ -16,6 +16,7 @@
 import pytest
 import numpy as np
 import piquasso as pq
+import tensorflow as tf
 
 import collections
 
@@ -35,9 +36,15 @@ def is_proportional(first, second):
     return np.allclose(first, proportion * second)
 
 
-TensorflowPureFockSimulator = partial(
-    pq.PureFockSimulator,
-    calculator=pq.TensorflowCalculator(),
+tf_purefock_simulators = (
+    partial(
+        pq.PureFockSimulator,
+        calculator=pq.TensorflowCalculator(),
+    ),
+    partial(
+        pq.PureFockSimulator,
+        calculator=pq.TensorflowCalculator(decorate_with=tf.function),
+    ),
 )
 
 
@@ -46,7 +53,7 @@ TensorflowPureFockSimulator = partial(
     (
         pq.GaussianSimulator,
         pq.PureFockSimulator,
-        TensorflowPureFockSimulator,
+        *tf_purefock_simulators,
         pq.FockSimulator,
     ),
 )
@@ -70,7 +77,7 @@ def test_fock_probabilities_should_be_numpy_array_of_floats(SimulatorClass):
     (
         pq.GaussianSimulator,
         pq.PureFockSimulator,
-        TensorflowPureFockSimulator,
+        *tf_purefock_simulators,
         pq.FockSimulator,
     ),
 )
@@ -148,7 +155,7 @@ def test_density_matrix_with_squeezed_state():
     (
         pq.GaussianSimulator,
         pq.PureFockSimulator,
-        TensorflowPureFockSimulator,
+        *tf_purefock_simulators,
         pq.FockSimulator,
     ),
 )
@@ -198,7 +205,7 @@ def test_fock_probabilities_with_displaced_state(SimulatorClass):
     (
         pq.PureFockSimulator,
         pq.FockSimulator,
-        TensorflowPureFockSimulator,
+        *tf_purefock_simulators,
         pq.GaussianSimulator,
     ),
 )
@@ -237,7 +244,7 @@ def test_Displacement_equivalence_on_multiple_modes(SimulatorClass):
     (
         pq.GaussianSimulator,
         pq.PureFockSimulator,
-        TensorflowPureFockSimulator,
+        *tf_purefock_simulators,
         pq.FockSimulator,
     ),
 )
@@ -288,7 +295,7 @@ def test_fock_probabilities_with_displaced_state_with_beamsplitter(SimulatorClas
     (
         pq.GaussianSimulator,
         pq.PureFockSimulator,
-        TensorflowPureFockSimulator,
+        *tf_purefock_simulators,
         pq.FockSimulator,
     ),
 )
@@ -339,7 +346,7 @@ def test_fock_probabilities_with_squeezed_state_with_beamsplitter(SimulatorClass
     (
         pq.GaussianSimulator,
         pq.PureFockSimulator,
-        TensorflowPureFockSimulator,
+        *tf_purefock_simulators,
         pq.FockSimulator,
     ),
 )
@@ -369,7 +376,7 @@ def test_fock_probabilities_with_two_single_mode_squeezings(SimulatorClass):
     (
         pq.GaussianSimulator,
         pq.PureFockSimulator,
-        TensorflowPureFockSimulator,
+        *tf_purefock_simulators,
         pq.FockSimulator,
     ),
 )
@@ -397,7 +404,7 @@ def test_Squeezing_equivalence_on_multiple_modes(SimulatorClass):
     (
         pq.GaussianSimulator,
         pq.PureFockSimulator,
-        TensorflowPureFockSimulator,
+        *tf_purefock_simulators,
         pq.FockSimulator,
     ),
 )
@@ -452,7 +459,7 @@ def test_fock_probabilities_with_two_mode_squeezing(SimulatorClass):
     (
         pq.GaussianSimulator,
         pq.PureFockSimulator,
-        TensorflowPureFockSimulator,
+        *tf_purefock_simulators,
         pq.FockSimulator,
     ),
 )
@@ -503,7 +510,7 @@ def test_fock_probabilities_with_two_mode_squeezing_and_beamsplitter(SimulatorCl
     (
         pq.GaussianSimulator,
         pq.PureFockSimulator,
-        TensorflowPureFockSimulator,
+        *tf_purefock_simulators,
         pq.FockSimulator,
     ),
 )
@@ -551,7 +558,7 @@ def test_fock_probabilities_with_quadratic_phase(SimulatorClass):
     (
         pq.GaussianSimulator,
         pq.PureFockSimulator,
-        TensorflowPureFockSimulator,
+        *tf_purefock_simulators,
         pq.FockSimulator,
     ),
 )
@@ -599,7 +606,7 @@ def test_fock_probabilities_with_position_displacement(SimulatorClass):
     (
         pq.GaussianSimulator,
         pq.PureFockSimulator,
-        TensorflowPureFockSimulator,
+        *tf_purefock_simulators,
         pq.FockSimulator,
     ),
 )
@@ -647,7 +654,7 @@ def test_fock_probabilities_with_momentum_displacement(SimulatorClass):
     (
         pq.GaussianSimulator,
         pq.PureFockSimulator,
-        TensorflowPureFockSimulator,
+        *tf_purefock_simulators,
         pq.FockSimulator,
     ),
 )
@@ -676,7 +683,7 @@ def test_fock_probabilities_with_position_displacement_is_HBAR_independent(
     (
         pq.GaussianSimulator,
         pq.PureFockSimulator,
-        TensorflowPureFockSimulator,
+        *tf_purefock_simulators,
         pq.FockSimulator,
     ),
 )
@@ -705,7 +712,7 @@ def test_fock_probabilities_with_momentum_displacement_is_HBAR_independent(
     (
         pq.GaussianSimulator,
         pq.PureFockSimulator,
-        TensorflowPureFockSimulator,
+        *tf_purefock_simulators,
         pq.FockSimulator,
     ),
 )
@@ -1164,7 +1171,7 @@ def test_fidelity_for_nondisplaced_mixed_states_on_3_modes(SimulatorClass):
     (
         pq.PureFockSimulator,
         pq.FockSimulator,
-        TensorflowPureFockSimulator,
+        *tf_purefock_simulators,
     ),
 )
 def test_cubic_phase_equivalency(SimulatorClass):
@@ -1193,7 +1200,7 @@ def test_cubic_phase_equivalency(SimulatorClass):
     (
         pq.PureFockSimulator,
         pq.FockSimulator,
-        TensorflowPureFockSimulator,
+        *tf_purefock_simulators,
     ),
 )
 def test_CubicPhase_equivalence_on_multiple_modes(SimulatorClass):
@@ -1231,7 +1238,7 @@ def test_CubicPhase_equivalence_on_multiple_modes(SimulatorClass):
     (
         pq.PureFockSimulator,
         pq.FockSimulator,
-        TensorflowPureFockSimulator,
+        *tf_purefock_simulators,
     ),
 )
 def test_Kerr_gate_leaves_fock_probabilities_invariant(SimulatorClass):
@@ -1257,7 +1264,7 @@ def test_Kerr_gate_leaves_fock_probabilities_invariant(SimulatorClass):
     "SimulatorClass",
     (
         pq.PureFockSimulator,
-        TensorflowPureFockSimulator,
+        *tf_purefock_simulators,
     ),
 )
 def test_Kerr_equivalence(SimulatorClass):
@@ -1460,7 +1467,7 @@ def test_Attenuator_raises_InvalidParam_for_non_zero_mean_thermal_excitation(
         pq.PureFockSimulator,
         pq.FockSimulator,
         pq.GaussianSimulator,
-        TensorflowPureFockSimulator,
+        *tf_purefock_simulators,
     ),
 )
 def test_Interferometer_smaller_than_system_size(SimulatorClass):
@@ -1525,4 +1532,64 @@ def test_Interferometer_smaller_than_system_size(SimulatorClass):
             0.0,
             0.00005109,
         ],
+    )
+
+
+@pytest.mark.parametrize(
+    "SimulatorClass",
+    (
+        pq.PureFockSimulator,
+        pq.FockSimulator,
+        pq.GaussianSimulator,
+        *tf_purefock_simulators,
+    ),
+)
+def test_Squeezing_with_zero_parameter(SimulatorClass):
+    config = pq.Config(cutoff=3)
+
+    d = 2
+
+    with pq.Program() as program:
+        pq.Q() | pq.Vacuum()
+
+        pq.Q(0) | pq.Squeezing(r=0.0)
+        pq.Q(1) | pq.Squeezing(r=0.1)
+
+    simulator = SimulatorClass(d=d, config=config)
+
+    state = simulator.execute(program).state
+
+    assert is_proportional(
+        state.fock_probabilities,
+        [0.99505769, 0.0, 0.0, 0.0, 0.0, 0.00494231],
+    )
+
+
+@pytest.mark.parametrize(
+    "SimulatorClass",
+    (
+        pq.PureFockSimulator,
+        pq.FockSimulator,
+        pq.GaussianSimulator,
+        *tf_purefock_simulators,
+    ),
+)
+def test_Displacement_with_zero_parameter(SimulatorClass):
+    config = pq.Config(cutoff=3)
+
+    d = 2
+
+    with pq.Program() as program:
+        pq.Q() | pq.Vacuum()
+
+        pq.Q(0) | pq.Displacement(r=0.0)
+        pq.Q(1) | pq.Displacement(r=0.1)
+
+    simulator = SimulatorClass(d=d, config=config)
+
+    state = simulator.execute(program).state
+
+    assert is_proportional(
+        state.fock_probabilities,
+        [0.99005, 0.0, 0.0099005, 0.0, 0.0, 0.0000495],
     )

--- a/tests/slow/test_tf_function.py
+++ b/tests/slow/test_tf_function.py
@@ -1,0 +1,436 @@
+#
+# Copyright 2021-2024 Budapest Quantum Computing Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import piquasso as pq
+import tensorflow as tf
+
+
+def test_tf_function_cvnn_layer_1_mode_1_layers():
+    d = 1
+    cutoff = 3
+
+    weights = tf.Variable(
+        [[0.20961794, -0.00454663, 0.17257116, -0.00007423, -0.12339027, -0.01005965]]
+    )
+
+    @tf.function
+    def func(weights):
+        simulator = pq.PureFockSimulator(
+            d=d,
+            config=pq.Config(cutoff=cutoff, normalize=False),
+            calculator=pq.TensorflowCalculator(),
+        )
+
+        with tf.GradientTape() as tape:
+            program = pq.cvqnn.create_program(weights)
+
+            state = simulator.execute(program).state
+            mean_position = state.mean_position(0)
+
+        return mean_position, tape.gradient(mean_position, weights)
+
+    mean_position, mean_position_grad = func(weights)
+
+    assert np.allclose(
+        mean_position,
+        -0.00014718642085721634,
+    )
+    assert np.allclose(
+        mean_position_grad,
+        [[0.0, 0.00001151, -0.00000038, 1.9829729, -0.00001934, -0.00001949]],
+    )
+
+
+def test_tf_function_cvnn_layer_2_modes_2_layers():
+    d = 2
+    cutoff = 3
+
+    weights = tf.Variable(
+        [
+            [
+                -0.01496882,
+                -0.00769323,
+                -0.23639019,
+                0.00605814,
+                -0.00198169,
+                -0.00070044,
+                -0.09768252,
+                0.10580704,
+                0.01289619,
+                0.00523546,
+                -0.1072419,
+                -0.06125172,
+                -0.00887781,
+                -0.02219815,
+            ],
+            [
+                -0.15894917,
+                0.15323096,
+                0.02459804,
+                0.00319082,
+                -0.0013642,
+                0.06503896,
+                -0.04608497,
+                -0.04319411,
+                -0.00326043,
+                0.00621172,
+                0.06301634,
+                0.07470028,
+                0.01229031,
+                0.00481799,
+            ],
+        ]
+    )
+
+    @tf.function
+    def func(weights):
+        simulator = pq.PureFockSimulator(
+            d=d,
+            config=pq.Config(cutoff=cutoff, normalize=False),
+            calculator=pq.TensorflowCalculator(),
+        )
+
+        with tf.GradientTape() as tape:
+            program = pq.cvqnn.create_program(weights)
+
+            state = simulator.execute(program).state
+            mean_position = state.mean_position(0)
+
+        return mean_position, tape.gradient(mean_position, weights)
+
+    mean_position, mean_position_grad = func(weights)
+
+    assert np.allclose(
+        mean_position,
+        0.019824614605943112,
+    )
+    assert np.allclose(
+        mean_position_grad,
+        [
+            [
+                0.0,
+                0.0,
+                0.0,
+                -0.00177408,
+                0.00011175,
+                0.00000129,
+                0.00000001,
+                -0.00009018,
+                1.96946914,
+                0.17731823,
+                0.00313927,
+                0.00034899,
+                0.00305477,
+                0.00035107,
+            ],
+            [
+                -0.00771081,
+                -0.00041313,
+                0.00346222,
+                -0.02683549,
+                0.00044953,
+                -0.00797526,
+                0.00006062,
+                0.00336663,
+                1.99442205,
+                -0.00004225,
+                0.00047722,
+                -0.00000408,
+                0.00381727,
+                -0.00000682,
+            ],
+        ],
+    )
+
+
+def test_tf_function_cvnn_layer_1_mode_1_layers_decorate_with_tf_function():
+    d = 1
+    cutoff = 3
+
+    weights = tf.Variable(
+        [[0.20961794, -0.00454663, 0.17257116, -0.00007423, -0.12339027, -0.01005965]]
+    )
+
+    @tf.function
+    def func(weights):
+        simulator = pq.PureFockSimulator(
+            d=d,
+            config=pq.Config(cutoff=cutoff, normalize=False),
+            calculator=pq.TensorflowCalculator(decorate_with=tf.function),
+        )
+
+        with tf.GradientTape() as tape:
+            program = pq.cvqnn.create_program(weights)
+
+            state = simulator.execute(program).state
+            mean_position = state.mean_position(0)
+
+        return mean_position, tape.gradient(mean_position, weights)
+
+    mean_position, mean_position_grad = func(weights)
+
+    assert np.allclose(
+        mean_position,
+        -0.00014718642085721634,
+    )
+    assert np.allclose(
+        mean_position_grad,
+        [[0.0, 0.00001151, -0.00000038, 1.9829729, -0.00001934, -0.00001949]],
+    )
+
+
+def test_tf_function_cvnn_layer_2_modes_2_layers_decorate_with_tf_function():
+    d = 2
+    cutoff = 3
+
+    weights = tf.Variable(
+        [
+            [
+                -0.01496882,
+                -0.00769323,
+                -0.23639019,
+                0.00605814,
+                -0.00198169,
+                -0.00070044,
+                -0.09768252,
+                0.10580704,
+                0.01289619,
+                0.00523546,
+                -0.1072419,
+                -0.06125172,
+                -0.00887781,
+                -0.02219815,
+            ],
+            [
+                -0.15894917,
+                0.15323096,
+                0.02459804,
+                0.00319082,
+                -0.0013642,
+                0.06503896,
+                -0.04608497,
+                -0.04319411,
+                -0.00326043,
+                0.00621172,
+                0.06301634,
+                0.07470028,
+                0.01229031,
+                0.00481799,
+            ],
+        ]
+    )
+
+    @tf.function
+    def func(weights):
+        simulator = pq.PureFockSimulator(
+            d=d,
+            config=pq.Config(cutoff=cutoff, normalize=False),
+            calculator=pq.TensorflowCalculator(decorate_with=tf.function),
+        )
+
+        with tf.GradientTape() as tape:
+            program = pq.cvqnn.create_program(weights)
+
+            state = simulator.execute(program).state
+            mean_position = state.mean_position(0)
+
+        return mean_position, tape.gradient(mean_position, weights)
+
+    mean_position, mean_position_grad = func(weights)
+
+    assert np.allclose(
+        mean_position,
+        0.019824614605943112,
+    )
+    assert np.allclose(
+        mean_position_grad,
+        [
+            [
+                0.0,
+                0.0,
+                0.0,
+                -0.00177408,
+                0.00011175,
+                0.00000129,
+                0.00000001,
+                -0.00009018,
+                1.96946914,
+                0.17731823,
+                0.00313927,
+                0.00034899,
+                0.00305477,
+                0.00035107,
+            ],
+            [
+                -0.00771081,
+                -0.00041313,
+                0.00346222,
+                -0.02683549,
+                0.00044953,
+                -0.00797526,
+                0.00006062,
+                0.00336663,
+                1.99442205,
+                -0.00004225,
+                0.00047722,
+                -0.00000408,
+                0.00381727,
+                -0.00000682,
+            ],
+        ],
+    )
+
+
+def test_tf_function_cvnn_layer_1_mode_1_layers_jit_compile():
+    d = 1
+    cutoff = 3
+
+    weights = tf.Variable(
+        [[0.20961794, -0.00454663, 0.17257116, -0.00007423, -0.12339027, -0.01005965]]
+    )
+
+    @tf.function(jit_compile=True)
+    def func(weights):
+        simulator = pq.PureFockSimulator(
+            d=d,
+            config=pq.Config(cutoff=cutoff, normalize=False),
+            calculator=pq.TensorflowCalculator(
+                decorate_with=tf.function(jit_compile=True)
+            ),
+        )
+
+        with tf.GradientTape() as tape:
+            program = pq.cvqnn.create_program(weights)
+
+            state = simulator.execute(program).state
+            mean_position = state.mean_position(0)
+
+        return mean_position, tape.gradient(mean_position, weights)
+
+    mean_position, mean_position_grad = func(weights)
+
+    assert np.allclose(
+        mean_position,
+        -0.00014718642085721634,
+    )
+    assert np.allclose(
+        mean_position_grad,
+        [[0.0, 0.00001151, -0.00000038, 1.9829729, -0.00001934, -0.00001949]],
+    )
+
+
+def test_tf_function_cvnn_layer_2_modes_2_layers_jit_compile():
+    d = 2
+    cutoff = 3
+
+    weights = tf.Variable(
+        [
+            [
+                -0.01496882,
+                -0.00769323,
+                -0.23639019,
+                0.00605814,
+                -0.00198169,
+                -0.00070044,
+                -0.09768252,
+                0.10580704,
+                0.01289619,
+                0.00523546,
+                -0.1072419,
+                -0.06125172,
+                -0.00887781,
+                -0.02219815,
+            ],
+            [
+                -0.15894917,
+                0.15323096,
+                0.02459804,
+                0.00319082,
+                -0.0013642,
+                0.06503896,
+                -0.04608497,
+                -0.04319411,
+                -0.00326043,
+                0.00621172,
+                0.06301634,
+                0.07470028,
+                0.01229031,
+                0.00481799,
+            ],
+        ]
+    )
+
+    @tf.function(jit_compile=True)
+    def func(weights):
+        simulator = pq.PureFockSimulator(
+            d=d,
+            config=pq.Config(cutoff=cutoff, normalize=False),
+            calculator=pq.TensorflowCalculator(
+                decorate_with=tf.function(jit_compile=True)
+            ),
+        )
+
+        with tf.GradientTape() as tape:
+            program = pq.cvqnn.create_program(weights)
+
+            state = simulator.execute(program).state
+            mean_position = state.mean_position(0)
+
+        return mean_position, tape.gradient(mean_position, weights)
+
+    mean_position, mean_position_grad = func(weights)
+
+    assert np.allclose(
+        mean_position,
+        0.019824614605943112,
+    )
+    assert np.allclose(
+        mean_position_grad,
+        [
+            [
+                0.0,
+                0.0,
+                0.0,
+                -0.00177408,
+                0.00011175,
+                0.00000129,
+                0.00000001,
+                -0.00009018,
+                1.96946914,
+                0.17731823,
+                0.00313927,
+                0.00034899,
+                0.00305477,
+                0.00035107,
+            ],
+            [
+                -0.00771081,
+                -0.00041313,
+                0.00346222,
+                -0.02683549,
+                0.00044953,
+                -0.00797526,
+                0.00006062,
+                0.00336663,
+                1.99442205,
+                -0.00004225,
+                0.00047722,
+                -0.00000408,
+                0.00381727,
+                -0.00000682,
+            ],
+        ],
+    )


### PR DESCRIPTION
`tf.function` requires Piquasso to use Tensorflow's NumPy API in the forward
pass. By default, we use regular NumPy for performance reasons, but this patch
enables users to run Piquasso inside `tf.function`, which might be faster with
JIT compilation enabled. JIT compilation takes some time though, but the
compiled function is an order of magnitude faster than the original function
decorated with `tf.function` only.

In order to enable Piquasso to use `tf.function` the possibility of avoiding
the custom gradient calculations had to be implemented, which is implemented
through `calculator._custom_gradient_enabled`. In the calculations where the
gradient has been replaced by a custom one, a different numpy
(`calculator.forward_pass_np`) needs to be used, and its value depends on
`_custom_gradient_enabled`.

Moreover, some functions might be slow for vague reasons, e.g., it is better to
avoid `tf.transpose` and `tf.gather(..., axis=1)`. These functions are avoided
where possible. Also, some functions work a bit differently, e.g.,
`tf.math.pow` handles `0^0` differently than `np.pow`, which is encountered in
`gate_matrices.py`.

Furthermore, the compilation time is in correlation with the graph size
compiled with Autograph. In order to limit the size of the compiled graph,
several things are implemented:

1. `decorate_with`

Decorating some functions in the simulation with `tf.function` during the
simulation makes the graph smaller, since consequent calls to this function
won't induce retracing. Therefore the possibility to decorate some of these
functions got enabled with the `decorate_with` constructor parameter of
`TensorflowCalculator`. In it, one can pass the `tf.function` decorator to
decorate the functions with, and one may also pass other parameter (like
`jit_compile`, `reduce_retracing`).

Moreover, a custom `_TrivialTraceType` had to be implemented for
`TensorflowCalculator` to make AutoGraph avoid retracing.

Moreover, the `_custom_gradient_enabled` is switched off when a decorator is
provided.

2. `TensorArray`

`tf.function` does not handle Python for loops well, because each iteration in
the for loop is handled independently in Autograph. Therefore, one needs to
avoid using for loops as much as possible, and use vectorized computations. If
not possible, one can use `TensorArray` instead, which has been implemented in
`TensorflowCalculator.accumulator` and in `gate_matrices.py`.

Technically, it could be implemented in other places as well, but it is a bit
more challenging, and (hopefully) using `decorate_with` limits the graph size
well enough.