### PR TITLE
perf(fock): Interferometer on Fock space JITted

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -7,3 +7,4 @@ ignore:
   - piquasso/_math/fock.py
   - piquasso/_math/indices.py
   - piquasso/_backends/fock/calculations.py
+  - piquasso/_backends/calculators/numpy_/interferometer.py

--- a/piquasso/_backends/calculators/calculator.py
+++ b/piquasso/_backends/calculators/calculator.py
@@ -56,28 +56,26 @@ class BuiltinCalculator(BaseCalculator):
         return embedded_matrix
 
     def calculate_interferometer_on_fock_space(self, interferometer, helper_indices):
+        """
+        This implementation uses Eq. (71) from
+        https://quantum-journal.org/papers/q-2020-11-30-366/pdf/
+        """
+
         np = self.forward_pass_np
         subspace_representations = []
 
         subspace_representations.append(np.array([[1.0]], dtype=interferometer.dtype))
         subspace_representations.append(interferometer)
 
-        cutoff = len(helper_indices["subspace_index_tensor"]) + 2
+        cutoff = len(helper_indices[0]) + 2
 
         for n in range(2, cutoff):
-            subspace_indices = helper_indices["subspace_index_tensor"][n - 2]
-            first_subspace_indices = helper_indices["first_subspace_index_tensor"][
-                n - 2
-            ]
+            subspace_indices = helper_indices[0][n - 2]
+            first_subspace_indices = helper_indices[2][n - 2]
 
-            first_nonzero_indices = helper_indices["first_nonzero_index_tensor"][n - 2]
-
-            sqrt_occupation_numbers = helper_indices["sqrt_occupation_numbers_tensor"][
-                n - 2
-            ]
-            sqrt_first_occupation_numbers = helper_indices[
-                "sqrt_first_occupation_numbers_tensor"
-            ][n - 2]
+            first_nonzero_indices = helper_indices[1][n - 2]
+            sqrt_occupation_numbers = helper_indices[3][n - 2]
+            sqrt_first_occupation_numbers = helper_indices[4][n - 2]
 
             first_part_partially_indexed = interferometer[first_nonzero_indices]
             second = self.gather_along_axis_1(

--- a/piquasso/_backends/calculators/numpy_/calculator.py
+++ b/piquasso/_backends/calculators/numpy_/calculator.py
@@ -22,6 +22,8 @@ from piquasso._math.hafnian import hafnian_with_reduction, loop_hafnian_with_red
 
 from ..calculator import BuiltinCalculator
 
+from .interferometer import calculate_interferometer_on_fock_space
+
 
 class NumpyCalculator(BuiltinCalculator):
     """The calculations for a simulation using NumPy (and SciPy).
@@ -45,6 +47,10 @@ class NumpyCalculator(BuiltinCalculator):
         self.permanent = permanent
         self.hafnian = hafnian_with_reduction
         self.loop_hafnian = loop_hafnian_with_reduction
+
+        self.calculate_interferometer_on_fock_space = (
+            calculate_interferometer_on_fock_space
+        )
 
     def sqrtm(self, matrix):
         return scipy.linalg.sqrtm(matrix).astype(np.complex128)

--- a/piquasso/_backends/calculators/numpy_/interferometer.py
+++ b/piquasso/_backends/calculators/numpy_/interferometer.py
@@ -1,0 +1,66 @@
+#
+# Copyright 2021-2024 Budapest Quantum Computing Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import numba as nb
+
+
+@nb.njit(cache=True)
+def calculate_interferometer_on_fock_space(interferometer, helper_indices):
+    cutoff = len(helper_indices[0]) + 2
+    subspace_representations = []
+
+    subspace_representations.append(np.array([[1.0]], dtype=interferometer.dtype))
+    subspace_representations.append(interferometer)
+
+    for n in range(2, cutoff):
+        subspace_indices = helper_indices[0][n - 2]
+        first_subspace_indices = helper_indices[2][n - 2]
+
+        first_nonzero_indices = helper_indices[1][n - 2]
+
+        sqrt_occupation_numbers = helper_indices[3][n - 2]
+        sqrt_first_occupation_numbers = helper_indices[4][n - 2]
+
+        previous_representation = subspace_representations[n - 1]
+
+        result_shape = (
+            first_nonzero_indices.shape[0],
+            sqrt_occupation_numbers.shape[0],
+        )
+
+        representation = np.zeros(result_shape, dtype=interferometer.dtype)
+
+        for k in range(result_shape[0]):
+            denominator = sqrt_first_occupation_numbers[k]
+            previous_representation_indexed = previous_representation[
+                first_subspace_indices[k]
+            ]
+
+            for j in range(sqrt_occupation_numbers.shape[1]):
+                one_particle_contrib = (
+                    interferometer[first_nonzero_indices[k], j] / denominator
+                )
+
+                for i in range(result_shape[1]):
+                    representation[k, i] += (
+                        one_particle_contrib
+                        * sqrt_occupation_numbers[i, j]
+                        * previous_representation_indexed[subspace_indices[i, j]]
+                    )
+
+        subspace_representations.append(representation.astype(interferometer.dtype))
+
+    return subspace_representations

--- a/piquasso/_backends/fock/general/calculations.py
+++ b/piquasso/_backends/fock/general/calculations.py
@@ -121,15 +121,9 @@ def _get_interferometer_on_fock_space(interferometer, cutoff, calculator):
         cutoff=cutoff,
     )
 
-    index_dict = {
-        "subspace_index_tensor": index_tuple[0],
-        "first_nonzero_index_tensor": index_tuple[1],
-        "first_subspace_index_tensor": index_tuple[2],
-        "sqrt_occupation_numbers_tensor": index_tuple[3],
-        "sqrt_first_occupation_numbers_tensor": index_tuple[4],
-    }
-
-    return calculator.calculate_interferometer_on_fock_space(interferometer, index_dict)
+    return calculator.calculate_interferometer_on_fock_space(
+        interferometer, index_tuple
+    )
 
 
 def particle_number_measurement(

--- a/piquasso/_backends/fock/pure/calculations/passive_linear.py
+++ b/piquasso/_backends/fock/pure/calculations/passive_linear.py
@@ -88,7 +88,7 @@ def _get_interferometer_on_fock_space(interferometer, cutoff, calculator):
         }
 
         subspace_representations = calculator.calculate_interferometer_on_fock_space(
-            interferometer, index_dict
+            interferometer, index_tuple
         )
         grad = _calculate_interferometer_gradient_on_fock_space(
             interferometer,


### PR DESCRIPTION
Calculating the unitary matrix corresponding to an interferometer is rewritten to be `numba.njit`-compatible. For this, the `helper_indices` dict is rewritten to be a tuple for compatibility.

The Numba implementation has been drastically modified compared to the Numpy implementation to increase performance. This is because using Numpy one wants to avoid, e.g., Python for loops, whereas in the JIT-compiled Numba code it is more efficient to use explicit for loops.