### PR TITLE
chore: Remove strawberryfields from benchmark dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,16 +39,7 @@ We also appreciate bug reports, suggestions, or any kind of idea regarding Piqua
 
 ## Development guide
 
-The `eigen3` C++ library needs to be installed for the `thewalrus` (dependency of
-`strawberryfields`).
-
-On Ubuntu/Debian you can install it with
-
-```
-sudo apt-get install libeigen3-dev
-```
-
-Now, to install development dependencies, use:
+To install development dependencies, use:
 ```
 pip install -e ".[dev]"
 ```

--- a/benchmarks/conftest.py
+++ b/benchmarks/conftest.py
@@ -15,7 +15,6 @@
 
 import pytest
 
-import strawberryfields as sf
 import piquasso as pq
 
 import numpy as np
@@ -119,7 +118,25 @@ def example_pq_purefock_state(pq_purefock_simulator, example_purefock_pq_program
 
 
 @pytest.fixture
-def example_gaussian_sf_program_and_engine(d):
+def sf():
+    try:
+        import strawberryfields
+    except ImportError as error:
+        known_error_message = "cannot import name 'simps' from 'scipy.integrate'"
+
+        if known_error_message in error.msg:
+            raise ImportError(
+                "Install a previous version of 'scipy', since 'strawberryfields' is "
+                "incompatible with newer versions of scipy."
+            )
+        else:
+            raise error
+
+    return strawberryfields
+
+
+@pytest.fixture
+def example_gaussian_sf_program_and_engine(d, sf):
     """
     NOTE: the covariance matrix SF is returning is half of ours...
     It seems that our implementation is OK, however.
@@ -154,7 +171,7 @@ def example_gaussian_sf_program_and_engine(d):
 
 
 @pytest.fixture
-def example_fock_sf_program_and_engine(d, cutoff):
+def example_fock_sf_program_and_engine(d, cutoff, sf):
     """
     NOTE: the covariance matrix SF is returning is half of ours...
     It seems that our implementation is OK, however.

--- a/benchmarks/gaussian_boson_sampling_benchmark.py
+++ b/benchmarks/gaussian_boson_sampling_benchmark.py
@@ -16,7 +16,6 @@
 import pytest
 
 import piquasso as pq
-import strawberryfields as sf
 
 
 pytestmark = pytest.mark.benchmark(
@@ -35,7 +34,7 @@ def piquasso_benchmark(benchmark, pq_gaussian_simulator, example_pq_gaussian_sta
         )
 
 
-def strawberryfields_benchmark(benchmark, example_sf_gaussian_state, d):
+def strawberryfields_benchmark(benchmark, example_sf_gaussian_state, d, sf):
     @benchmark
     def func():
         new_program = sf.Program(d)

--- a/benchmarks/gaussian_homodyne_benchmark.py
+++ b/benchmarks/gaussian_homodyne_benchmark.py
@@ -17,7 +17,6 @@ import pytest
 
 import numpy as np
 import piquasso as pq
-import strawberryfields as sf
 
 
 pytestmark = pytest.mark.benchmark(
@@ -36,7 +35,7 @@ def piquasso_benchmark(benchmark, pq_gaussian_simulator, example_pq_gaussian_sta
             )
 
 
-def strawberryfields_benchmark(benchmark, example_sf_gaussian_state, d):
+def strawberryfields_benchmark(benchmark, example_sf_gaussian_state, d, sf):
     @benchmark
     def func():
         new_program = sf.Program(d)

--- a/benchmarks/gaussian_threshold_detection_benchmark.py
+++ b/benchmarks/gaussian_threshold_detection_benchmark.py
@@ -16,7 +16,6 @@
 import pytest
 
 import piquasso as pq
-import strawberryfields as sf
 import numpy as np
 
 
@@ -49,7 +48,7 @@ def piquasso_benchmark(benchmark, pq_gaussian_simulator):
         pq_gaussian_simulator.execute(program, shots=20)
 
 
-def strawberryfields_benchmark(benchmark, d):
+def strawberryfields_benchmark(benchmark, d, sf):
     @benchmark
     def func():
         program = sf.Program(d)

--- a/benchmarks/purefock_beamsplitter_benchmark.py
+++ b/benchmarks/purefock_beamsplitter_benchmark.py
@@ -16,7 +16,6 @@
 import pytest
 
 import piquasso as pq
-import strawberryfields as sf
 
 
 pytestmark = pytest.mark.benchmark(
@@ -42,7 +41,7 @@ def piquasso_benchmark(benchmark, pq_purefock_simulator):
         pq_purefock_simulator.execute(new_program)
 
 
-def strawberryfields_benchmark(benchmark, d, cutoff):
+def strawberryfields_benchmark(benchmark, d, cutoff, sf):
     @benchmark
     def func():
         new_program = sf.Program(d)

--- a/benchmarks/purefock_beamsplitter_increasing_cutoff_benchmark.py
+++ b/benchmarks/purefock_beamsplitter_increasing_cutoff_benchmark.py
@@ -18,7 +18,6 @@ import pytest
 import numpy as np
 
 import piquasso as pq
-import strawberryfields as sf
 
 
 pytestmark = pytest.mark.benchmark(
@@ -54,7 +53,7 @@ def piquasso_benchmark(benchmark, d, cutoff, theta):
 
 
 @pytest.mark.parametrize("cutoff", (3, 4, 5))
-def strawberryfields_benchmark(benchmark, d, cutoff, theta):
+def strawberryfields_benchmark(benchmark, d, cutoff, theta, sf):
     @benchmark
     def func():
         eng = sf.Engine(backend="fock", backend_options={"cutoff_dim": cutoff})

--- a/benchmarks/purefock_beamsplitter_increasing_modes_benchmark.py
+++ b/benchmarks/purefock_beamsplitter_increasing_modes_benchmark.py
@@ -18,7 +18,6 @@ import pytest
 import numpy as np
 
 import piquasso as pq
-import strawberryfields as sf
 
 
 pytestmark = pytest.mark.benchmark(
@@ -52,7 +51,7 @@ def piquasso_benchmark(benchmark, d, cutoff, theta):
 
 
 @pytest.mark.parametrize("d", (3, 4, 5, 6))
-def strawberryfields_benchmark(benchmark, d, cutoff, theta):
+def strawberryfields_benchmark(benchmark, d, cutoff, theta, sf):
     @benchmark
     def func():
         eng = sf.Engine(backend="fock", backend_options={"cutoff_dim": cutoff})

--- a/benchmarks/purefock_boson_sampling_benchmark.py
+++ b/benchmarks/purefock_boson_sampling_benchmark.py
@@ -16,7 +16,6 @@
 import pytest
 
 import piquasso as pq
-import strawberryfields as sf
 
 
 pytestmark = pytest.mark.benchmark(
@@ -45,7 +44,7 @@ def piquasso_benchmark(
         )
 
 
-def strawberryfields_benchmark(benchmark, example_sf_fock_state, d, cutoff, shots):
+def strawberryfields_benchmark(benchmark, example_sf_fock_state, d, cutoff, shots, sf):
     @benchmark
     def func():
         new_program = sf.Program(d)

--- a/benchmarks/purefock_general_benchmark.py
+++ b/benchmarks/purefock_general_benchmark.py
@@ -16,7 +16,6 @@
 import pytest
 
 import piquasso as pq
-import strawberryfields as sf
 
 from scipy.stats import unitary_group
 
@@ -70,7 +69,7 @@ def piquasso_benchmark(benchmark, cutoff, r, alpha, xi, d):
         simulator_fock.execute(program)
 
 
-def strawberryfields_benchmark(benchmark, cutoff, r, alpha, xi, d):
+def strawberryfields_benchmark(benchmark, cutoff, r, alpha, xi, d, sf):
     @benchmark
     def func():
         eng = sf.Engine(backend="fock", backend_options={"cutoff_dim": cutoff})

--- a/benchmarks/purefock_interferometer_benchmark.py
+++ b/benchmarks/purefock_interferometer_benchmark.py
@@ -18,7 +18,6 @@ import pytest
 import numpy as np
 
 import piquasso as pq
-import strawberryfields as sf
 
 
 pytestmark = pytest.mark.benchmark(
@@ -79,7 +78,7 @@ def piquasso_benchmark(benchmark, pq_purefock_simulator, interferometer):
         pq_purefock_simulator.execute(new_program)
 
 
-def strawberryfields_benchmark(benchmark, d, cutoff, interferometer):
+def strawberryfields_benchmark(benchmark, d, cutoff, interferometer, sf):
     @benchmark
     def func():
         new_program = sf.Program(d)

--- a/benchmarks/purefock_interferometer_increasing_modes_benchmark.py
+++ b/benchmarks/purefock_interferometer_increasing_modes_benchmark.py
@@ -18,7 +18,6 @@ import pytest
 import numpy as np
 
 import piquasso as pq
-import strawberryfields as sf
 
 from scipy.stats import unitary_group
 
@@ -56,7 +55,7 @@ def piquasso_benchmark(benchmark, d, interferometer, cutoff, theta):
 
 
 @pytest.mark.parametrize("d, interferometer", parameters[:2])
-def strawberryfields_benchmark(benchmark, d, interferometer, cutoff, theta):
+def strawberryfields_benchmark(benchmark, d, interferometer, cutoff, theta, sf):
     @benchmark
     def func():
         eng = sf.Engine(backend="fock", backend_options={"cutoff_dim": cutoff})

--- a/benchmarks/purefock_squeezing_increasing_cutoff_benchmark.py
+++ b/benchmarks/purefock_squeezing_increasing_cutoff_benchmark.py
@@ -16,7 +16,6 @@
 import pytest
 
 import piquasso as pq
-import strawberryfields as sf
 
 
 pytestmark = pytest.mark.benchmark(
@@ -50,7 +49,7 @@ def piquasso_benchmark(benchmark, d, cutoff, r):
 
 
 @pytest.mark.parametrize("cutoff", (3, 4, 5, 6))
-def strawberryfields_benchmark(benchmark, d, cutoff, r):
+def strawberryfields_benchmark(benchmark, d, cutoff, r, sf):
     @benchmark
     def func():
         eng = sf.Engine(backend="fock", backend_options={"cutoff_dim": cutoff})

--- a/benchmarks/purefock_squeezing_increasing_modes_benchmark.py
+++ b/benchmarks/purefock_squeezing_increasing_modes_benchmark.py
@@ -16,7 +16,6 @@
 import pytest
 
 import piquasso as pq
-import strawberryfields as sf
 
 
 pytestmark = pytest.mark.benchmark(
@@ -50,7 +49,7 @@ def piquasso_benchmark(benchmark, d, cutoff, r):
 
 
 @pytest.mark.parametrize("d", (3, 4, 5, 6))
-def strawberryfields_benchmark(benchmark, d, cutoff, r):
+def strawberryfields_benchmark(benchmark, d, cutoff, r, sf):
     @benchmark
     def func():
         eng = sf.Engine(backend="fock", backend_options={"cutoff_dim": cutoff})

--- a/benchmarks/tf_1_mode_cvnn_benchmark.py
+++ b/benchmarks/tf_1_mode_cvnn_benchmark.py
@@ -24,7 +24,6 @@ import pytest
 import numpy as np
 import tensorflow as tf
 
-import strawberryfields as sf
 import piquasso as pq
 
 
@@ -105,7 +104,7 @@ def _calculate_piquasso_results(weights, cutoff, layer_count):
     return state_vector, tape.jacobian(state_vector, weights)
 
 
-def _calculate_strawberryfields_results(weights, cutoff, layer_count):
+def _calculate_strawberryfields_results(weights, cutoff, layer_count, sf):
     eng = sf.Engine(backend="tf", backend_options={"cutoff_dim": cutoff})
     prog = sf.Program(1)
 

--- a/benchmarks/tf_general_benchmark.py
+++ b/benchmarks/tf_general_benchmark.py
@@ -16,7 +16,6 @@
 import pytest
 
 import piquasso as pq
-import strawberryfields as sf
 import tensorflow as tf
 
 from scipy.stats import unitary_group
@@ -74,7 +73,7 @@ def piquasso_benchmark(benchmark, d, interferometer, alpha, r, xi):
 
 
 @pytest.mark.parametrize("d, interferometer", parameters)
-def strawberryfields_benchmark(benchmark, d, interferometer, alpha, r, xi):
+def strawberryfields_benchmark(benchmark, d, interferometer, alpha, r, xi, sf):
     @benchmark
     def func():
         program = sf.Program(d)

--- a/benchmarks/tf_purefock_displacement_benchmark.py
+++ b/benchmarks/tf_purefock_displacement_benchmark.py
@@ -17,7 +17,6 @@ import pytest
 
 import piquasso as pq
 import tensorflow as tf
-import strawberryfields as sf
 
 
 pytestmark = pytest.mark.benchmark(
@@ -50,7 +49,7 @@ def piquasso_benchmark(benchmark, cutoff, d):
 
 
 @pytest.mark.parametrize("d, cutoff", zip(d_tuple, d_tuple))
-def strawberryfields_benchmark(benchmark, cutoff, d):
+def strawberryfields_benchmark(benchmark, cutoff, d, sf):
     @benchmark
     def func():
         new_program = sf.Program(d)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,6 @@ dev = [
 ]
 doc = ["sphinx~=7.1.2", "nbsphinx~=0.8.8", "furo~=2024.1.29"]
 benchmark = [
-  "strawberryfields~=0.23.0",
   "matplotlib~=3.7.5",
   "pytest-profiling~=1.7.0",
   "pytest-benchmark~=4.0.0",


### PR DESCRIPTION
Strawberry Fields has not been updated for a while, and it fails with recent version of SciPy (e.g., with strawberryfields==0.23.0 and scipy==1.14.0). For this reason, the strawberryfields imports from `benchmarks` were moved to a pytest fixture. In `scripts` this has not been done, since these files don't use pytest, and have less rationale in running these without strawberryfields.