### PR TITLE
fix(tensorflow): Executing with initial state

### DIFF
--- a/piquasso/_backends/fock/pure/state.py
+++ b/piquasso/_backends/fock/pure/state.py
@@ -296,3 +296,14 @@ class PureFockState(BaseFockState):
             self.state_vector,
             [cutoff] * d,
         )
+
+    def copy(self) -> "PureFockState":
+        # NOTE: `__deepcopy__` is not allowed for tensorflow variables, so we have to
+        # do it explicitely here.
+        state = self.__class__(
+            d=self.d, calculator=self._calculator, config=self._config.copy()
+        )
+
+        state.state_vector = self._calculator.np.copy(self.state_vector)
+
+        return state


### PR DESCRIPTION
**Problem**

When an initial state is specified for `Simulator.execute` and `tf.function` is used, Piquasso throws an error, because the specified initial state is deep-copied, and TensorFlow variables cannot be copied like this.

**Solution**

A `PureFockState.copy` method has been written, which copies explicitely the state vector using the NumPy API of TensorFlow.