### PR TITLE
fix(README.md): Piquasso logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-    <img src="piquasso_logo.svg" alt="Piquasso logo"/>
+    <img src="https://raw.githubusercontent.com/Budapest-Quantum-Computing-Group/piquasso/main/piquasso_logo.svg" alt="Piquasso logo"/>
 </p>
 
 ![Codecov](https://img.shields.io/codecov/c/github/Budapest-Quantum-Computing-Group/piquasso)


### PR DESCRIPTION
The Piquasso logo is not loaded in PyPI when the image is loaded from file, so it is loaded from its GitHub URL instead.