### PR TITLE
perf(fock): Reduction edge cases

### DIFF
--- a/piquasso/_backends/fock/general/state.py
+++ b/piquasso/_backends/fock/general/state.py
@@ -152,6 +152,9 @@ class FockState(BaseFockState):
         fallback_np = self._calculator.fallback_np
         d = self.d
 
+        if modes == tuple(range(d)):
+            return self
+
         outer_modes = self._get_auxiliary_modes(modes)
 
         inner_size = len(modes)


### PR DESCRIPTION
Reduction or partial trace is computationally expensive, therefore we might not want to do it in trivial cases. When the `modes` parameter of `reduced` corresponds to all modes, then the reduction should yield the same state. This edge case is added in this patch.