### PR TITLE
feat(fock): Making `PostSelectPhotons` differentiable

### DIFF
--- a/piquasso/_backends/fock/pure/calculations/__init__.py
+++ b/piquasso/_backends/fock/pure/calculations/__init__.py
@@ -72,6 +72,7 @@ def particle_number_measurement(
         subspace_basis=sample,
         modes=instruction.modes,
         normalization=normalization,
+        calculator=state._calculator,
     )
 
     return Result(state=state, samples=samples)

--- a/piquasso/_backends/fock/pure/calculations/misc.py
+++ b/piquasso/_backends/fock/pure/calculations/misc.py
@@ -29,6 +29,7 @@ def post_select_photons(
         subspace_basis=instruction.params["photon_counts"],
         modes=instruction.params["postselect_modes"],
         normalization=1.0,
+        calculator=state._calculator,
     )
 
     return Result(state=state)

--- a/piquasso/_backends/fock/pure/calculations/utils.py
+++ b/piquasso/_backends/fock/pure/calculations/utils.py
@@ -21,25 +21,30 @@ from ...calculations import get_projection_operator_indices
 
 from ..state import PureFockState
 
+from piquasso.api.calculator import BaseCalculator
+
 
 def project_to_subspace(
     state: PureFockState,
     *,
     subspace_basis: Tuple[int, ...],
     modes: Tuple[int, ...],
-    normalization: float
+    normalization: float,
+    calculator: BaseCalculator
 ) -> None:
     projected_state_vector = _get_projected_state_vector(
-        state=state,
-        subspace_basis=subspace_basis,
-        modes=modes,
+        state=state, subspace_basis=subspace_basis, modes=modes, calculator=calculator
     )
 
     state.state_vector = projected_state_vector * normalization
 
 
 def _get_projected_state_vector(
-    state: PureFockState, *, subspace_basis: Tuple[int, ...], modes: Tuple[int, ...]
+    state: PureFockState,
+    *,
+    subspace_basis: Tuple[int, ...],
+    modes: Tuple[int, ...],
+    calculator: BaseCalculator
 ) -> np.ndarray:
     new_state_vector = state._get_empty()
 
@@ -50,6 +55,8 @@ def _get_projected_state_vector(
         subspace_basis,
     )
 
-    new_state_vector[index] = state.state_vector[index]
+    new_state_vector = calculator.assign(
+        new_state_vector, index, state.state_vector[index]
+    )
 
     return new_state_vector

--- a/tests/backends/tensorflow/test_gates.py
+++ b/tests/backends/tensorflow/test_gates.py
@@ -16,6 +16,7 @@
 import piquasso as pq
 import pytest
 import tensorflow as tf
+import numpy as np
 
 
 @pytest.mark.monkey
@@ -35,3 +36,73 @@ def test_Interferometer_numpy_array_as_parameter(generate_unitary_matrix):
         pq.Q(all) | pq.Interferometer(interferometer)
 
     simulator.execute(program)
+
+
+def test_PostSelectPhotons_gradient():
+    def _calculate_loss(weights, calculator, state_vector):
+        np = calculator.np
+
+        with pq.Program() as preparation:
+            pq.Q(all) | pq.StateVector([0, 1, 0]) * state_vector[0]
+            pq.Q(all) | pq.StateVector([1, 1, 0]) * state_vector[1]
+            pq.Q(all) | pq.StateVector([2, 1, 0]) * state_vector[2]
+
+        phase_shifter_phis = weights[:3]
+        thetas = weights[3:6]
+        phis = weights[6:]
+        with pq.Program() as interferometer:
+            for i in range(3):
+                pq.Q(i) | pq.Phaseshifter(phase_shifter_phis[i])
+
+            pq.Q(1, 2) | pq.Beamsplitter(theta=thetas[0], phi=phis[0])
+            pq.Q(0, 1) | pq.Beamsplitter(theta=thetas[1], phi=phis[1])
+            pq.Q(1, 2) | pq.Beamsplitter(theta=thetas[2], phi=phis[2])
+
+        with pq.Program() as program:
+            pq.Q(all) | preparation
+
+            pq.Q(all) | interferometer
+
+            pq.Q(all) | pq.PostSelectPhotons(
+                postselect_modes=(1, 2), photon_counts=(1, 0)
+            )
+
+        simulator = pq.PureFockSimulator(
+            d=3, config=pq.Config(cutoff=4), calculator=calculator
+        )
+
+        state = simulator.execute(program).state
+
+        state.normalize()
+
+        reduced_state = state.reduced((0,))
+
+        density_matrix = reduced_state.density_matrix[:3, :3]
+
+        expected_state = np.copy(state_vector)
+        expected_state = calculator.assign(expected_state, 2, -expected_state[2])
+
+        loss = 1 - np.sqrt(
+            np.real(np.conj(expected_state) @ density_matrix @ expected_state)
+        )
+
+        return loss
+
+    calculator = pq.TensorflowCalculator()
+
+    weights = tf.Variable(
+        [np.pi, 0.0, 0.0, np.pi / 8, 65.5302 * 2 * np.pi / 360, -np.pi / 8, 0, 0, 0]
+    )
+
+    with tf.GradientTape() as tape:
+        loss = _calculate_loss(
+            weights=weights,
+            calculator=calculator,
+            state_vector=np.sqrt([0.2, 0.3, 0.5]),
+        )
+
+    grad = tape.gradient(loss, weights)
+
+    assert np.isclose(loss, 0.0)
+
+    assert np.allclose(grad, 0.0, atol=1e-7)


### PR DESCRIPTION
The `PostSelectPhotons` instruction is made differentiable by using the NumPy API in `calculator`.