### PR TITLE
chore(tests): Fix flaky test in `test_cvqnn.py` again

### DIFF
--- a/tests/test_cvqnn.py
+++ b/tests/test_cvqnn.py
@@ -58,7 +58,7 @@ def test_create_program_yields_valid_program():
     weights = cvqnn.generate_random_cvqnn_weights(layer_count=10, d=d)
     program = cvqnn.create_program(weights)
 
-    simulator = pq.PureFockSimulator(d)
+    simulator = pq.PureFockSimulator(d, config=pq.Config(cutoff=7))
 
     state = simulator.execute(program).state
 
@@ -71,7 +71,7 @@ def test_create_program_yields_valid_program_for_1_mode():
     weights = cvqnn.generate_random_cvqnn_weights(layer_count=10, d=d)
     program = cvqnn.create_program(weights)
 
-    simulator = pq.PureFockSimulator(d)
+    simulator = pq.PureFockSimulator(d, config=pq.Config(cutoff=7))
 
     state = simulator.execute(program).state
 


### PR DESCRIPTION
Since f3023f343b2ed642f4b8936f5d338d8026356f84, some tests are flaky, since the state is not automatically normalized after applying active gates, making this test flaky. To remedy this situation, the Fock space cutoff is increased.

Similar fix was done in 88521afbee23554c3a30d39c57eb93a2e16aaf24, but that was not comprehensive enough.