### PR TITLE
chore(tests): Fix flaky test in `test_cvqnn.py`

### DIFF
--- a/tests/test_cvqnn.py
+++ b/tests/test_cvqnn.py
@@ -45,7 +45,7 @@ def test_create_layers_yields_valid_program():
 
         pq.Q() | layers
 
-    simulator = pq.PureFockSimulator(d)
+    simulator = pq.PureFockSimulator(d, config=pq.Config(cutoff=7))
 
     state = simulator.execute(program).state
 


### PR DESCRIPTION
The test `test_create_layers_yields_valid_program` is flaky since commit f3023f343b2ed642f4b8936f5d338d8026356f84, since the state is not automatically normalized after applying active gates, making this test flaky. To remedy this situation, the Fock space cutoff is increased.