### PR TITLE
feat!(clements): Rewrite Clements decomposition

### DIFF
--- a/piquasso/_backends/calculator.py
+++ b/piquasso/_backends/calculator.py
@@ -57,6 +57,13 @@ class _BuiltinCalculator(BaseCalculator):
     def transpose(self, matrix):
         return self.np.transpose(matrix)
 
+    def embed_in_identity(self, matrix, indices, dim):
+        embedded_matrix = self.np.identity(dim, dtype=complex)
+
+        embedded_matrix = self.assign(embedded_matrix, indices, matrix)
+
+        return embedded_matrix
+
 
 class NumpyCalculator(_BuiltinCalculator):
     """The calculations for a simulation using NumPy (and SciPy).

--- a/piquasso/api/calculator.py
+++ b/piquasso/api/calculator.py
@@ -112,6 +112,9 @@ class BaseCalculator(abc.ABC):
         """
         raise NotImplementedCalculation()
 
+    def embed_in_identity(self, matrix, indices, dim):
+        raise NotImplementedCalculation()
+
     def block(self, arrays):
         """Assembling submatrices into a single matrix.
 

--- a/piquasso/decompositions/clements.py
+++ b/piquasso/decompositions/clements.py
@@ -22,200 +22,353 @@ William R. Clements, Peter C. Humphreys, Benjamin J. Metcalf,
 W. Steven Kolthammer, Ian A. Walmsley, "An Optimal Design for Universal Multiport
 Interferometers", `arXiv:1603.08788 <https://arxiv.org/abs/1603.08788>`_.
 """
-from typing import List
 
-import numpy as np
+from typing import List, Tuple, TYPE_CHECKING
+
+from dataclasses import dataclass
+
+from piquasso.api.calculator import BaseCalculator
+
+from piquasso._math.indices import get_operator_index
+
+from piquasso._backends.calculator import NumpyCalculator
+
+if TYPE_CHECKING:
+    import numpy as np
 
 
-class T(np.ndarray):
-    """A definition for the representation of the beamsplitter.
-
-    The matrix is automatically embedded in a `d` times `d` identity
-    matrix, which can be readily applied during decomposition.
+@dataclass
+class BS:
+    """
+    The Beamsplitter is implemented as described in
+    `arXiv:1603.08788 <https://arxiv.org/abs/1603.08788>`_.
     """
 
-    def __new__(cls, operation: dict, d: int) -> "T":
-        """
-        Args:
-            operation (dict):
-                A dict containing the angle parameters and the modes on which the
-                beamsplitter operation is applied.
-            d (int): The total number of modes.
-        """
+    modes: Tuple[int, int]
+    params: Tuple["np.float64", "np.float64"]
 
-        theta, phi = operation["params"]
-        i, j = operation["modes"]
 
-        matrix = np.array(
-            [
-                [np.exp(1j * phi) * np.cos(theta), -np.sin(theta)],
-                [np.exp(1j * phi) * np.sin(theta), np.cos(theta)],
-            ]
+@dataclass
+class PS:
+    """
+    Phaseshifter gate.
+    """
+
+    mode: int
+    phi: "np.float64"
+
+
+@dataclass
+class Decomposition:
+    """
+    The data stucture which holds the decomposed angles from the Clements decomposition.
+
+    Example usage::
+
+        with pq.Program() as program_with_decomposition:
+            ...
+
+            for operation in decomposition.first_beamsplitters:
+                pq.Q(operation.modes[0]) | pq.Phaseshifter(phi=operation.params[1])
+                pq.Q(*operation.modes) | pq.Beamsplitter(operation.params[0], 0.0)
+
+            for operation in decomposition.middle_phaseshifters:
+                pq.Q(operation.mode) | pq.Phaseshifter(operation.phi)
+
+            for operation in decomposition.last_beamsplitters:
+                pq.Q(*operation.modes) | pq.Beamsplitter(-operation.params[0], 0.0)
+                pq.Q(operation.modes[0]) | pq.Phaseshifter(phi=-operation.params[1])
+
+    """
+
+    first_beamsplitters: List[BS]
+    middle_phaseshifters: List[PS]
+    last_beamsplitters: List[BS]
+
+
+def inverse_clements(
+    decomposition: Decomposition, calculator: BaseCalculator, dtype: "np.dtype"
+) -> "np.ndarray":
+    """Inverse of the Clements decomposition.
+
+    Returns:
+        The unitary matrix corresponding to the interferometer.
+    """
+
+    d = len(decomposition.middle_phaseshifters)
+
+    np = calculator.np
+    interferometer = np.identity(d, dtype=dtype)
+
+    for beamsplitter in decomposition.first_beamsplitters:
+        beamsplitter_matrix = _get_embedded_beamsplitter_matrix(
+            beamsplitter, d, calculator, dtype=dtype
         )
 
-        self = np.asarray(np.identity(d, dtype=complex))
+        interferometer = beamsplitter_matrix @ interferometer
 
-        self[i, i] = matrix[0, 0]
-        self[i, j] = matrix[0, 1]
-        self[j, i] = matrix[1, 0]
-        self[j, j] = matrix[1, 1]
+    phis = np.empty(d, dtype=interferometer.dtype)
 
-        return self.view(cls)
+    for phaseshifter in decomposition.middle_phaseshifters:
+        phis = calculator.assign(phis, phaseshifter.mode, phaseshifter.phi)
 
-    @classmethod
-    def transposed(cls, operation: dict, d: int) -> "T":
-        """Transposed beamsplitter matrix.
+    interferometer = np.diag(np.exp(1j * phis)) @ interferometer
 
-        Args:
-            operation (dict):
-                A dict containing the angle parameters and the modes on which the
-                beamsplitter operation is applied.
-            d (int): The total number of modes.
+    for beamsplitter in decomposition.last_beamsplitters:
+        beamsplitter_matrix = np.conj(
+            _get_embedded_beamsplitter_matrix(beamsplitter, d, calculator, dtype=dtype)
+        ).T
 
-        Returns:
-            T: The transposed beamsplitter matrix.
-        """
+        interferometer = beamsplitter_matrix @ interferometer
 
-        theta, phi = operation["params"]
-
-        return cls.transpose(
-            cls({"params": (theta, -phi), "modes": operation["modes"]}, d=d)
-        ).view(T)
-
-    @classmethod
-    def i(cls, operation: dict, d: int) -> "T":
-        """Shorthand for :meth:`transposed`.
-
-        The inverse of the matrix equals the transpose in this case.
-
-        Returns:
-            T: The transposed beamsplitter matrix.
-        """
-        return cls.transposed(operation, d)
+    return interferometer
 
 
-class Clements:
-    def __init__(self, U: np.ndarray, decompose: bool = True):
-        """
-        Args:
-            U (numpy.ndarray): The (square) unitary matrix to be decomposed.
-            decompose (bool):
-                Optional, if `True`, the decomposition is automatically calculated.
-                Defaults to `True`.
-        """
+def clements(
+    U: "np.ndarray",
+    calculator: BaseCalculator,
+) -> Decomposition:
+    """
+    Decomposes the specified unitary matrix by application of beamsplitters
+    prescribed by the decomposition.
 
-        self.U: np.ndarray = U
-        self.d: int = U.shape[0]
-        self.inverse_operations: List[dict] = []
-        self.direct_operations: List[dict] = []
-        self.diagonals: np.ndarray
+    Args:
+        U (numpy.ndarray): The (square) unitary matrix to be decomposed.
 
-        if decompose:
-            self.decompose()
+    Returns:
+        The Clements decomposition. See :class:`Decomposition`.
+    """
 
-    def decompose(self) -> None:
-        """
-        Decomposes the specified unitary matrix by application of beamsplitters
-        prescribed by the decomposition.
-        """
+    first_beampsplitters = []
+    last_beamsplitters = []
 
-        for column in reversed(range(0, self.d - 1)):
-            if column % 2 == 0:
-                self.apply_direct_beamsplitters(column)
-            else:
-                self.apply_inverse_beamsplitters(column)
+    np = calculator.np
 
-        self.diagonals = np.diag(self.U)
+    d = U.shape[0]
 
-    def apply_direct_beamsplitters(self, column: int) -> None:
-        """
-        Calculates the direct beamsplitters for a given column `column`, and
-        applies it to `U`.
+    for column in reversed(range(0, d - 1)):
+        if column % 2 == 0:
+            operations, U = _apply_direct_beamsplitters(column, U, calculator)
+            last_beamsplitters.extend(operations)
+        else:
+            operations, U = _apply_inverse_beamsplitters(column, U, calculator)
+            first_beampsplitters.extend(operations)
 
-        Args:
-            column (int): The current column.
-        """
+    middle_phasshifters = [
+        PS(mode=mode, phi=np.angle(diagonal))
+        for mode, diagonal in enumerate(np.diag(U))
+    ]
 
-        for j in range(self.d - 1 - column):
-            operation = self.eliminate_lower_offdiagonal(column + j + 1, j)
-            self.direct_operations.append(operation)
+    last_beamsplitters = list(reversed(last_beamsplitters))
 
-            beamsplitter = T(operation, d=self.d)
+    return Decomposition(
+        first_beamsplitters=first_beampsplitters,
+        last_beamsplitters=last_beamsplitters,
+        middle_phaseshifters=middle_phasshifters,
+    )
 
-            self.U = beamsplitter @ self.U
 
-    def apply_inverse_beamsplitters(self, column: int) -> None:
-        """
-        Calculates the inverse beamsplitters for a given column `column`, and
-        applies it to `U`.
+def _apply_direct_beamsplitters(
+    column: int, U: "np.ndarray", calculator: BaseCalculator
+) -> tuple:
+    """
+    Calculates the direct beamsplitters for a given column `column`, and
+    applies it to `U`.
 
-        Args:
-            column (int): The current column.
-        """
+    Args:
+        column (int): The current column.
+    """
 
-        for j in reversed(range(self.d - 1 - column)):
-            operation = self.eliminate_upper_offdiagonal(column + j + 1, j)
-            self.inverse_operations.append(operation)
+    operations = []
 
-            beamsplitter = T.i(operation, d=self.d)
-            self.U = self.U @ beamsplitter
+    d = U.shape[0]
 
-    def eliminate_lower_offdiagonal(self, i: int, j: int) -> dict:
-        """
-        Calculates the parameters required to eliminate the lower triangular
-        element `i`, `j` of `U` using `T`.
-        """
-        if np.isclose(self.U[i - 1, j], 0.0):
-            return {
-                "modes": (i - 1, i),
-                "params": (np.pi / 2, 0),
-            }
+    dtype = U.dtype
 
-        r = -self.U[i, j] / self.U[i - 1, j]
-        theta = np.arctan(np.abs(r))
-        phi = np.angle(r)
+    for j in range(d - 1 - column):
+        modes = (column + j, column + j + 1)
 
-        return {
-            "modes": (i - 1, i),
-            "params": (theta, phi),
-        }
+        matrix_element_to_eliminate = U[modes[0], j]
+        matrix_element_above = -U[modes[1], j]
 
-    def eliminate_upper_offdiagonal(self, i: int, j: int) -> dict:
-        """
-        Calculates the parameters required to eliminate the upper triangular
-        `i`, `j` of `U` using `T.transposed`.
-        """
+        angles = _get_angles(
+            matrix_element_to_eliminate, matrix_element_above, calculator
+        )
 
-        if np.isclose(self.U[i, j + 1], 0.0):
-            return {
-                "modes": (j, j + 1),
-                "params": (np.pi / 2, 0),
-            }
+        operation = BS(modes=modes, params=angles)
 
-        r = self.U[i, j] / self.U[i, j + 1]
-        theta = np.arctan(np.abs(r))
-        phi = np.angle(r)
+        matrix = _get_embedded_beamsplitter_matrix(operation, d, calculator, dtype)
 
-        return {
-            "modes": (j, j + 1),
-            "params": (theta, phi),
-        }
+        U = matrix @ U
 
-    @staticmethod
-    def from_decomposition(decomposition: "Clements") -> np.ndarray:
-        """
-        Creates the unitary operator from the Clements operations.
-        """
-        U = np.identity(decomposition.d, dtype=complex)
+        operations.append(operation)
 
-        for operation in decomposition.inverse_operations:
-            beamsplitter = T(operation, d=decomposition.d)
-            U = beamsplitter @ U
+    return operations, U
 
-        U = np.diag(decomposition.diagonals) @ U
 
-        for operation in reversed(decomposition.direct_operations):
-            beamsplitter = T.i(operation, d=decomposition.d)
-            U = beamsplitter @ U
+def _apply_inverse_beamsplitters(
+    column: int, U: "np.ndarray", calculator: BaseCalculator
+) -> tuple:
+    """
+    Calculates the inverse beamsplitters for a given column `column`, and
+    applies it to `U`.
 
-        return U
+    Args:
+        column (int): The current column.
+    """
+
+    operations = []
+
+    d = U.shape[0]
+
+    dtype = U.dtype
+
+    for j in reversed(range(d - 1 - column)):
+        modes = (j, j + 1)
+
+        i = column + j + 1
+
+        matrix_element_to_eliminate = U[i, modes[1]]
+        matrix_element_to_left = U[i, modes[0]]
+
+        angles = _get_angles(
+            matrix_element_to_eliminate, matrix_element_to_left, calculator
+        )
+
+        operation = BS(modes=modes, params=angles)
+
+        beamsplitter = calculator.np.conj(
+            _get_embedded_beamsplitter_matrix(operation, d, calculator, dtype)
+        ).T
+
+        U = U @ beamsplitter
+
+        operations.append(operation)
+
+    return operations, U
+
+
+def _get_angles(matrix_element_to_eliminate, other_matrix_element, calculator):
+    np = calculator.np
+
+    if np.isclose(matrix_element_to_eliminate, 0.0):
+        return np.pi / 2, 0.0
+
+    r = other_matrix_element / matrix_element_to_eliminate
+    theta = np.arctan(np.abs(r))
+    phi = np.angle(r)
+
+    return theta, phi
+
+
+def _get_embedded_beamsplitter_matrix(
+    operation: BS, d: int, calculator: BaseCalculator, dtype: "np.dtype"
+) -> "np.ndarray":
+    np = calculator.np
+
+    theta, phi = operation.params
+    i, j = operation.modes
+
+    c = np.cos(theta).astype(dtype)
+    s = np.sin(theta).astype(dtype)
+
+    matrix = np.array(
+        [
+            [np.exp(1j * phi) * c, -s],
+            [np.exp(1j * phi) * s, c],
+        ],
+        dtype=dtype,
+    )
+
+    return calculator.embed_in_identity(matrix, get_operator_index((i, j)), d)
+
+
+def get_weights_from_decomposition(
+    decomposition: Decomposition, d: int, calculator: BaseCalculator
+) -> "np.ndarray":
+    """Concatenates the weight vector from the angles in the Clements decomposition.
+
+    Returns:
+        The Clements decomposition. See :class:`Decomposition`.
+    """
+    np = calculator.np
+
+    dtype = decomposition.middle_phaseshifters[0].phi.dtype
+    weights = np.empty(d**2, dtype=dtype)
+
+    index = 0
+    for beamsplitter in decomposition.first_beamsplitters:
+        weights = calculator.assign(weights, index, beamsplitter.params[0])
+        index += 1
+        weights = calculator.assign(weights, index, beamsplitter.params[1])
+        index += 1
+
+    for phaseshifter in decomposition.middle_phaseshifters:
+        weights = calculator.assign(weights, index, phaseshifter.phi)
+        index += 1
+
+    for beamsplitter in decomposition.last_beamsplitters:
+        weights = calculator.assign(weights, index, beamsplitter.params[0])
+        index += 1
+        weights = calculator.assign(weights, index, beamsplitter.params[1])
+        index += 1
+
+    return weights
+
+
+def get_decomposition_from_weights(
+    weights: "np.ndarray", d: int, calculator: BaseCalculator
+) -> Decomposition:
+    """Puts the data in the weight vector into a Clements decompositon.
+
+    Returns:
+        The Clements decomposition. See :class:`Decomposition`.
+    """
+
+    fallback_np = calculator.fallback_np
+
+    # NOTE: This is tricky: the ordering in the Clements decomposition is not unique,
+    # since beamsplitters acting on different modes may commute, and the ordering comes
+    # out very ugly after all the Givens rotations. Therefore, it is easier to just
+    # create a trivial decomposition, and fill it with the required values (for now).
+    decomposition = clements(fallback_np.identity(d), calculator=NumpyCalculator())
+
+    index = 0
+
+    for beamsplitter in decomposition.first_beamsplitters:
+        beamsplitter.params = (weights[index], weights[index + 1])
+        index += 2
+
+    for phaseshifter in decomposition.middle_phaseshifters:
+        phaseshifter.phi = weights[index]
+        index += 1
+
+    for beamsplitter in decomposition.last_beamsplitters:
+        beamsplitter.params = (weights[index], weights[index + 1])
+        index += 2
+
+    return decomposition
+
+
+def get_weights_from_interferometer(
+    U: "np.ndarray", calculator: BaseCalculator
+) -> "np.ndarray":
+    """Creates a vector of weights from the Clements angles."""
+    decomposition = clements(U, calculator)
+
+    return get_weights_from_decomposition(decomposition, U.shape[0], calculator)
+
+
+def get_interferometer_from_weights(
+    weights: "np.ndarray",
+    d: int,
+    calculator: BaseCalculator,
+    dtype: "np.dtype",
+) -> "np.ndarray":
+    """Returns the interferometer matrix corresponding to the specified weights.
+
+    It is the inverse of :func:`get_weights_from_interferometer`.
+    """
+    decomposition = get_decomposition_from_weights(weights, d, calculator)
+
+    return inverse_clements(decomposition, calculator, dtype)


### PR DESCRIPTION
The Clements decomposition in Piquasso is a bit hard to use in some cases. It is not differentiable, and the datatypes in it are not trivial, it takes time to wrap one's head around it.

For variational circuits, it would be beneficial to support calculating weights from interferometer matrices and to make this decomposition differentiable. These features have been enabled in this patch.