### PR TITLE
FIX(cvqnn): Fix `get_cvqnn_weight_indices`

### DIFF
--- a/piquasso/cvqnn.py
+++ b/piquasso/cvqnn.py
@@ -163,7 +163,7 @@ def create_program(weights: np.ndarray) -> Program:
 
 
 def _get_number_of_single_layer_parameters(d):
-    return 2 * (d**2 + 2 * d - 1)
+    return 2 * _get_number_of_interferometer_parameters(d) + 4 * d
 
 
 def get_number_of_modes(number_of_parameters: int) -> int:

--- a/tests/test_cvqnn.py
+++ b/tests/test_cvqnn.py
@@ -188,6 +188,23 @@ def test_get_number_of_modes_with_invalid_number_of_parameters():
     )
 
 
+def test_get_cvqnn_weight_indices_1_mode():
+    weight_indices = cvqnn.get_cvqnn_weight_indices(1)
+
+    expected_weight_indices = [
+        np.array([0]),
+        np.array([1]),
+        np.array([2]),
+        np.array([3]),
+        np.array([4]),
+        np.array([5]),
+    ]
+
+    assert all(
+        np.allclose(a, b) for a, b in zip(weight_indices, expected_weight_indices)
+    )
+
+
 def test_get_cvqnn_weight_indices():
     weight_indices = cvqnn.get_cvqnn_weight_indices(4)
 


### PR DESCRIPTION
There has been a typo in commit `b6833d8`: the function `_get_number_of_single_layer_parameters` returned incorrect results for 1 mode, which is basically an edge case, and should be handled by `_get_number_of_interferometer_parameters`.