### PR TITLE
feat(sampling): Partial JAX support

### DIFF
--- a/piquasso/_backends/calculator.py
+++ b/piquasso/_backends/calculator.py
@@ -487,6 +487,8 @@ class JaxCalculator(_BuiltinCalculator):
 
         config.update("jax_enable_x64", True)
 
+        from piquasso._math.jax.permanent import permanent_with_reduction
+
         self.np = jnp
         self._scipy = jax.scipy
         self.fallback_np = np
@@ -498,6 +500,7 @@ class JaxCalculator(_BuiltinCalculator):
         self.powm = jnp.linalg.matrix_power
         self.sqrtm = jax.scipy.linalg.sqrtm
         self.svd = jnp.linalg.svd
+        self.permanent = permanent_with_reduction
 
     def preprocess_input_for_custom_gradient(self, value):
         return value

--- a/piquasso/_backends/sampling/calculations.py
+++ b/piquasso/_backends/sampling/calculations.py
@@ -79,9 +79,13 @@ def passive_linear(
 def _apply_matrix_on_modes(
     state: SamplingState, matrix: np.ndarray, modes: Tuple[int, ...]
 ) -> None:
+    calculator = state._calculator
+    np = calculator.np
+    fallback_np = calculator.fallback_np
+
     embedded = np.identity(len(state.interferometer), dtype=state._config.complex_dtype)
 
-    embedded[np.ix_(modes, modes)] = matrix
+    embedded = calculator.assign(embedded, fallback_np.ix_(modes, modes), matrix)
 
     state.interferometer = embedded @ state.interferometer
 

--- a/piquasso/_backends/sampling/simulator.py
+++ b/piquasso/_backends/sampling/simulator.py
@@ -16,7 +16,7 @@
 from ..simulator import BuiltinSimulator
 from piquasso.instructions import preparations, gates, measurements, channels
 
-from piquasso._backends.calculator import NumpyCalculator
+from piquasso._backends.calculator import NumpyCalculator, JaxCalculator
 
 from .state import SamplingState
 from .calculations import (
@@ -89,3 +89,5 @@ class SamplingSimulator(BuiltinSimulator):
     _state_class = SamplingState
 
     _default_calculator_class = NumpyCalculator
+
+    _extra_builtin_calculators = [JaxCalculator]

--- a/piquasso/_backends/sampling/state.py
+++ b/piquasso/_backends/sampling/state.py
@@ -42,10 +42,8 @@ class SamplingState(State):
         """
         super().__init__(calculator=calculator, config=config)
 
-        self.initial_state: np.ndarray = np.zeros((d,), dtype=int)
-        self.interferometer: np.ndarray = np.diag(
-            np.ones(d, dtype=self._config.complex_dtype)
-        )
+        self.initial_state = np.zeros((d,), dtype=int)
+        self.interferometer = np.diag(np.ones(d, dtype=self._config.complex_dtype))
 
         self.is_lossy = False
 
@@ -96,6 +94,7 @@ class SamplingState(State):
 
     @property
     def state_vector(self):
+        np = self._calculator.np
         state_vector_on_smaller_subspaces = np.zeros(
             shape=cutoff_cardinality(d=self.d, cutoff=self.particle_number),
             dtype=self._config.dtype,

--- a/piquasso/_backends/sampling/utils.py
+++ b/piquasso/_backends/sampling/utils.py
@@ -37,8 +37,11 @@ def calculate_state_vector(interferometer, initial_state, config, calculator):
     detection.
     """
 
+    np = calculator.np
+    fallback_np = calculator.fallback_np
+
     possible_outputs = partitions(
-        particles=np.sum(initial_state),
+        particles=calculator.fallback_np.sum(initial_state),
         boxes=len(initial_state),
     )
 
@@ -49,11 +52,13 @@ def calculate_state_vector(interferometer, initial_state, config, calculator):
     for idx, output in enumerate(possible_outputs):
         permanent = calculator.permanent(interferometer, cols=input, rows=output)
 
-        state_vector_coefficient = permanent / np.sqrt(np.prod(factorial(output)))
+        state_vector_coefficient = permanent / fallback_np.sqrt(
+            fallback_np.prod(factorial(output))
+        )
 
-        state_vector[idx] = state_vector_coefficient
+        state_vector = calculator.assign(state_vector, idx, state_vector_coefficient)
 
-    state_vector /= np.sqrt(np.prod(factorial(input)))
+    state_vector /= fallback_np.sqrt(fallback_np.prod(factorial(input)))
 
     return state_vector
 
@@ -64,8 +69,11 @@ def calculate_distribution(interferometer, initial_state, config, calculator):
     detection.
     """
 
+    np = calculator.np
+    fallback_np = calculator.fallback_np
+
     possible_outputs = partitions(
-        particles=np.sum(initial_state),
+        particles=fallback_np.sum(initial_state),
         boxes=len(initial_state),
     )
 
@@ -78,11 +86,13 @@ def calculate_distribution(interferometer, initial_state, config, calculator):
             np.abs(calculator.permanent(interferometer, cols=input, rows=output)) ** 2
         )
 
-        output_probability = permanent_squared / np.prod(factorial(output))
+        output_probability = permanent_squared / fallback_np.prod(factorial(output))
 
-        output_probabilities[idx] = output_probability
+        output_probabilities = calculator.assign(
+            output_probabilities, idx, output_probability
+        )
 
-    output_probabilities /= np.prod(factorial(input))
+    output_probabilities /= fallback_np.prod(factorial(input))
 
     return output_probabilities
 

--- a/piquasso/_math/jax/permanent.py
+++ b/piquasso/_math/jax/permanent.py
@@ -1,0 +1,79 @@
+#
+# Copyright 2021-2024 Budapest Quantum Computing Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from jax import jit, lax
+
+import jax.numpy as jnp
+
+from piquasso._math.linalg import assym_reduce
+
+
+def permanent_with_reduction(matrix, rows, cols):
+    """JAX implementation of the permanent, using the Glynn formula with Gray codes.
+
+    Note:
+        Unfortunately, JAX (or rather XLA) could not JIT-compile creating arrays
+        whose shapes depend on the values of the input, so the reduction of the
+        interferometer is needed to be made in advance.
+    """
+
+    reduced_matrix = assym_reduce(matrix, rows, cols)
+
+    return permanent(reduced_matrix)
+
+
+@jit
+def permanent(M):
+    n = M.shape[0]
+
+    binary_powers = 2 ** jnp.arange(n)
+
+    N = 2 ** (n - 1)
+
+    def body_fun(index, val):
+        sum_, sign, old_gray_code, row_sum = val
+
+        sum_ += sign * jnp.prod(row_sum)
+
+        new_gray_code = index ^ (index // 2)
+        grey_diff = old_gray_code ^ new_gray_code
+        matrix_row_index = jnp.where(binary_powers == grey_diff, size=1)[0][0]
+
+        diff = lax.cond(
+            old_gray_code > new_gray_code,
+            lambda: 1,
+            lambda: -1,
+        )
+
+        row_sum += M[matrix_row_index] * 2 * diff
+
+        sign = -sign
+        old_gray_code = new_gray_code
+
+        return sum_, sign, old_gray_code, row_sum
+
+    sum_ = 0.0
+    sign = +1
+    old_gray_code = 0
+    row_sum = jnp.sum(M, axis=0)
+
+    sum_ = lax.fori_loop(
+        lower=1,
+        upper=N + 1,
+        body_fun=body_fun,
+        init_val=(sum_, sign, old_gray_code, row_sum),
+    )[0]
+
+    return sum_ / N

--- a/piquasso/_math/linalg.py
+++ b/piquasso/_math/linalg.py
@@ -81,19 +81,26 @@ def block_reduce(array: np.ndarray, reduce_on: Tuple[int, ...]) -> np.ndarray:
     return reduce_(array, reduce_on=(reduce_on * 2))
 
 
-def assym_reduce(
-    array: np.ndarray, row_reduce_on: Iterable[int], column_reduce_on: Iterable[int]
-) -> np.ndarray:
-    proper_row_index = []
-    proper_column_index = []
+def assym_reduce(array, row_reduce_on, col_reduce_on):
+    particles = np.sum(row_reduce_on)
 
-    for index, multiplier in enumerate(row_reduce_on):
-        proper_row_index.extend([index] * multiplier)
+    proper_row_index = np.zeros(particles, dtype=int)
+    proper_col_index = np.zeros(particles, dtype=int)
 
-    for index, multiplier in enumerate(column_reduce_on):
-        proper_column_index.extend([index] * multiplier)
+    row_stride = 0
+    col_stride = 0
 
-    return array[np.ix_(proper_column_index, proper_row_index)]
+    for index in range(len(row_reduce_on)):
+        row_multiplier = row_reduce_on[index]
+        col_multiplier = col_reduce_on[index]
+
+        proper_row_index[row_stride : row_stride + row_multiplier] = index
+        proper_col_index[col_stride : col_stride + col_multiplier] = index
+
+        row_stride += row_multiplier
+        col_stride += col_multiplier
+
+    return array[np.ix_(proper_row_index, proper_col_index)]
 
 
 def vector_absolute_square(vector, calculator):

--- a/tests/backends/sampling/test_gates.py
+++ b/tests/backends/sampling/test_gates.py
@@ -226,7 +226,8 @@ def test_LossyInterferometer_raises_InvalidParameter_for_invalid_matrix(
         pq.LossyInterferometer(invalid_matrix)
 
 
-def test_Interferometer_fock_probabilities():
+@pytest.mark.parametrize("calculator", (pq.NumpyCalculator(), pq.JaxCalculator()))
+def test_Interferometer_fock_probabilities(calculator):
     U = np.array(
         [
             [
@@ -272,7 +273,7 @@ def test_Interferometer_fock_probabilities():
 
         pq.Q(all) | pq.Interferometer(U)
 
-    simulator = pq.SamplingSimulator(d=5)
+    simulator = pq.SamplingSimulator(d=5, calculator=calculator)
     state = simulator.execute(program).state
 
     assert np.allclose(
@@ -534,7 +535,8 @@ def test_Interferometer_fock_probabilities():
     )
 
 
-def test_LossyInterferometer_fock_probabilities():
+@pytest.mark.parametrize("calculator", (pq.NumpyCalculator(), pq.JaxCalculator()))
+def test_LossyInterferometer_fock_probabilities(calculator):
     U = np.array(
         [
             [
@@ -584,7 +586,7 @@ def test_LossyInterferometer_fock_probabilities():
 
         pq.Q(all) | pq.LossyInterferometer(lossy_interferometer_matrix)
 
-    simulator = pq.SamplingSimulator(d=5)
+    simulator = pq.SamplingSimulator(d=5, calculator=calculator)
     state = simulator.execute(program).state
 
     assert np.allclose(
@@ -846,7 +848,8 @@ def test_LossyInterferometer_fock_probabilities():
     )
 
 
-def test_Interferometer_state_vector():
+@pytest.mark.parametrize("calculator", (pq.NumpyCalculator(), pq.JaxCalculator()))
+def test_Interferometer_state_vector(calculator):
     U = np.array(
         [
             [
@@ -892,7 +895,7 @@ def test_Interferometer_state_vector():
 
         pq.Q(all) | pq.Interferometer(U)
 
-    simulator = pq.SamplingSimulator(d=5)
+    simulator = pq.SamplingSimulator(d=5, calculator=calculator)
     state = simulator.execute(program).state
 
     assert np.allclose(
@@ -1154,7 +1157,8 @@ def test_Interferometer_state_vector():
     )
 
 
-def test_LossyInterferometer_state_vector():
+@pytest.mark.parametrize("calculator", (pq.NumpyCalculator(), pq.JaxCalculator()))
+def test_LossyInterferometer_state_vector(calculator):
     U = np.array(
         [
             [
@@ -1204,7 +1208,7 @@ def test_LossyInterferometer_state_vector():
 
         pq.Q(all) | pq.LossyInterferometer(lossy_interferometer_matrix)
 
-    simulator = pq.SamplingSimulator(d=5)
+    simulator = pq.SamplingSimulator(d=5, calculator=calculator)
     state = simulator.execute(program).state
 
     assert np.allclose(

--- a/tests/backends/sampling/test_jax_gradient.py
+++ b/tests/backends/sampling/test_jax_gradient.py
@@ -1,0 +1,94 @@
+#
+# Copyright 2021-2024 Budapest Quantum Computing Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+import numpy as np
+
+import piquasso as pq
+
+from jax import grad
+import jax.numpy as jnp
+
+
+def test_Beamsplitter_gradient_at_theta_equal_0():
+    calculator = pq.JaxCalculator()
+
+    def get_fidelity(theta):
+        initial_state = [1, 1, 0]
+
+        with pq.Program() as program:
+            pq.Q() | pq.StateVector(initial_state)
+
+        with pq.Program() as rotated_program:
+            pq.Q() | program
+
+            pq.Q(0, 1) | pq.Beamsplitter(theta=theta)
+
+        simulator = pq.SamplingSimulator(d=3, calculator=calculator)
+
+        initial_state_vector = simulator.execute(program).state.state_vector
+        rotated_state_vector = simulator.execute(rotated_program).state.state_vector
+
+        return jnp.abs(jnp.conj(initial_state_vector) @ rotated_state_vector)
+
+    angle = 0.0
+
+    fidelity_at_0 = get_fidelity(angle)
+
+    assert np.isclose(fidelity_at_0, 1.0)
+
+    grad_get_fidelity = grad(get_fidelity)
+    fidelity_grad_at_0 = grad_get_fidelity(angle)
+
+    assert np.isclose(fidelity_grad_at_0, 0.0)
+
+
+@pytest.mark.monkey
+def test_Beamsplitter_gradient_at_random_angle():
+    calculator = pq.JaxCalculator()
+
+    def get_fidelity(theta):
+        initial_state = [1, 1, 0]
+
+        with pq.Program() as program:
+            pq.Q() | pq.StateVector(initial_state)
+
+        with pq.Program() as rotated_program:
+            pq.Q() | program
+
+            pq.Q(0, 1) | pq.Beamsplitter(theta=theta)
+
+        simulator = pq.SamplingSimulator(d=3, calculator=calculator)
+
+        initial_state_vector = simulator.execute(program).state.state_vector
+        rotated_state_vector = simulator.execute(rotated_program).state.state_vector
+
+        return jnp.abs(jnp.conj(initial_state_vector) @ rotated_state_vector)
+
+    angle = np.random.uniform() * 2 * np.pi
+
+    expected_fidelity = np.abs(np.cos(2 * angle))
+
+    fidelity = get_fidelity(angle)
+
+    assert np.isclose(fidelity, expected_fidelity)
+
+    grad_get_fidelity = grad(get_fidelity)
+    fidelity_grad = grad_get_fidelity(angle)
+
+    expected_fidelity_grad = -2 * np.sin(2 * angle) * np.sign(np.cos(2 * angle))
+
+    assert np.isclose(fidelity_grad, expected_fidelity_grad)

--- a/tests/backends/test_backend_gradient_equivalence.py
+++ b/tests/backends/test_backend_gradient_equivalence.py
@@ -1,0 +1,118 @@
+#
+# Copyright 2021-2024 Budapest Quantum Computing Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+import numpy as np
+
+import piquasso as pq
+
+from jax import grad
+import jax.numpy as jnp
+
+
+@pytest.mark.monkey
+@pytest.mark.parametrize("SimulatorClass", (pq.PureFockSimulator, pq.SamplingSimulator))
+def test_Jax_gradient_equivalence_for_single_Beamsplitter(SimulatorClass):
+    calculator = pq.JaxCalculator()
+
+    def get_fidelity(theta):
+        initial_state = [1, 1, 0]
+
+        d = len(initial_state)
+        cutoff = np.sum(initial_state) + 1
+
+        with pq.Program() as program:
+            pq.Q() | pq.StateVector(initial_state)
+
+        with pq.Program() as rotated_program:
+            pq.Q() | program
+
+            pq.Q(0, 1) | pq.Beamsplitter(theta=theta)
+
+        simulator = SimulatorClass(
+            d=d,
+            calculator=calculator,
+            config=pq.Config(cutoff=cutoff),
+        )
+
+        initial_state_vector = simulator.execute(program).state.state_vector
+        rotated_state_vector = simulator.execute(rotated_program).state.state_vector
+
+        return jnp.abs(jnp.conj(initial_state_vector) @ rotated_state_vector)
+
+    angle = np.random.uniform() * 2 * np.pi
+
+    expected_fidelity = np.abs(np.cos(2 * angle))
+
+    fidelity = get_fidelity(angle)
+
+    assert np.isclose(fidelity, expected_fidelity)
+
+    grad_get_fidelity = grad(get_fidelity)
+    fidelity_grad = grad_get_fidelity(angle)
+
+    expected_fidelity_grad = -2 * np.sin(2 * angle) * np.sign(np.cos(2 * angle))
+
+    assert np.isclose(fidelity_grad, expected_fidelity_grad)
+
+
+@pytest.mark.parametrize("SimulatorClass", (pq.PureFockSimulator, pq.SamplingSimulator))
+def test_Jax_gradient_equivalence_complex_scenario(SimulatorClass):
+    calculator = pq.JaxCalculator()
+
+    def get_fidelity(theta):
+        initial_state = [1, 1, 0]
+
+        d = len(initial_state)
+        cutoff = np.sum(initial_state) + 1
+
+        with pq.Program() as program:
+            pq.Q() | pq.StateVector(initial_state)
+
+        with pq.Program() as rotated_program:
+            pq.Q() | program
+
+            pq.Q(1, 2) | pq.Beamsplitter(theta=0.1, phi=0.42)
+
+            pq.Q(0, 1) | pq.Beamsplitter(theta=theta)
+
+            pq.Q(1, 2) | pq.Beamsplitter(theta=1.5, phi=0.35)
+
+        simulator = SimulatorClass(
+            d=d,
+            calculator=calculator,
+            config=pq.Config(cutoff=cutoff),
+        )
+
+        initial_state_vector = simulator.execute(program).state.state_vector
+        rotated_state_vector = simulator.execute(rotated_program).state.state_vector
+
+        return jnp.abs(jnp.conj(initial_state_vector) @ rotated_state_vector)
+
+    angle = np.pi / 7
+
+    fidelity = get_fidelity(angle)
+
+    expected_fidelity = 0.04604777
+
+    assert np.isclose(fidelity, expected_fidelity)
+
+    grad_get_fidelity = grad(get_fidelity)
+    fidelity_grad = grad_get_fidelity(angle)
+
+    expected_fidelity_grad = 0.06591828
+
+    assert np.isclose(fidelity_grad, expected_fidelity_grad)


### PR DESCRIPTION
A partial JAX support in `SamplingSimulator` has been enabled. For this, the permanent is implemented in JAX. The same algorithm could not be implemented as in `piquasso._math.permanent`, since JIT compilation in XLA does not handle dynamic shapes which depend on non-static values, e.g., row or column repetitions. Therefore, the permanent is needed to be reduced before calculating the permanent with the Glynn algorithm using Gray codes is implemented.

Moreover, the method `assym_reduce` has been rewritten, which produces the reduced (or scattering) matrix.

The gradient of some attributes of `SamplingState` also works, and is tested in `sampling/test_jax_gradient.py` and `test_backend_gradient_equivalence.py`.