### PR TITLE
perf(sampling): Faster `get_particle_detection_probability`

### DIFF
--- a/piquasso/_backends/sampling/state.py
+++ b/piquasso/_backends/sampling/state.py
@@ -16,7 +16,6 @@
 from typing import Optional, List
 import numpy as np
 
-from piquasso._math.indices import get_index_in_fock_subspace
 from piquasso._math.fock import cutoff_cardinality
 from piquasso._math.linalg import is_unitary
 from piquasso._math.validations import all_natural
@@ -27,7 +26,7 @@ from piquasso.api.state import State
 from piquasso.api.exceptions import PiquassoException
 from piquasso.api.calculator import BaseCalculator
 
-from .utils import calculate_distribution, calculate_state_vector
+from .utils import calculate_distribution, calculate_state_vector, calculate_probability
 
 
 class SamplingState(State):
@@ -81,11 +80,12 @@ class SamplingState(State):
         if number_of_particles != sum(self._initial_state):
             return 0.0
 
-        index = get_index_in_fock_subspace(occupation_number)
-
-        subspace_probabilities = self._get_fock_probabilities_on_subspace()
-
-        return subspace_probabilities[index]
+        return calculate_probability(
+            interferometer=self.interferometer,
+            input=self._initial_state,
+            output=np.array(occupation_number),
+            calculator=self._calculator,
+        )
 
     @property
     def state_vector(self):

--- a/piquasso/_backends/sampling/utils.py
+++ b/piquasso/_backends/sampling/utils.py
@@ -97,6 +97,18 @@ def calculate_distribution(interferometer, initial_state, config, calculator):
     return output_probabilities
 
 
+def calculate_probability(interferometer, input, output, calculator):
+    np = calculator.np
+    fallback_np = calculator.fallback_np
+    permanent_squared = (
+        np.abs(calculator.permanent(interferometer, cols=input, rows=output)) ** 2
+    )
+
+    return permanent_squared / (
+        fallback_np.prod(factorial(output)) * fallback_np.prod(factorial(input))
+    )
+
+
 def generate_lossless_samples(input, shots, calculate_permanent, rng):
     """
     Generates samples corresponding to the Clifford & Clifford algorithm

--- a/tests/backends/sampling/test_preparations.py
+++ b/tests/backends/sampling/test_preparations.py
@@ -187,6 +187,39 @@ def test_get_particle_detection_probability():
     assert np.allclose(probability, 0.30545762086020883)
 
 
+def test_get_particle_detection_probability_complex_scenario():
+    U = np.array(
+        [
+            [
+                -0.25022099 + 0.32110177j,
+                -0.69426529 - 0.49960543j,
+                -0.28233272 + 0.15153042j,
+            ],
+            [
+                -0.69028768 + 0.23351228j,
+                0.14839865 + 0.49185272j,
+                -0.43153658 - 0.13714903j,
+            ],
+            [
+                0.41073351 + 0.36681879j,
+                -0.06655274 + 0.00442722j,
+                -0.22146243 - 0.80202711j,
+            ],
+        ],
+    )
+
+    with pq.Program() as program:
+        pq.Q(all) | pq.StateVector([0, 1, 2])
+        pq.Q(all) | pq.Interferometer(U)
+
+    simulator = pq.SamplingSimulator(d=3)
+    state = simulator.execute(program).state
+
+    probability = state.get_particle_detection_probability(occupation_number=(2, 1, 0))
+
+    assert np.allclose(probability, 0.038483056956364094)
+
+
 def test_get_particle_detection_probability_on_different_subspace():
     U = np.array(
         [


### PR DESCRIPTION
The method `get_particle_detection_probability` was very inefficient, since it calculated the whole distribution for no reason. This has been fixed by defining a `calculate_probability` method in `utils`.