### PR TITLE
feat(JaxCalculator): Supporting JAX in `PureFockSimulator`

### DIFF
--- a/piquasso/__init__.py
+++ b/piquasso/__init__.py
@@ -44,7 +44,11 @@ from piquasso._backends.fock import (
     FockSimulator,
     PureFockSimulator,
 )
-from piquasso._backends.calculator import NumpyCalculator, TensorflowCalculator
+from piquasso._backends.calculator import (
+    NumpyCalculator,
+    TensorflowCalculator,
+    JaxCalculator,
+)
 
 from .instructions.preparations import (
     Vacuum,
@@ -120,6 +124,7 @@ __all__ = [
     # Calculators
     "NumpyCalculator",
     "TensorflowCalculator",
+    "JaxCalculator",
     # States
     "GaussianState",
     "SamplingState",

--- a/piquasso/_backends/fock/pure/simulator.py
+++ b/piquasso/_backends/fock/pure/simulator.py
@@ -37,7 +37,11 @@ from ..calculations import attenuator
 from ...simulator import BuiltinSimulator
 from piquasso.instructions import preparations, gates, measurements, channels, batch
 
-from piquasso._backends.calculator import NumpyCalculator, TensorflowCalculator
+from piquasso._backends.calculator import (
+    NumpyCalculator,
+    TensorflowCalculator,
+    JaxCalculator,
+)
 
 
 class PureFockSimulator(BuiltinSimulator):
@@ -116,4 +120,4 @@ class PureFockSimulator(BuiltinSimulator):
 
     _default_calculator_class = NumpyCalculator
 
-    _extra_builtin_calculators = [TensorflowCalculator]
+    _extra_builtin_calculators = [TensorflowCalculator, JaxCalculator]

--- a/scripts/jax_cvnn_benchmark.py
+++ b/scripts/jax_cvnn_benchmark.py
@@ -1,0 +1,102 @@
+#
+# Copyright 2021-2024 Budapest Quantum Computing Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import time
+
+import jax
+
+import piquasso as pq
+
+from functools import partial
+
+from scipy.special import comb
+
+import numpy as np
+
+from jax import grad, jit
+
+
+@partial(jit, static_argnums=2)
+def _calculate_loss(target_state_vector, weights, cutoff):
+    d = pq.cvqnn.get_number_of_modes(weights.shape[1])
+
+    simulator = pq.PureFockSimulator(
+        d=d,
+        config=pq.Config(cutoff=cutoff, normalize=False, dtype=np.float32),
+        calculator=pq.JaxCalculator(),
+    )
+
+    program = pq.cvqnn.create_program(weights)
+
+    state_vector = simulator.execute(program).state.state_vector
+
+    return jax.numpy.sum(jax.numpy.abs(state_vector - target_state_vector))
+
+
+if __name__ == "__main__":
+    cutoff = 10
+    layer_count = 3
+    d = 2
+
+    state_vector_size = comb(d + cutoff - 1, cutoff - 1, exact=True)
+
+    target_state_vector = np.random.rand(state_vector_size) + 1j * np.random.rand(
+        state_vector_size
+    )
+
+    target_state_vector /= np.abs(target_state_vector)
+
+    iterations = 100
+
+    _calculate_loss_grad = jit(grad(_calculate_loss), static_argnums=2)
+
+    weights = pq.cvqnn.generate_random_cvqnn_weights(layer_count, d)
+
+    start_time = time.time()
+    _calculate_loss(target_state_vector, weights, cutoff)
+    _calculate_loss_grad(target_state_vector, weights, cutoff)
+    print("COMPILATION TIME: ", time.time() - start_time)
+
+    runtimes = []
+
+    for i in range(iterations):
+        weights = pq.cvqnn.generate_random_cvqnn_weights(layer_count, d)
+
+        start_time = time.time()
+        loss = _calculate_loss(target_state_vector, weights, cutoff)
+        end_time = time.time()
+
+        runtime = end_time - start_time
+        runtimes.append(runtime)
+
+        print(f"{i}:\truntime = {runtime},\tloss = {loss}")
+
+    print(f"AVERAGE RUNTIME: {np.mean(runtimes)} (+/- {np.std(runtimes)})")
+
+    runtimes = []
+
+    for i in range(iterations):
+        weights = pq.cvqnn.generate_random_cvqnn_weights(layer_count, d)
+
+        start_time = time.time()
+        _calculate_loss_grad(target_state_vector, weights, cutoff)
+        end_time = time.time()
+
+        runtime = end_time - start_time
+        runtimes.append(runtime)
+
+        print(f"{i}:\truntime = {runtime}")
+
+    print(f"AVERAGE RUNTIME: {np.mean(runtimes)} (+/- {np.std(runtimes)})")

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
     ],
     extras_require={
         "tensorflow": "tensorflow",
+        "jax": "jax[cpu]",
     },
     classifiers=[
         "Intended Audience :: Developers",

--- a/tests/backends/fock/pure/test_state.py
+++ b/tests/backends/fock/pure/test_state.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
+
 import numpy as np
 
 import piquasso as pq
@@ -172,7 +174,8 @@ def test_normalize_if_disabled_in_Config():
     assert not np.isclose(norm, 1.0)
 
 
-def test_PureFockState_get_tensor_representation():
+@pytest.mark.parametrize("calculator", (pq.NumpyCalculator(), pq.JaxCalculator()))
+def test_PureFockState_get_tensor_representation(calculator):
     d = 2
     cutoff = 3
 
@@ -182,7 +185,9 @@ def test_PureFockState_get_tensor_representation():
         pq.Q() | pq.StateVector([0, 2]) / 2
         pq.Q() | pq.StateVector([2, 0]) / np.sqrt(2)
 
-    simulator = pq.PureFockSimulator(d=d, config=pq.Config(cutoff=cutoff))
+    simulator = pq.PureFockSimulator(
+        d=d, config=pq.Config(cutoff=cutoff), calculator=calculator
+    )
     state = simulator.execute(program).state
 
     state_tensor = state.get_tensor_representation()

--- a/tests/backends/fock/test_gates.py
+++ b/tests/backends/fock/test_gates.py
@@ -33,12 +33,20 @@ tf_purefock_simulators = (
     ),
 )
 
+jax_purefock_simulator = [
+    partial(
+        pq.PureFockSimulator,
+        calculator=pq.JaxCalculator(),
+    ),
+]
+
 
 @pytest.mark.parametrize(
     "SimulatorClass",
     (
         pq.PureFockSimulator,
         *tf_purefock_simulators,
+        *jax_purefock_simulator,
         pq.FockSimulator,
     ),
 )
@@ -67,6 +75,7 @@ def test_squeezing_probabilities(SimulatorClass):
     (
         pq.PureFockSimulator,
         *tf_purefock_simulators,
+        *jax_purefock_simulator,
         pq.FockSimulator,
     ),
 )

--- a/tests/backends/fock/test_jax_calculator.py
+++ b/tests/backends/fock/test_jax_calculator.py
@@ -1,0 +1,85 @@
+#
+# Copyright 2021-2024 Budapest Quantum Computing Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+import builtins
+
+import pytest
+
+
+@pytest.fixture
+def raise_ImportError_when_importing_jax():
+    real_import = builtins.__import__
+
+    def fake_import(name, globals, locals, fromlist, level):
+        if name == "jax":
+            raise ImportError()
+
+        return real_import(name, globals, locals, fromlist, level)
+
+    builtins.__import__ = fake_import
+
+    yield
+
+    builtins.__import__ = real_import
+
+
+@pytest.fixture
+def unimport_jax():
+    """
+    Deletes `jax` from `sys.modules`.
+    """
+
+    if "jax" in sys.modules:
+        del sys.modules["jax"]
+
+
+def test_jaxCalculator_imports_jax_if_installed():
+    import piquasso as pq
+
+    pq.JaxCalculator()
+
+    assert "jax" in sys.modules
+
+
+def test_jaxCalculator_raises_ImportError_if_jax_not_installed(
+    raise_ImportError_when_importing_jax,
+):
+    import piquasso as pq
+
+    with pytest.raises(ImportError) as error:
+        pq.JaxCalculator()
+
+    assert error.value.args[0] == (
+        "You have invoked a feature which requires 'jax'.\n"
+        "You can install JAX via:\n"
+        "\n"
+        "pip install piquasso[jax]"
+    )
+
+
+def test_importing_Piquasso_does_not_import_jax(unimport_jax):
+    import piquasso as pq  # noqa: F401
+
+    assert "jax" not in sys.modules
+
+
+def test_Piquasso_works_without_jax(
+    unimport_jax,
+    raise_ImportError_when_importing_jax,
+):
+    import piquasso as pq  # noqa: F401
+
+    assert "jax" not in sys.modules

--- a/tests/backends/test_backend_equivalence.py
+++ b/tests/backends/test_backend_equivalence.py
@@ -25,7 +25,7 @@ from functools import partial
 from scipy.linalg import polar, sinhm, coshm, expm
 
 
-def is_proportional(first, second):
+def is_proportional(first, second, rtol=1e-5):
     first = np.array(first)
     second = np.array(second)
 
@@ -33,7 +33,7 @@ def is_proportional(first, second):
 
     proportion = first[index] / second[index]
 
-    return np.allclose(first, proportion * second)
+    return np.allclose(first, proportion * second, rtol=rtol)
 
 
 tf_purefock_simulators = (
@@ -46,6 +46,13 @@ tf_purefock_simulators = (
         calculator=pq.TensorflowCalculator(decorate_with=tf.function),
     ),
 )
+
+jax_purefock_simulator = [
+    partial(
+        pq.PureFockSimulator,
+        calculator=pq.JaxCalculator(),
+    ),
+]
 
 
 @pytest.mark.parametrize(
@@ -78,6 +85,7 @@ def test_fock_probabilities_should_be_numpy_array_of_floats(SimulatorClass):
         pq.GaussianSimulator,
         pq.PureFockSimulator,
         *tf_purefock_simulators,
+        *jax_purefock_simulator,
         pq.FockSimulator,
     ),
 )
@@ -156,6 +164,7 @@ def test_density_matrix_with_squeezed_state():
         pq.GaussianSimulator,
         pq.PureFockSimulator,
         *tf_purefock_simulators,
+        *jax_purefock_simulator,
         pq.FockSimulator,
     ),
 )
@@ -206,6 +215,7 @@ def test_fock_probabilities_with_displaced_state(SimulatorClass):
         pq.PureFockSimulator,
         pq.FockSimulator,
         *tf_purefock_simulators,
+        *jax_purefock_simulator,
         pq.GaussianSimulator,
     ),
 )
@@ -245,6 +255,7 @@ def test_Displacement_equivalence_on_multiple_modes(SimulatorClass):
         pq.GaussianSimulator,
         pq.PureFockSimulator,
         *tf_purefock_simulators,
+        *jax_purefock_simulator,
         pq.FockSimulator,
     ),
 )
@@ -296,6 +307,7 @@ def test_fock_probabilities_with_displaced_state_with_beamsplitter(SimulatorClas
         pq.GaussianSimulator,
         pq.PureFockSimulator,
         *tf_purefock_simulators,
+        *jax_purefock_simulator,
         pq.FockSimulator,
     ),
 )
@@ -347,6 +359,7 @@ def test_fock_probabilities_with_squeezed_state_with_beamsplitter(SimulatorClass
         pq.GaussianSimulator,
         pq.PureFockSimulator,
         *tf_purefock_simulators,
+        *jax_purefock_simulator,
         pq.FockSimulator,
     ),
 )
@@ -377,6 +390,7 @@ def test_fock_probabilities_with_two_single_mode_squeezings(SimulatorClass):
         pq.GaussianSimulator,
         pq.PureFockSimulator,
         *tf_purefock_simulators,
+        *jax_purefock_simulator,
         pq.FockSimulator,
     ),
 )
@@ -405,6 +419,7 @@ def test_Squeezing_equivalence_on_multiple_modes(SimulatorClass):
         pq.GaussianSimulator,
         pq.PureFockSimulator,
         *tf_purefock_simulators,
+        *jax_purefock_simulator,
         pq.FockSimulator,
     ),
 )
@@ -460,6 +475,7 @@ def test_fock_probabilities_with_two_mode_squeezing(SimulatorClass):
         pq.GaussianSimulator,
         pq.PureFockSimulator,
         *tf_purefock_simulators,
+        *jax_purefock_simulator,
         pq.FockSimulator,
     ),
 )
@@ -511,6 +527,7 @@ def test_fock_probabilities_with_two_mode_squeezing_and_beamsplitter(SimulatorCl
         pq.GaussianSimulator,
         pq.PureFockSimulator,
         *tf_purefock_simulators,
+        *jax_purefock_simulator,
         pq.FockSimulator,
     ),
 )
@@ -559,6 +576,7 @@ def test_fock_probabilities_with_quadratic_phase(SimulatorClass):
         pq.GaussianSimulator,
         pq.PureFockSimulator,
         *tf_purefock_simulators,
+        *jax_purefock_simulator,
         pq.FockSimulator,
     ),
 )
@@ -607,6 +625,7 @@ def test_fock_probabilities_with_position_displacement(SimulatorClass):
         pq.GaussianSimulator,
         pq.PureFockSimulator,
         *tf_purefock_simulators,
+        *jax_purefock_simulator,
         pq.FockSimulator,
     ),
 )
@@ -655,6 +674,7 @@ def test_fock_probabilities_with_momentum_displacement(SimulatorClass):
         pq.GaussianSimulator,
         pq.PureFockSimulator,
         *tf_purefock_simulators,
+        *jax_purefock_simulator,
         pq.FockSimulator,
     ),
 )
@@ -684,6 +704,7 @@ def test_fock_probabilities_with_position_displacement_is_HBAR_independent(
         pq.GaussianSimulator,
         pq.PureFockSimulator,
         *tf_purefock_simulators,
+        *jax_purefock_simulator,
         pq.FockSimulator,
     ),
 )
@@ -713,6 +734,7 @@ def test_fock_probabilities_with_momentum_displacement_is_HBAR_independent(
         pq.GaussianSimulator,
         pq.PureFockSimulator,
         *tf_purefock_simulators,
+        *jax_purefock_simulator,
         pq.FockSimulator,
     ),
 )
@@ -773,7 +795,7 @@ def test_fock_probabilities_with_general_gaussian_transform(SimulatorClass):
     assert all(probability >= 0 for probability in probabilities)
     assert sum(probabilities) <= 1.0 or np.isclose(sum(probabilities), 1.0)
 
-    assert is_proportional(probabilities, expected_probabilities)
+    assert is_proportional(probabilities, expected_probabilities, rtol=1e-4)
 
 
 @pytest.mark.monkey

--- a/tests/slow/test_jax_jit_compilation.py
+++ b/tests/slow/test_jax_jit_compilation.py
@@ -1,0 +1,85 @@
+#
+# Copyright 2021-2024 Budapest Quantum Computing Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import piquasso as pq
+
+from jax import jit, jacfwd
+
+
+def test_jit_compilation():
+    def func(r, theta, xi):
+        simulator = pq.PureFockSimulator(
+            d=2,
+            config=pq.Config(cutoff=5, dtype=np.float32, normalize=False),
+            calculator=pq.JaxCalculator(),
+        )
+
+        with pq.Program() as program:
+            pq.Q() | pq.Vacuum()
+
+            pq.Q(0) | pq.Displacement(r=r)
+
+            pq.Q(0, 1) | pq.Beamsplitter(theta=theta)
+
+            pq.Q(0) | pq.Kerr(xi=xi)
+
+        return simulator.execute(program).state.fock_probabilities
+
+    r = 0.1
+    theta = np.pi / 5
+    xi = 0.01
+
+    compiled_func = jit(func)
+
+    result = func(r, theta, xi)
+    compiled_result = compiled_func(r, theta, xi)
+
+    assert np.allclose(result, compiled_result)
+
+
+def test_jit_and_jacfwd_compilation():
+    def func(r, theta, xi):
+        simulator = pq.PureFockSimulator(
+            d=2,
+            config=pq.Config(cutoff=5, dtype=np.float32, normalize=False),
+            calculator=pq.JaxCalculator(),
+        )
+
+        with pq.Program() as program:
+            pq.Q() | pq.Vacuum()
+
+            pq.Q(0) | pq.Displacement(r=r)
+
+            pq.Q(0, 1) | pq.Beamsplitter(theta=theta)
+
+            pq.Q(0) | pq.Kerr(xi=xi)
+
+        return simulator.execute(program).state.fock_probabilities
+
+    r = 0.1
+    theta = np.pi / 5
+    xi = 0.01
+
+    jacobian = jacfwd(func, argnums=(0, 1, 2))
+
+    compiled_jacobian = jit(jacobian)
+
+    result = jacobian(r, theta, xi)
+    compiled_result = compiled_jacobian(r, theta, xi)
+
+    assert np.allclose(result[0], compiled_result[0])
+    assert np.allclose(result[1], compiled_result[1])
+    assert np.allclose(result[2], compiled_result[2])

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ python =
     3.11: py311
 
 [testenv]
-extras = tensorflow
+extras = tensorflow,jax
 deps = -rrequirements.txt
 commands =
     flake8


### PR DESCRIPTION
Because JAX has a NumPy API, supporting JAX is not that difficult, and it has been done in this patch.

Unfortunately, the JIT compilation is still very slow, and we may need to reduce the number of Python control flows during the calculation in the future.