### PR TITLE
perf(fock): jitted `calculate_interferometer_helper_indices`

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -3,3 +3,7 @@ ignore:
   - piquasso/_math/hafnian/*
   - piquasso/_math/permanent.py
   - piquasso/_backends/fock/pure/calculations/homodyne.py
+  - piquasso/_math/combinatorics.py
+  - piquasso/_math/fock.py
+  - piquasso/_math/indices.py
+  - piquasso/_backends/fock/calculations.py

--- a/piquasso/_backends/fock/calculations.py
+++ b/piquasso/_backends/fock/calculations.py
@@ -33,6 +33,7 @@ from piquasso._math.fock import (
     cutoff_cardinality_array,
     operator_basis,
     get_fock_space_basis,
+    nb_get_fock_space_basis,
 )
 from piquasso._math.indices import (
     get_index_in_fock_space,
@@ -145,7 +146,7 @@ def calculate_state_index_matrix_list(d, cutoff, mode):
 
 @nb.njit
 def calculate_interferometer_helper_indices(d, cutoff):
-    space = get_fock_space_basis(d=d, cutoff=cutoff)
+    space = nb_get_fock_space_basis(d=d, cutoff=cutoff)
 
     indices = cutoff_cardinality_array(cutoff=np.arange(1, cutoff + 1), d=d)
 

--- a/piquasso/_backends/fock/general/calculations.py
+++ b/piquasso/_backends/fock/general/calculations.py
@@ -117,10 +117,18 @@ def _calculate_density_matrix_after_interferometer(
 
 
 def _get_interferometer_on_fock_space(interferometer, cutoff, calculator):
-    index_dict = calculate_interferometer_helper_indices(
+    index_tuple = calculate_interferometer_helper_indices(
         d=len(interferometer),
         cutoff=cutoff,
     )
+
+    index_dict = {
+        "subspace_index_tensor": index_tuple[0],
+        "first_nonzero_index_tensor": index_tuple[1],
+        "first_subspace_index_tensor": index_tuple[2],
+        "sqrt_occupation_numbers_tensor": index_tuple[3],
+        "sqrt_first_occupation_numbers_tensor": index_tuple[4],
+    }
 
     return calculate_interferometer_on_fock_space(
         interferometer, index_dict, calculator

--- a/piquasso/_backends/fock/pure/calculations/passive_linear.py
+++ b/piquasso/_backends/fock/pure/calculations/passive_linear.py
@@ -76,9 +76,17 @@ def _do_apply_passive_linear(
 def _get_interferometer_on_fock_space(interferometer, cutoff, calculator):
     def _get_interferometer_with_gradient_callback(interferometer):
         interferometer = calculator.preprocess_input_for_custom_gradient(interferometer)
-        index_dict = calculate_interferometer_helper_indices(
+        index_tuple = calculate_interferometer_helper_indices(
             d=len(interferometer), cutoff=cutoff
         )
+
+        index_dict = {
+            "subspace_index_tensor": index_tuple[0],
+            "first_nonzero_index_tensor": index_tuple[1],
+            "first_subspace_index_tensor": index_tuple[2],
+            "sqrt_occupation_numbers_tensor": index_tuple[3],
+            "sqrt_first_occupation_numbers_tensor": index_tuple[4],
+        }
 
         subspace_representations = calculate_interferometer_on_fock_space(
             interferometer, index_dict, calculator

--- a/piquasso/_math/combinatorics.py
+++ b/piquasso/_math/combinatorics.py
@@ -17,6 +17,34 @@ from itertools import chain, combinations
 from typing import Tuple, Iterable, Iterator, TypeVar
 
 import numpy as np
+import numba as nb
+
+
+@nb.njit
+def arr_comb(n, k):
+    n = np.where((n < 0) | (n < k), 0, n)
+    prod = np.ones(n.shape, dtype=np.int64)
+
+    for i in range(k):
+        prod *= n - i
+        prod = prod // (i + 1)
+
+    return prod
+
+
+@nb.njit(cache=True)
+def comb(n, k):
+    if n <= 0 or n < k:
+        return 0
+
+    prod = 1
+
+    for i in range(k):
+        prod *= n - i
+        prod = prod // (i + 1)
+
+    return prod
+
 
 _T = TypeVar("_T")
 

--- a/piquasso/_math/fock.py
+++ b/piquasso/_math/fock.py
@@ -20,6 +20,7 @@ import numpy as np
 import numba as nb
 
 from scipy.special import comb
+from piquasso._math.combinatorics import comb as nb_comb
 
 from piquasso.api.config import Config
 from piquasso._math.combinatorics import partitions
@@ -47,8 +48,14 @@ def cutoff_cardinality(*, cutoff: int, d: int) -> int:
     return comb(d + cutoff - 1, cutoff - 1, exact=True)
 
 
-def cutoff_cardinality_array(*, cutoff, d):
-    return np.round(comb(d + cutoff - 1, d)).astype(int)
+@nb.njit
+def cutoff_cardinality_array(cutoff, d):
+    ret = np.empty(cutoff.shape, dtype=np.int32)
+
+    for i in range(len(cutoff)):
+        ret[i] = nb_comb(d + cutoff[i] - 1, d)
+
+    return ret
 
 
 def symmetric_subspace_cardinality_array(*, d: int, n: int) -> int:

--- a/piquasso/_math/fock.py
+++ b/piquasso/_math/fock.py
@@ -63,7 +63,7 @@ def symmetric_subspace_cardinality_array(*, d: int, n: int) -> int:
 
 
 @nb.njit(cache=True)
-def get_fock_space_basis(d: int, cutoff: int) -> np.ndarray:
+def nb_get_fock_space_basis(d: int, cutoff: int) -> np.ndarray:
     partitions_list = [partitions(boxes=d, particles=n) for n in range(cutoff)]
 
     total_elements = 0
@@ -78,6 +78,9 @@ def get_fock_space_basis(d: int, cutoff: int) -> np.ndarray:
         current_row += num_rows
 
     return ret
+
+
+get_fock_space_basis = functools.lru_cache(maxsize=None)(nb_get_fock_space_basis)
 
 
 def get_single_mode_squeezing_operator(

--- a/piquasso/_math/indices.py
+++ b/piquasso/_math/indices.py
@@ -16,8 +16,10 @@
 from typing import Tuple
 
 import numpy as np
+import numba as nb
 
 from scipy.special import comb
+from piquasso._math.combinatorics import arr_comb
 
 
 def get_operator_index(modes: Tuple[int, ...]) -> Tuple[np.ndarray, np.ndarray]:
@@ -72,13 +74,14 @@ def get_index_in_fock_subspace(element: np.ndarray) -> int:
     return accumulator
 
 
+@nb.njit
 def get_index_in_fock_subspace_array(basis: np.ndarray) -> np.ndarray:
-    sum_ = np.zeros(shape=basis.shape[:-1], dtype=int)
-    accumulator = np.zeros(shape=basis.shape[:-1], dtype=int)
+    sum_ = np.zeros(shape=basis.shape[:-1], dtype=np.int32)
+    accumulator = np.zeros(shape=basis.shape[:-1], dtype=np.int32)
 
     for i in range(basis.shape[-1] - 1):
         sum_ += basis[..., -1 - i]
-        accumulator += np.round(comb(sum_ + i, i + 1)).astype(int)
+        accumulator += np.round(arr_comb(sum_ + i, i + 1)).astype(np.int32)
 
     return accumulator
 

--- a/piquasso/_math/permanent.py
+++ b/piquasso/_math/permanent.py
@@ -17,6 +17,8 @@ import numpy as np
 
 import numba as nb
 
+from piquasso._math.combinatorics import comb
+
 
 def permanent(matrix, rows, cols):
     """Calculates the permanent of a matrix given row and column repetitions.
@@ -103,7 +105,7 @@ def _iterate_over_deltas(
                 index_min=idx + 1,
                 current_multiplicity=(
                     current_multiplicity
-                    * _nb_comb(delta_limits[idx], index_of_multiplicity)
+                    * comb(delta_limits[idx], index_of_multiplicity)
                 ),
                 cols=cols,
                 mtx2=mtx2,
@@ -146,7 +148,7 @@ def _iterate_over_deltas_recursively(
                 index_min=idx + 1,
                 current_multiplicity=(
                     current_multiplicity
-                    * _nb_comb(delta_limits[idx], index_of_multiplicity)
+                    * comb(delta_limits[idx], index_of_multiplicity)
                 ),
                 cols=cols,
                 mtx2=mtx2,
@@ -156,14 +158,3 @@ def _iterate_over_deltas_recursively(
         outer_sum += inner_sum
 
     return outer_sum + current_multiplicity * sign * np.prod(col_sum**cols)
-
-
-@nb.njit(cache=True)
-def _nb_comb(n, k):
-    prod = 1
-
-    for i in range(k):
-        prod *= n - i
-        prod = prod // (i + 1)
-
-    return prod


### PR DESCRIPTION
Several functions have been rewritten so that they can be compiled using Numba JIT. This is a partial milestone and more functions are planned to be rewritten in this manner.

Specifically, the following changes occurred:
- The `comb` function is now part of the `combinatorics.py` module, and an additional `arr_comb` is implemented accepting and returning arrays. 
- `partitions` is now also jitted alongside `nb_combinations`, equivalent to `itertools.combinations` which is used in many places, hence the different name with the `nb_` prefix. 
- The function `get_fock_space_basis` has also a new implementation with a `nb_` prefix denoting the jitted version. The distinction is necessary due to the extensive use of LRU caching at other parts of the code.
- The function `get_index_in_fock_subspace_array` now can be compiled using Numba JIT.
- And finally `calculate_interferometer_helper_indices` is also now jitted with Numba. 

Notes:
- For the special case of the parametrization of `partitions` the shape `(1,0)` is specifically chosen so that it can be stacked in `get_fock_space_basis` correctly. 
- The function header for `cutoff_cardinality_array` got changed so that it does not force keyword arguments. This seems to be a bug in Numba related to keyword arguments when they are called in another function that is also JIT compiled. (see issue [here](https://github.com/numba/numba/issues/9185))
- The function `calculate_interferometer_helper_indices` now returns tuples instead of dictionaries (due to Numba) and therefore a temporary dictionary is added between function calls until the entire `get_interferometer_on_fock_space` function gets Numba JIT implementation as well.