### PR TITLE
fix(simulator): Minor error message fix

### DIFF
--- a/piquasso/api/simulator.py
+++ b/piquasso/api/simulator.py
@@ -118,12 +118,12 @@ class Simulator(Computer, _mixins.CodeMixin):
                     return instruction_category
 
             raise InvalidInstruction(
-                "\n"
-                "The instruction is not a subclass of the following classes:\n"
-                "{all_instruction_classes}.\n"
-                "Make sure that all your instructions are subclassed properly from the "
-                "above classes.\n"
-                "instruction={instruction}."
+                f"\n"
+                f"The instruction is not a subclass of the following classes:\n"
+                f"{all_instruction_categories}.\n"
+                f"Make sure that all your instructions are subclassed properly from "
+                f"the above classes.\n"
+                f"instruction={instruction}."
             )
 
         instruction_category_projection = list(

--- a/tests/api/test_simulator.py
+++ b/tests/api/test_simulator.py
@@ -98,11 +98,21 @@ def test_program_execution_with_unregistered_instruction_raises_InvalidSimulatio
 
     simulator = FakeSimulator(d=1)
 
-    with pytest.raises(pq.api.exceptions.InvalidSimulation):
+    with pytest.raises(pq.api.exceptions.InvalidSimulation) as error:
         simulator.validate(program)
 
-    with pytest.raises(pq.api.exceptions.InvalidSimulation):
+    error_message = error.value.args[0]
+
+    assert "No such instruction implemented for this simulator." in error_message
+    assert "instruction=<pq.ImproperInstruction(modes=())>" in error_message
+
+    with pytest.raises(pq.api.exceptions.InvalidSimulation) as error:
         simulator.execute(program)
+
+    error_message = error.value.args[0]
+
+    assert "No such instruction implemented for this simulator." in error_message
+    assert "instruction=<pq.ImproperInstruction(modes=())>" in error_message
 
 
 def test_program_execution_with_wrong_instruction_order_raises_InvalidSimulation(


### PR DESCRIPTION
The error message was not properly formatted when invalid instruction is specified.