### PR TITLE
refact!(config): Preserving RNG when copying `Config`

### DIFF
--- a/piquasso/api/config.py
+++ b/piquasso/api/config.py
@@ -143,4 +143,10 @@ class Config(_mixins.CodeMixin):
             Config: An exact copy of this config object.
         """
 
-        return copy.deepcopy(self)
+        config_copy = copy.deepcopy(self)
+
+        # NOTE: We want to preserve the RNG, otherwise simulations may lead to repeated
+        # samples if the user reuses the simulator.
+        config_copy.rng = self.rng
+
+        return config_copy

--- a/tests/api/test_config.py
+++ b/tests/api/test_config.py
@@ -78,3 +78,11 @@ def test_complex_dtype():
     assert conf_f32.complex_dtype == np.complex64
     assert conf_f64.complex_dtype == np.complex128
     assert conf_f.complex_dtype == np.complex128
+
+
+def test_Config_rng_is_shallow_copied():
+    config = pq.Config(seed_sequence=123)
+
+    config_copy = config.copy()
+
+    assert config.rng is config_copy.rng


### PR DESCRIPTION
When the user copies a config, it is beneficial to use the original RNG, since otherwise the RNG would reinitialize with the same seed in, e.g., a for loop.