### PR TITLE
FIX(gaussian): Random number generation from RNG

### DIFF
--- a/piquasso/_backends/gaussian/calculations.py
+++ b/piquasso/_backends/gaussian/calculations.py
@@ -440,7 +440,7 @@ def _get_particle_number_choice(
 
     weights /= np.sum(weights)
 
-    return np.random.choice(possible_choices, p=weights)
+    return state._config.rng.choice(possible_choices, p=weights)
 
 
 def threshold_measurement(

--- a/tests/backends/gaussian/test_measurements.py
+++ b/tests/backends/gaussian/test_measurements.py
@@ -288,3 +288,36 @@ def test_measure_threshold_on_all_modes(nondisplaced_state):
     result = simulator.execute(program, initial_state=nondisplaced_state)
 
     assert result
+
+
+@pytest.mark.monkey
+def test_seeded_gaussian_boson_sampling():
+    d = 5
+    shots = 10
+
+    A = np.array(
+        [
+            [0, 1, 0, 1, 1],
+            [1, 0, 0, 0, 1],
+            [0, 0, 0, 1, 0],
+            [1, 0, 1, 0, 1],
+            [1, 1, 0, 1, 0],
+        ]
+    )
+
+    with pq.Program() as gaussian_boson_sampling:
+        pq.Q(all) | pq.Graph(A)
+
+        pq.Q(all) | pq.ParticleNumberMeasurement()
+
+    simulator1 = pq.GaussianSimulator(
+        d=d, calculator=pq.NumpyCalculator(), config=pq.Config(seed_sequence=123)
+    )
+    result1 = simulator1.execute(gaussian_boson_sampling, shots=shots)
+
+    simulator2 = pq.GaussianSimulator(
+        d=d, calculator=pq.NumpyCalculator(), config=pq.Config(seed_sequence=123)
+    )
+    result2 = simulator2.execute(gaussian_boson_sampling, shots=shots)
+
+    assert result1.samples == result2.samples


### PR DESCRIPTION
`_get_particle_number_choice` did not generate samples from the NumPy RNG, so if the user does not seed NumPy, the samples will not be reproducible. To fix this, choices in `_get_particle_number_choice` needs to be generated from the RNG from the config.