### PR TITLE
fix(gaussian): Seeding `ThresholdMeasurement`+`use_torontonian`

### DIFF
--- a/piquasso/_backends/gaussian/calculations.py
+++ b/piquasso/_backends/gaussian/calculations.py
@@ -17,7 +17,6 @@ from typing import Tuple, List
 
 import itertools
 import scipy
-import random
 import numpy as np
 
 from itertools import repeat
@@ -524,6 +523,8 @@ def _generate_threshold_samples_using_torontonian(
             f"xpxp_mean_vector={state.xpxp_mean_vector}"
         )
 
+    rng = state._config.rng
+
     modes = instruction.modes
 
     @lru_cache(state._config.cache_size)
@@ -556,7 +557,7 @@ def _generate_threshold_samples_using_torontonian(
             conditional_probability = probability / previous_probability
 
             choice: int
-            guess = random.uniform(0.0, 1.0)
+            guess = rng.uniform()
 
             if guess < conditional_probability:
                 choice = 0

--- a/tests/backends/gaussian/test_measurements.py
+++ b/tests/backends/gaussian/test_measurements.py
@@ -321,3 +321,45 @@ def test_seeded_gaussian_boson_sampling():
     result2 = simulator2.execute(gaussian_boson_sampling, shots=shots)
 
     assert result1.samples == result2.samples
+
+
+def test_ThresholdMeasurement_use_torontonian_seeding():
+    d = 5
+    shots = 10
+
+    seed_sequence = 123
+
+    A = np.array(
+        [
+            [0, 1, 0, 1, 1],
+            [1, 0, 0, 0, 1],
+            [0, 0, 0, 1, 0],
+            [1, 0, 1, 0, 1],
+            [1, 1, 0, 1, 0],
+        ]
+    )
+
+    with pq.Program() as program:
+        pq.Q(all) | pq.Graph(A)
+
+        pq.Q(all) | pq.ThresholdMeasurement()
+
+    simulator = pq.GaussianSimulator(
+        d=d,
+        calculator=pq.NumpyCalculator(),
+        config=pq.Config(seed_sequence=seed_sequence, use_torontonian=True),
+    )
+    result = simulator.execute(program, shots=shots)
+
+    assert result.samples == [
+        (1, 0, 0, 0, 1),
+        (1, 1, 0, 1, 1),
+        (1, 0, 1, 1, 1),
+        (1, 1, 0, 1, 1),
+        (0, 0, 0, 0, 0),
+        (0, 0, 0, 1, 1),
+        (1, 1, 0, 1, 1),
+        (0, 0, 0, 0, 0),
+        (0, 0, 0, 0, 0),
+        (0, 0, 0, 0, 0),
+    ]


### PR DESCRIPTION
The random numbers in `ThresholdMeasurement` with `use_torontonian=True` was not using the random number generator from config. This has been fixed in this patch.