### PR TITLE
perf(fock): Faster `FockState.norm`

### DIFF
--- a/piquasso/_backends/fock/general/state.py
+++ b/piquasso/_backends/fock/general/state.py
@@ -200,6 +200,11 @@ class FockState(BaseFockState):
 
         return reduced_state
 
+    @property
+    def norm(self) -> float:
+        np = self._calculator.np
+        return np.real(np.trace(self._density_matrix))
+
     def normalize(self) -> None:
         """Normalizes the density matrix to have a trace of 1.
 

--- a/piquasso/_backends/fock/state.py
+++ b/piquasso/_backends/fock/state.py
@@ -38,7 +38,7 @@ class BaseFockState(State, abc.ABC):
         return self._d
 
     @property
-    def norm(self) -> int:
+    def norm(self) -> float:
         return self._calculator.np.sum(self.fock_probabilities)
 
     def _as_code(self) -> str:


### PR DESCRIPTION
A custom `norm` method has been written for `FockState`, which is faster with `TensorflowCalculator`, since it uses less tensorflow operations. Moreover, the typing in the signature of `norm` is fixed along the way.