### PR TITLE
refactor!(sampling): Delete unused attributes

### DIFF
--- a/piquasso/_backends/sampling/calculations.py
+++ b/piquasso/_backends/sampling/calculations.py
@@ -37,7 +37,7 @@ from .utils import (
 
 
 def state_vector(state: SamplingState, instruction: Instruction, shots: int) -> Result:
-    if not np.all(state.initial_state == 0):
+    if not np.all(state._initial_state == 0):
         raise InvalidState("State vector is already set.")
 
     coefficient = instruction._all_params["coefficient"]
@@ -50,7 +50,7 @@ def state_vector(state: SamplingState, instruction: Instruction, shots: int) -> 
             f"Invalid initial state specified: instruction={instruction}"
         )
 
-    state.initial_state = np.rint(initial_state).astype(int)
+    state._initial_state = np.rint(initial_state).astype(int)
 
     return Result(state=state)
 
@@ -135,7 +135,7 @@ def particle_number_measurement(
     algorithm.
     """
 
-    initial_state = state.initial_state
+    initial_state = state._initial_state
 
     interferometer_svd = np.linalg.svd(state.interferometer)
 

--- a/tests/backends/sampling/test_gates.py
+++ b/tests/backends/sampling/test_gates.py
@@ -128,8 +128,10 @@ def test_lossy_program():
     d = 5
     simulator = pq.SamplingSimulator(d=d)
 
+    initial_state = [1, 1, 1, 0, 0]
+
     with pq.Program() as program:
-        pq.Q(all) | pq.StateVector([1, 1, 1, 0, 0])
+        pq.Q(all) | pq.StateVector(initial_state)
 
         for i in range(d):
             pq.Q(i) | pq.Loss(losses)
@@ -139,7 +141,7 @@ def test_lossy_program():
 
     result = simulator.execute(program, shots=1)
     sample = result.samples[0]
-    assert sum(sample) < sum(result.state.initial_state)
+    assert sum(sample) < sum(initial_state)
 
 
 @pytest.mark.monkey
@@ -156,15 +158,17 @@ def test_LossyInterferometer_decreases_particle_number(generate_unitary_matrix):
 
     simulator = pq.SamplingSimulator(d=d)
 
+    initial_state = [1, 1, 1, 0, 0]
+
     with pq.Program() as program:
-        pq.Q(all) | pq.StateVector([1, 1, 1, 0, 0])
+        pq.Q(all) | pq.StateVector(initial_state)
 
         pq.Q() | pq.LossyInterferometer(lossy_interferometer_matrix)
         pq.Q() | pq.ParticleNumberMeasurement()
 
     result = simulator.execute(program, shots=1)
     sample = result.samples[0]
-    assert sum(sample) < sum(result.state.initial_state)
+    assert sum(sample) < sum(initial_state)
 
 
 @pytest.mark.monkey

--- a/tests/backends/sampling/test_preparations.py
+++ b/tests/backends/sampling/test_preparations.py
@@ -20,28 +20,6 @@ import numpy as np
 import piquasso as pq
 
 
-def test_initial_state():
-    with pq.Program() as program:
-        pq.Q() | pq.StateVector([1, 1, 1, 0, 0])
-
-    simulator = pq.SamplingSimulator(d=5)
-    state = simulator.execute(program).state
-
-    expected_initial_state = [1, 1, 1, 0, 0]
-    assert np.allclose(state.initial_state, expected_initial_state)
-
-
-def test_initial_state_multiplied_with_coefficient():
-    with pq.Program() as program:
-        pq.Q() | pq.StateVector([1, 1, 1, 0, 0]) * 2.0
-
-    simulator = pq.SamplingSimulator(d=5)
-    state = simulator.execute(program).state
-
-    expected_initial_state = [2, 2, 2, 0, 0]
-    assert np.allclose(state.initial_state, expected_initial_state)
-
-
 def test_initial_state_raises_InvalidState_for_noninteger_input_state():
     with pq.Program() as program:
         pq.Q() | pq.StateVector([1, 1, 1, 0, 0]) * 0.5


### PR DESCRIPTION
`SamplingState.initial_state` is made private, since:
- It will not make sense when combinations of Fock basis vectors will be supported;
- It is not really useful to keep it public anyway.

Similar can be said about the `particle_number` attribute, which is just the sum of `initial_state`. Hence, the attributes `particle_number` and `initial_state` got deleted.