### PR TITLE
FIX(fock): `ImperfectPostSelectPhotons` density matrix

### DIFF
--- a/piquasso/_backends/fock/pure/calculations/measurements.py
+++ b/piquasso/_backends/fock/pure/calculations/measurements.py
@@ -95,7 +95,7 @@ def imperfect_post_select_photons(
         )
 
         new_state._density_matrix += detector_probability * np.outer(
-            np.conj(state_vector), state_vector
+            state_vector, np.conj(state_vector)
         )
 
     return Result(state=new_state)


### PR DESCRIPTION
There was an error at the density matrix calculation in `ImperfectPostSelectPhotons`, namely, that the conjugation is needed to be done in the second argument in `np.outer`. This way, the resulting density matrix was conjugated.