### PR TITLE
refact(fock): Moving `calculate_interferometer_on_fock_space`

### DIFF
--- a/piquasso/_backends/fock/general/calculations.py
+++ b/piquasso/_backends/fock/general/calculations.py
@@ -41,7 +41,6 @@ from piquasso._math.fock import (
 from ..calculations import (
     calculate_state_index_matrix_list,
     calculate_interferometer_helper_indices,
-    calculate_interferometer_on_fock_space,
     calculate_index_list_for_appling_interferometer,
     get_projection_operator_indices,
 )
@@ -130,9 +129,7 @@ def _get_interferometer_on_fock_space(interferometer, cutoff, calculator):
         "sqrt_first_occupation_numbers_tensor": index_tuple[4],
     }
 
-    return calculate_interferometer_on_fock_space(
-        interferometer, index_dict, calculator
-    )
+    return calculator.calculate_interferometer_on_fock_space(interferometer, index_dict)
 
 
 def particle_number_measurement(

--- a/piquasso/_backends/fock/pure/calculations/passive_linear.py
+++ b/piquasso/_backends/fock/pure/calculations/passive_linear.py
@@ -26,7 +26,6 @@ from piquasso.api.calculator import BaseCalculator
 from ..state import PureFockState
 from ...calculations import (
     calculate_interferometer_helper_indices,
-    calculate_interferometer_on_fock_space,
     calculate_index_list_for_appling_interferometer,
 )
 from piquasso.instructions import gates
@@ -88,8 +87,8 @@ def _get_interferometer_on_fock_space(interferometer, cutoff, calculator):
             "sqrt_first_occupation_numbers_tensor": index_tuple[4],
         }
 
-        subspace_representations = calculate_interferometer_on_fock_space(
-            interferometer, index_dict, calculator
+        subspace_representations = calculator.calculate_interferometer_on_fock_space(
+            interferometer, index_dict
         )
         grad = _calculate_interferometer_gradient_on_fock_space(
             interferometer,

--- a/piquasso/api/calculator.py
+++ b/piquasso/api/calculator.py
@@ -229,3 +229,16 @@ class BaseCalculator(abc.ABC):
             matrix (numpy.ndarray): The input matrix.
         """
         raise NotImplementedCalculation()
+
+    def calculate_interferometer_on_fock_space(self, interferometer, helper_indices):
+        """Calculates the interferometer unitary matrix on the Fock space.
+
+        Args:
+            interferometer: One-particle unitary corresponding to the interferometer.
+            helper_indices: Separately calculated helper indices.
+
+        Returns:
+            All the n-particle unitary matrices corresponding to the interferometer up
+            to cutoff.
+        """
+        raise NotImplementedCalculation()


### PR DESCRIPTION
The function `calculate_interferometer_on_fock_space` is refactored such that it is part of the `BuiltinCalculator` class as a preparation to make it jit compiled in the future.