### PR TITLE
feat(gaussian): JAX support for `GaussianSimulator`

### DIFF
--- a/piquasso/_backends/calculators/jax_/calculator.py
+++ b/piquasso/_backends/calculators/jax_/calculator.py
@@ -100,6 +100,7 @@ class JaxCalculator(BuiltinCalculator):
         self.powm = jnp.linalg.matrix_power
         self.sqrtm = jax.scipy.linalg.sqrtm
         self.svd = jnp.linalg.svd
+        self.schur = jax.scipy.linalg.schur
         self.permanent = permanent_with_reduction
 
     def preprocess_input_for_custom_gradient(self, value):

--- a/piquasso/_backends/calculators/numpy_/calculator.py
+++ b/piquasso/_backends/calculators/numpy_/calculator.py
@@ -41,6 +41,7 @@ class NumpyCalculator(BuiltinCalculator):
         self.polar = scipy.linalg.polar
         self.sqrtm = scipy.linalg.sqrtm
         self.svd = np.linalg.svd
+        self.schur = scipy.linalg.schur
 
         self.permanent = permanent
         self.hafnian = hafnian_with_reduction

--- a/piquasso/_backends/gaussian/calculations.py
+++ b/piquasso/_backends/gaussian/calculations.py
@@ -55,17 +55,24 @@ def passive_linear(
 
 
 def _apply_passive_linear(state, passive_block, modes):
-    state._m[(modes,)] = passive_block @ state._m[modes,]
+    calculator = state._calculator
+
+    state._m = calculator.assign(state._m, (modes,), passive_block @ state._m[modes,])
+
     _apply_passive_linear_to_C_and_G(state, passive_block, modes=modes)
 
 
 def _apply_passive_linear_to_C_and_G(
     state: GaussianState, T: np.ndarray, modes: Tuple[int, ...]
 ) -> None:
+    calculator = state._calculator
+
     index = get_operator_index(modes)
 
-    state._C[index] = T.conjugate() @ state._C[index] @ T.transpose()
-    state._G[index] = T @ state._G[index] @ T.transpose()
+    state._C = calculator.assign(
+        state._C, index, T.conjugate() @ state._C[index] @ T.transpose()
+    )
+    state._G = calculator.assign(state._G, index, T @ state._G[index] @ T.transpose())
 
     auxiliary_modes = state._get_auxiliary_modes(modes)
 
@@ -79,13 +86,23 @@ def _apply_passive_linear_to_auxiliary_modes(
     modes: Tuple[int, ...],
     auxiliary_modes: Tuple[int, ...],
 ) -> None:
+    calculator = state._calculator
+    np = calculator.np
+
     auxiliary_index = get_auxiliary_operator_index(modes, auxiliary_modes)
 
-    state._C[auxiliary_index] = T.conjugate() @ state._C[auxiliary_index]
-    state._G[auxiliary_index] = T @ state._G[auxiliary_index]
+    state._C = calculator.assign(
+        state._C, auxiliary_index, T.conjugate() @ state._C[auxiliary_index]
+    )
+    state._G = calculator.assign(
+        state._G, auxiliary_index, T @ state._G[auxiliary_index]
+    )
 
-    state._C[:, modes] = np.conj(state._C[modes, :]).transpose()
-    state._G[:, modes] = state._G[modes, :].transpose()
+    assign_index = np.ix_(np.arange(state.d), np.array(modes))
+    state._C = calculator.assign(
+        state._C, assign_index, np.conj(state._C[modes, :]).transpose()
+    )
+    state._G = calculator.assign(state._G, assign_index, state._G[modes, :].transpose())
 
 
 def linear(
@@ -105,9 +122,14 @@ def linear(
 
 
 def _apply_linear(state, passive_block, active_block, modes):
-    state._m[(modes,)] = passive_block @ state._m[(modes,)] + active_block @ np.conj(
-        state._m[modes,]
-    )
+    calculator = state._calculator
+    np = calculator.np
+
+    passive_part = passive_block @ state._m[(modes,)]
+
+    active_part = active_block @ np.conj(state._m[modes,])
+
+    state._m = calculator.assign(state._m, (modes,), passive_part + active_part)
 
     _apply_linear_to_C_and_G(state, passive_block, active_block, modes)
 
@@ -115,25 +137,32 @@ def _apply_linear(state, passive_block, active_block, modes):
 def _apply_linear_to_C_and_G(
     state: GaussianState, P: np.ndarray, A: np.ndarray, modes: Tuple[int, ...]
 ) -> None:
+    calculator = state._calculator
+    np = calculator.np
+
     index = get_operator_index(modes)
 
     original_C = state._C[index]
     original_G = state._G[index]
 
-    state._G[index] = (
+    state._G = calculator.assign(
+        state._G,
+        index,
         P @ original_G @ P.transpose()
         + A @ original_G.conjugate().transpose() @ A.transpose()
         + P @ (original_C.transpose() + np.identity(len(modes))) @ A.transpose()
-        + A @ original_C @ P.transpose()
+        + A @ original_C @ P.transpose(),
     )
 
-    state._C[index] = (
+    state._C = calculator.assign(
+        state._C,
+        index,
         P.conjugate() @ original_C @ P.transpose()
         + A.conjugate()
         @ (original_C.transpose() + np.identity(len(modes)))
         @ A.transpose()
         + P.conjugate() @ original_G.conjugate().transpose() @ A.transpose()
-        + A.conjugate() @ original_G @ P.transpose()
+        + A.conjugate() @ original_G @ P.transpose(),
     )
 
     auxiliary_modes = state._get_auxiliary_modes(modes)
@@ -149,27 +178,45 @@ def _apply_linear_to_auxiliary_modes(
     modes: Tuple[int, ...],
     auxiliary_modes: Tuple[int, ...],
 ) -> None:
+    calculator = state._calculator
+    np = calculator.np
+
     auxiliary_index = get_auxiliary_operator_index(modes, auxiliary_modes)
 
     auxiliary_C = state._C[auxiliary_index]
     auxiliary_G = state._G[auxiliary_index]
 
-    state._C[auxiliary_index] = (
-        P.conjugate() @ auxiliary_C + A.conjugate() @ auxiliary_G
+    state._C = calculator.assign(
+        state._C,
+        auxiliary_index,
+        P.conjugate() @ auxiliary_C + A.conjugate() @ auxiliary_G,
     )
 
-    state._G[auxiliary_index] = P @ auxiliary_G + A @ auxiliary_C
+    state._G = calculator.assign(
+        state._G, auxiliary_index, P @ auxiliary_G + A @ auxiliary_C
+    )
 
-    state._C[:, modes] = state._C[modes, :].conjugate().transpose()
-    state._G[:, modes] = state._G[modes, :].transpose()
+    assign_index = np.ix_(np.arange(state.d), np.array(modes))
+
+    state._C = calculator.assign(
+        state._C, assign_index, state._C[modes, :].conjugate().transpose()
+    )
+    state._G = calculator.assign(state._G, assign_index, state._G[modes, :].transpose())
 
 
 def displacement(state: GaussianState, instruction: Instruction, shots: int) -> Result:
+    calculator = state._calculator
+    np = calculator.np
+
     modes = instruction.modes
     r = instruction._all_params["r"]
     phi = instruction._all_params["phi"]
 
-    state._m[modes,] += r * np.exp(1j * phi)
+    indices = np.ix_(np.array(modes))
+
+    state._m = calculator.assign(
+        state._m, indices, state._m[indices] + r * np.exp(1j * phi)
+    )
 
     return Result(state=state)
 
@@ -319,6 +366,7 @@ def _get_particle_number_measurement_samples(
     pure_covariance, mixed_contribution = decompose_to_pure_and_mixed(
         reduced_state.xxpp_covariance_matrix,
         hbar=state._config.hbar,
+        calculator=state._calculator,
     )
     pure_state = GaussianState(
         len(reduced_state), calculator=state._calculator, config=state._config

--- a/piquasso/_backends/gaussian/simulator.py
+++ b/piquasso/_backends/gaussian/simulator.py
@@ -16,7 +16,7 @@
 from ..simulator import BuiltinSimulator
 from piquasso.instructions import preparations, gates, measurements, channels
 
-from piquasso._backends.calculators import NumpyCalculator
+from piquasso._backends.calculators import NumpyCalculator, JaxCalculator
 
 from .state import GaussianState
 from .calculations import (
@@ -133,3 +133,5 @@ class GaussianSimulator(BuiltinSimulator):
     _state_class = GaussianState
 
     _default_calculator_class = NumpyCalculator
+
+    _extra_builtin_calculators = [JaxCalculator]

--- a/piquasso/_backends/gaussian/state.py
+++ b/piquasso/_backends/gaussian/state.py
@@ -67,6 +67,8 @@ class GaussianState(State):
     def reset(self) -> None:
         r"""Resets the state to a vacuum."""
 
+        np = self._calculator.np
+
         vector_shape = (self.d,)
         matrix_shape = vector_shape * 2
 
@@ -160,6 +162,8 @@ class GaussianState(State):
             numpy.ndarray: A :math:`2d`-vector where :math:`d` is the number of modes.
         """
 
+        np = self._calculator.np
+
         dimensionless_xxpp_mean_vector = np.concatenate(
             [self._m.real, self._m.imag]
         ) * np.sqrt(2)
@@ -192,6 +196,7 @@ class GaussianState(State):
             numpy.ndarray:
                 The :math:`2d \times 2d` xp-ordered covariance matrix.
         """
+        np = self._calculator.np
 
         C = self._C
         G = self._G
@@ -232,7 +237,10 @@ class GaussianState(State):
             numpy.ndarray: The :math:`2d \times 2d` correlation matrix in the
             xxpp-basis.
         """
+        np = self._calculator.np
+
         xxpp_mean_vector = self.xxpp_mean_vector
+
         return self.xxpp_covariance_matrix + 2 * np.outer(
             xxpp_mean_vector, xxpp_mean_vector
         )
@@ -262,6 +270,8 @@ class GaussianState(State):
 
     @xpxp_mean_vector.setter
     def xpxp_mean_vector(self, value: np.ndarray) -> None:
+        np = self._calculator.np
+
         self._validate_mean(value, self.d)
 
         m = (value[::2] + 1j * value[1::2]) / np.sqrt(2 * self._config.hbar)
@@ -296,6 +306,8 @@ class GaussianState(State):
 
     @xpxp_covariance_matrix.setter
     def xpxp_covariance_matrix(self, new_cov: np.ndarray) -> None:
+        np = self._calculator.np
+
         d = self.d
 
         self._validate_cov(new_cov, d)
@@ -384,6 +396,7 @@ class GaussianState(State):
         Returns:
             numpy.ndarray: The complex displacement.
         """
+        np = self._calculator.np
 
         return np.concatenate([self._m, self._m.conj()])
 
@@ -423,6 +436,8 @@ class GaussianState(State):
         Returns:
             numpy.ndarray: The complex covariance.
         """
+
+        np = self._calculator.np
 
         return 2 * np.block(
             [[self._C.conj(), self._G], [self._G.conj(), self._C]]
@@ -469,6 +484,8 @@ class GaussianState(State):
         Returns:
             GaussianState: The rotated `GaussianState` instance.
         """
+        np = self._calculator.np
+
         phase = np.exp(-1j * phi)
 
         return self.__class__._from_representation(
@@ -698,6 +715,9 @@ class GaussianState(State):
         Returns:
             float: The calculated fidelity.
         """  # noqa: E501
+
+        np = self._calculator.np
+
         hbar = self._config.hbar
 
         sigma_1 = self.xpxp_covariance_matrix / hbar
@@ -775,6 +795,8 @@ class GaussianState(State):
         Returns:
             float: The expectation value of the quadratic polynomial.
         """
+
+        np = self._calculator.np
 
         if not is_symmetric(A):
             raise InvalidParameter("The specified matrix is not symmetric.")
@@ -904,6 +926,8 @@ class GaussianState(State):
         Returns:
             GaussianState: The purified Gaussian state.
         """  # noqa: E501
+        np = self._calculator.np
+
         hbar = self._config.hbar
         cov = self.xpxp_covariance_matrix / hbar
 
@@ -911,7 +935,7 @@ class GaussianState(State):
 
         T = from_xxpp_to_xpxp_transformation_matrix(d)
 
-        S, D = williamson(T.T @ cov @ T)
+        S, D = williamson(T.T @ cov @ T, self._calculator)
 
         beta_diagonals = np.diag(np.sqrt(np.abs(np.diag(D)[:d] ** 2 - 1)))
         zeros = np.zeros_like(beta_diagonals)

--- a/piquasso/api/calculator.py
+++ b/piquasso/api/calculator.py
@@ -44,6 +44,8 @@ class BaseCalculator(abc.ABC):
     fallback_np: Any
     forward_pass_np: Any
     range: Any
+    sqrtm: Any
+    schur: Any
 
     def __deepcopy__(self, memo: Any) -> "BaseCalculator":
         """

--- a/tests/backends/gaussian/test_gradient.py
+++ b/tests/backends/gaussian/test_gradient.py
@@ -1,0 +1,69 @@
+#
+# Copyright 2021-2024 Budapest Quantum Computing Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import piquasso as pq
+
+import numpy as np
+
+from jax import grad, jit
+
+
+def test_mean_photon_number_gradient():
+    def func(r):
+        simulator = pq.GaussianSimulator(d=2, calculator=pq.JaxCalculator())
+
+        with pq.Program() as program:
+            pq.Q() | pq.Vacuum()
+
+            pq.Q(0) | pq.Squeezing(r)
+
+            pq.Q(0, 1) | pq.Beamsplitter()
+
+        result = simulator.execute(program)
+
+        mean_photon_number = result.state.mean_photon_number(modes=(0, 1))
+
+        return mean_photon_number
+
+    grad_func = jit(grad(func))
+
+    r = 0.3
+
+    assert np.allclose(func(r), np.sinh(r) ** 2)
+    assert np.allclose(grad_func(r), 2 * np.sinh(r) * np.cosh(r))
+
+
+def test_variance_photon_number_gradient():
+    def func(r):
+        simulator = pq.GaussianSimulator(d=2, calculator=pq.JaxCalculator())
+
+        with pq.Program() as program:
+            pq.Q() | pq.Vacuum()
+
+            pq.Q(0) | pq.Displacement(r)
+
+            pq.Q(0, 1) | pq.Beamsplitter()
+
+        result = simulator.execute(program)
+
+        variance_photon_number = result.state.variance_photon_number(modes=(0, 1))
+
+        return variance_photon_number
+
+    grad_func = jit(grad(func))
+
+    r = 0.3
+    assert np.allclose(func(r), r**2)
+    assert np.allclose(grad_func(r), 2 * r)


### PR DESCRIPTION
A partial support for JAX has been implemented in `GaussianSimulator`.

Note, that calculations needing the (loop)hafnian is not differentiable (yet).