### PR TITLE
perf(hafnian): Include repetitions

### DIFF
--- a/piquasso/_math/hafnian/__init__.py
+++ b/piquasso/_math/hafnian/__init__.py
@@ -18,9 +18,15 @@ Package containing hafnian and loop hafnian calculations.
 
 Most of the code in this package are translated versions of the PiquassoBoost C++ code
 from https://github.com/Budapest-Quantum-Computing-Group/piquassoboost.
+
+Moreover, the algorithms are enhanced by factoring in repetitions according to
+https://arxiv.org/abs/2108.01622.
 """
 
-from .utils import hafnian_with_reduction, loop_hafnian_with_reduction
+from .plain_hafnian import hafnian_with_reduction
+
+from .loop_hafnian import loop_hafnian_with_reduction
+
 
 __all__ = [
     "hafnian_with_reduction",

--- a/piquasso/_math/hafnian/loop_corrections.py
+++ b/piquasso/_math/hafnian/loop_corrections.py
@@ -18,7 +18,10 @@ import numpy as np
 
 
 @nb.njit(cache=True)
-def calculate_loop_correction(cx_diag_elements, diag_elements, AZ, num_of_modes):
+def calculate_loop_corrections(cx_diag_elements, diag_elements, AZ, num_of_modes):
+    """
+    Calculates loop corrections.
+    """
     loop_correction = np.zeros(num_of_modes, dtype=AZ.dtype)
 
     max_idx = len(cx_diag_elements)

--- a/piquasso/_math/hafnian/loop_hafnian.py
+++ b/piquasso/_math/hafnian/loop_hafnian.py
@@ -16,23 +16,33 @@
 import numba as nb
 import numpy as np
 
-from .powtrace import calculate_power_traces_and_loop_corrections
+from piquasso._math.combinatorics import comb
+
+from .powtrace import calculate_power_traces_loop
+
+from .utils import match_occupation_numbers, ix_, get_kept_edges
+from .loop_corrections import calculate_loop_corrections
 
 
 @nb.njit(cache=True)
 def _scale_matrix(matrix):
-    if matrix.shape[0] <= 10:
+    r"""
+    Scales the matrix for better accuracy.
+    """
+
+    dim = matrix.shape[0]
+
+    if dim <= 10:
         return matrix, 1.0
 
     scale_factor = np.sum(np.abs(matrix))
 
-    scale_factor = scale_factor / matrix.shape[0] ** 2 / np.sqrt(2.0)
+    scale_factor = scale_factor / dim**2 / np.sqrt(2.0)
 
     inverse_scale_factor = 1 / scale_factor
 
-    for row_idx in range(0, matrix.shape[0]):
-
-        for col_idx in range(0, matrix.shape[1]):
+    for row_idx in range(dim):
+        for col_idx in range(dim):
             if col_idx == row_idx:
                 matrix[row_idx, col_idx] = matrix[row_idx, col_idx] * np.sqrt(
                     inverse_scale_factor
@@ -45,115 +55,204 @@ def _scale_matrix(matrix):
     return matrix, scale_factor
 
 
-@nb.njit(cache=True, parallel=True)
-def loop_hafnian(matrix):
+@nb.njit(cache=True)
+def _calc_B_and_reduced_diagonals(matrix, diagonal, delta):
+    r"""
+    Creates the input data required to calculate power traces and loop corrections
+    according to `delta`.
+
+    Args:
+        matrix (np.ndarray): The input matrix.
+        diagonal (np.ndarray): The displacement term.
+        delta (np.ndarray): Elements required in $X_{\delta}$ from Eq. (B11) from
+            https://arxiv.org/abs/2108.01622.
+
+    Returns:
+        Tuple: The input data required to calculate power traces and loop corrections.
     """
+    nonzero_indices = np.nonzero(delta)[0]
+    nonzero_dim_over_2 = len(nonzero_indices)
+
+    nonzero_dim = 2 * nonzero_dim_over_2
+
+    B = np.empty((nonzero_dim, nonzero_dim), dtype=matrix.dtype)
+    reduced_diagonal_left = np.empty(nonzero_dim, dtype=matrix.dtype)
+    reduced_diagonal_right = np.empty(nonzero_dim, dtype=matrix.dtype)
+
+    for i in range(nonzero_dim_over_2):
+        even = 2 * i
+        odd = 2 * i + 1
+
+        delta_i = delta[nonzero_indices[i]]
+
+        source_col_even = 2 * nonzero_indices[i] + 1
+        source_col_odd = 2 * nonzero_indices[i]
+
+        for row_idx in range(nonzero_dim):
+            source_row = 2 * nonzero_indices[row_idx // 2] + row_idx % 2
+
+            B[row_idx, even] = delta_i * matrix[source_row, source_col_even]
+            B[row_idx, odd] = delta_i * matrix[source_row, source_col_odd]
+
+        reduced_diagonal_right[even] = diagonal[source_col_odd]
+        reduced_diagonal_right[odd] = diagonal[source_col_even]
+
+        reduced_diagonal_left[even] = delta_i * diagonal[source_col_even]
+        reduced_diagonal_left[odd] = delta_i * diagonal[source_col_odd]
+
+    return B, reduced_diagonal_left, reduced_diagonal_right
+
+
+@nb.njit(cache=True)
+def _calc_f_loop(traces, loop_corrections):
+    r"""Calcualates `f` from Appendix B.1 from https://arxiv.org/abs/2108.01622.
+
+    This function uses the previously calculated power traces and loop corrections.
+
+    Args:
+        traces (numpy.ndarray): The power traces.
+        loop_corrections (numpy.ndarray): Loop corrections.
+    """
+
+    dim_over_2 = len(traces)
+    dim = 2 * dim_over_2
+
+    aux0 = np.zeros(dim_over_2 + 1, dtype=traces.dtype)
+    aux1 = np.zeros(dim_over_2 + 1, dtype=traces.dtype)
+
+    aux0[0] = 1.0
+
+    data = [aux0, aux1]
+
+    p_aux0 = 0
+    p_aux1 = 1
+
+    for idx in range(1, dim_over_2 + 1):
+        factor = traces[idx - 1] / (2.0 * idx) + loop_corrections[idx - 1] * 0.5
+
+        powfactor = 1.0
+
+        if idx % 2 == 1:
+            p_aux0 = 0
+            p_aux1 = 1
+        else:
+            p_aux0 = 1
+            p_aux1 = 0
+
+        data[p_aux1] = np.copy(data[p_aux0])
+
+        for jdx in range(1, dim // (2 * idx) + 1):
+            powfactor = powfactor * factor / jdx
+
+            for kdx in range(idx * jdx, dim_over_2 + 1):
+                data[p_aux1][kdx] += data[p_aux0][kdx - idx * jdx] * powfactor
+
+    return data[p_aux1][dim_over_2]
+
+
+@nb.njit(cache=True, parallel=True)
+def loop_hafnian_with_reduction(matrix_orig, diagonal_orig, occupation_numbers):
+    r"""
     Calculates the loop hafnian of the input matrix using the power trace algorithm
     with Glynn-type iterations.
+
+    The algorithm is enhanced by factoring in repetitions according to
+    https://arxiv.org/abs/2108.01622.
     """
-    if len(matrix) % 2 == 1:
-        odd_dim = len(matrix)
-        new_matrix = np.empty((odd_dim + 1, odd_dim + 1), dtype=matrix.dtype)
-        new_matrix[1:, 1:] = matrix
+
+    n = sum(occupation_numbers)
+
+    diagonal_orig = diagonal_orig.astype(matrix_orig.dtype)
+
+    if n == 0:
+        return 1.0
+    elif n % 2 == 1:
+        # Handling the odd case by extending the matrix with a 1 to be even.
+        #
+        # TODO: This is not the best handling of the odd case, and we can definitely
+        # squeeze out a bit more performance if needed.
+        dim = len(matrix_orig)
+        new_matrix = np.empty((dim + 1, dim + 1), dtype=matrix_orig.dtype)
+        new_matrix[1:, 1:] = matrix_orig
         new_matrix[0, 0] = 1.0
         new_matrix[1:, 0] = 0.0
         new_matrix[0, 1:] = 0.0
 
-        matrix = new_matrix
+        matrix_orig = new_matrix
+
+        d = len(occupation_numbers)
+
+        new_occupation_numbers = np.empty(d + 1, dtype=occupation_numbers.dtype)
+        new_diagonal = np.empty(d + 1, dtype=diagonal_orig.dtype)
+
+        new_occupation_numbers[0] = 1
+        new_diagonal[0] = 1.0
+
+        for i in range(d):
+            new_occupation_numbers[i + 1] = occupation_numbers[i]
+            new_diagonal[i + 1] = diagonal_orig[i]
+
+        occupation_numbers = new_occupation_numbers
+        diagonal_orig = new_diagonal
+
+    all_edges, edge_indices = match_occupation_numbers(occupation_numbers)
+
+    matrix = ix_(matrix_orig, edge_indices, edge_indices)
+    diagonal = diagonal_orig[edge_indices]
 
     matrix, scale_factor = _scale_matrix(matrix)
+    diagonal = diagonal / np.sqrt(scale_factor)
 
-    dim = matrix.shape[0]
-    dim_over_2 = dim // 2
-    permutation_idx_max = 2**dim_over_2
+    dim_over_2 = sum(all_edges)
+    dim = 2 * dim_over_2
 
-    start_idx = 0
-    step_idx = 1
-    max_idx = permutation_idx_max // 2
+    result = 0.0
 
-    if matrix.shape[0] == 0:
-        return 1.0
-    elif matrix.shape[0] % 2 != 0:
-        return 0.0
+    comb_cache = {}
 
-    res = 0.0
+    for n in range(max(all_edges) + 1):
+        for k in range(n + 1):
+            comb_cache[(n, k)] = comb(n, k)
 
-    for permutation_idx in nb.prange(start_idx, max_idx, step_idx):
-        summand = 0.0
+    size = np.prod(all_edges + 1) // 2
 
-        diag_elements = np.empty(dim, dtype=matrix.dtype)
-        cx_diag_elements = np.empty(dim, dtype=matrix.dtype)
-        AZ = np.empty((dim, dim), dtype=matrix.dtype)
-
+    for permutation_idx in nb.prange(size):
+        kept_edges = get_kept_edges(all_edges, permutation_idx)
         fact = False
+        combinatorial_factor = 1.0
 
-        for idx in range(0, dim):
-            row_offset = idx ^ 1
+        delta = np.empty_like(all_edges)
 
-            for jdx in range(0, dim_over_2):
-                neg = (permutation_idx & (1 << jdx)) != 0
-                if idx == jdx:
-                    fact ^= neg
-                if neg:
-                    AZ[idx, jdx * 2] = -matrix[row_offset, jdx * 2]
-                    AZ[idx, jdx * 2 + 1] = -matrix[row_offset, jdx * 2 + 1]
-                else:
-                    AZ[idx, jdx * 2] = matrix[row_offset, jdx * 2]
-                    AZ[idx, jdx * 2 + 1] = matrix[row_offset, jdx * 2 + 1]
+        for i in range(len(all_edges)):
+            no_of_edges = all_edges[i]
+            no_of_kept_edges = kept_edges[i]
 
-            diag_elements[row_offset] = AZ[idx, row_offset]
+            fact ^= (no_of_edges - no_of_kept_edges) % 2
+            comb_input = (no_of_edges, no_of_kept_edges)
+            combinatorial_factor *= comb_cache[comb_input]
 
-            cx_diag_elements[idx] = (
-                (-diag_elements[row_offset])
-                if (permutation_idx & (1 << (idx // 2))) != 0
-                else diag_elements[row_offset]
-            )
+            delta[i] = 2 * no_of_kept_edges - no_of_edges
 
-        traces, loop_corrections = calculate_power_traces_and_loop_corrections(
-            cx_diag_elements, diag_elements, AZ, dim_over_2
+        prefactor = (-1.0 if fact else 1) * combinatorial_factor
+
+        B, reduced_diagonal_left, reduced_diagonal_right = (
+            _calc_B_and_reduced_diagonals(matrix, diagonal, delta)
         )
 
-        aux0 = np.zeros(dim_over_2 + 1, dtype=AZ.dtype)
-        aux1 = np.zeros(dim_over_2 + 1, dtype=AZ.dtype)
+        traces = calculate_power_traces_loop(
+            reduced_diagonal_right, reduced_diagonal_left, B, dim_over_2
+        )
 
-        aux0[0] = 1.0
+        loop_corrections = calculate_loop_corrections(
+            reduced_diagonal_right, reduced_diagonal_left, B, dim_over_2
+        )
 
-        data = [aux0, aux1]
+        summand = prefactor * _calc_f_loop(traces, loop_corrections)
 
-        p_aux0 = 0
-        p_aux1 = 1
+        result += summand
 
-        for idx in range(1, dim_over_2 + 1):
-            factor = traces[idx - 1] / (2.0 * idx) + loop_corrections[idx - 1] * 0.5
+    result *= scale_factor**dim_over_2
 
-            powfactor = 1.0
+    result /= 1 << (dim_over_2 - 1)
 
-            if idx % 2 == 1:
-                p_aux0 = 0
-                p_aux1 = 1
-            else:
-                p_aux0 = 1
-                p_aux1 = 0
-
-            data[p_aux1] = np.copy(data[p_aux0])
-
-            for jdx in range(1, dim // (2 * idx) + 1):
-                powfactor = powfactor * factor / jdx
-
-                for kdx in range(idx * jdx + 1, dim_over_2 + 2):
-                    data[p_aux1][kdx - 1] += (
-                        data[p_aux0][kdx - idx * jdx - 1] * powfactor
-                    )
-
-        if fact:
-            summand -= data[p_aux1][dim_over_2]
-        else:
-            summand += data[p_aux1][dim_over_2]
-
-        res += summand
-
-    res *= scale_factor**dim_over_2
-
-    res /= 1 << (dim_over_2 - 1)
-
-    return res
+    return result

--- a/piquasso/_math/hafnian/powtrace.py
+++ b/piquasso/_math/hafnian/powtrace.py
@@ -22,7 +22,6 @@ from .hessenberg import (
     transform_matrix_to_hessenberg,
     transform_matrix_to_hessenberg_loop,
 )
-from .loop_corrections import calculate_loop_correction
 
 
 @nb.njit(cache=True)
@@ -81,7 +80,7 @@ def calc_power_traces(A, pow_max):
 
 
 @nb.njit(cache=True)
-def calculate_power_traces_and_loop_corrections(
+def calculate_power_traces_loop(
     cx_diag_elements,
     diag_elements,
     AZ,
@@ -89,18 +88,11 @@ def calculate_power_traces_and_loop_corrections(
 ):
     r"""
     Call to calculate the power traces $Tr(mtx^j)~\forall~1\leq j\leq l$ for a squared
-    complex matrix $mtx$ of dimensions $n\times n$ and a loop corrections in Eq (3.26)
-    of [arxiv:1805.12498](https://arxiv.org/pdf/1104.3769v1.pdf).
+    complex matrix $mtx$ of dimensions $n\times n$ according to Eq. (3.26) of
+    [arxiv:1805.12498](https://arxiv.org/pdf/1104.3769v1.pdf).
     """
-
     transform_matrix_to_hessenberg_loop(AZ, diag_elements, cx_diag_elements)
 
     coeffs_labudde = labudde(AZ)
 
-    loop_corrections = calculate_loop_correction(
-        cx_diag_elements, diag_elements, AZ, pow_max
-    )
-
-    traces = _powtrace_from_charpoly(coeffs_labudde, pow_max)
-
-    return traces, loop_corrections
+    return _powtrace_from_charpoly(coeffs_labudde, pow_max)

--- a/scripts/hafnian_benchmark.py
+++ b/scripts/hafnian_benchmark.py
@@ -1,0 +1,73 @@
+#
+# Copyright 2021-2024 Budapest Quantum Computing Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Benchmarking the Piquasso vs. TheWalrus hafnian with repetitions.
+"""
+
+import time
+
+from piquasso._math.hafnian import hafnian_with_reduction
+from thewalrus import hafnian_repeated
+
+import matplotlib.pyplot as plt
+
+import numpy as np
+
+np.set_printoptions(suppress=True, linewidth=200)
+
+
+if __name__ == "__main__":
+    x = []
+    y = []
+    z = []
+
+    ITER = 10
+
+    for d in range(6, 24, 2):
+        print(d)
+        x.append(d)
+        A = np.random.rand(d, d) + 1j * np.random.rand(d, d)
+
+        A = A + A.T
+
+        occupation_numbers = 2 * np.ones(d, dtype=int)
+        sum_ = 0.0
+
+        for _ in range(ITER):
+            print("|", end="", flush=True)
+            start_time = time.time()
+            hafnian_with_reduction(A, occupation_numbers)
+            sum_ += time.time() - start_time
+
+        y.append(sum_ / ITER)
+        print()
+
+        sum_ = 0.0
+
+        for _ in range(ITER):
+            print("-", end="", flush=True)
+            start_time = time.time()
+            hafnian_repeated(A, occupation_numbers)
+            sum_ += time.time() - start_time
+
+        z.append(sum_ / ITER)
+        print()
+
+    plt.scatter(x[1:], np.log(y[1:]), label="Piquasso")
+    plt.scatter(x[1:], np.log(z[1:]), label="TheWalrus")
+    plt.legend()
+
+    plt.show()

--- a/scripts/loop_hafnian_benchmark.py
+++ b/scripts/loop_hafnian_benchmark.py
@@ -1,0 +1,76 @@
+#
+# Copyright 2021-2024 Budapest Quantum Computing Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Benchmarking the Piquasso vs. TheWalrus loop hafnian with repetitions.
+"""
+
+import time
+
+from piquasso._math.hafnian import loop_hafnian_with_reduction
+from thewalrus import loop_hafnian as loop_hafnian_repeated
+
+import matplotlib.pyplot as plt
+
+import numpy as np
+
+np.set_printoptions(suppress=True, linewidth=200)
+
+
+if __name__ == "__main__":
+    x = []
+    y = []
+    z = []
+
+    ITER = 10
+
+    for d in range(6, 24, 1):
+        print(d)
+        x.append(d)
+        A = np.random.rand(d, d) + 1j * np.random.rand(d, d)
+
+        A = A + A.T
+
+        diag = np.random.rand(d) + 1j * np.random.rand(d)
+
+        occupation_numbers = 2 * np.ones(d, dtype=int)
+
+        sum_ = 0.0
+
+        for _ in range(ITER):
+            print("|", end="", flush=True)
+            start_time = time.time()
+            loop_hafnian_with_reduction(A, diag, occupation_numbers)
+            sum_ += time.time() - start_time
+
+        y.append(sum_ / ITER)
+        print()
+
+        sum_ = 0.0
+
+        for _ in range(ITER):
+            print("-", end="", flush=True)
+            start_time = time.time()
+            loop_hafnian_repeated(A, diag, occupation_numbers)
+            sum_ += time.time() - start_time
+
+        z.append(sum_ / ITER)
+        print()
+
+    plt.scatter(x[1:], np.log(y[1:]), label="Piquasso")
+    plt.scatter(x[1:], np.log(z[1:]), label="TheWalrus")
+    plt.legend()
+
+    plt.show()

--- a/tests/_math/test_hafnian.py
+++ b/tests/_math/test_hafnian.py
@@ -18,15 +18,41 @@ import pytest
 import numpy as np
 
 from scipy.linalg import block_diag
-from piquasso._math.hafnian.utils import (
-    hafnian,
-    loop_hafnian,
+from piquasso._math.hafnian import (
     hafnian_with_reduction,
     loop_hafnian_with_reduction,
 )
 
+from piquasso._math.linalg import reduce_
 
-def test_hafnian_on_2_by_2_real_matrix():
+
+def test_hafnian_with_empty_reduction():
+    matrix = np.array(
+        [
+            [1, -500j],
+            [500j, 6],
+        ],
+        dtype=complex,
+    )
+
+    assert np.isclose(hafnian_with_reduction(matrix, np.array([0, 0])), 1.0)
+
+
+def test_loop_hafnian_with_empty_reduction():
+    matrix = np.array(
+        [
+            [1, -500j],
+            [500j, 6],
+        ],
+        dtype=complex,
+    )
+
+    assert np.isclose(
+        loop_hafnian_with_reduction(matrix, np.array([0, 0]), np.array([0, 0])), 1.0
+    )
+
+
+def test_hafnian_with_reduction_on_2_by_2_real_matrix():
     matrix = np.array(
         [
             [1, 500],
@@ -35,22 +61,22 @@ def test_hafnian_on_2_by_2_real_matrix():
         dtype=float,
     )
 
-    assert np.isclose(hafnian(matrix), 500.0)
+    assert np.isclose(hafnian_with_reduction(matrix, np.array([2, 4])), 18000108)
 
 
-def test_hafnian_on_2_by_2_complex_matrix():
+def test_hafnian_with_reduction_on_2_by_2_complex_matrix():
     matrix = np.array(
         [
-            [1, 500j],
+            [1, -500j],
             [500j, 6],
         ],
         dtype=complex,
     )
 
-    assert np.isclose(hafnian(matrix), 500.0j)
+    assert np.isclose(hafnian_with_reduction(matrix, np.array([4, 0])), 3)
 
 
-def test_loop_hafnian_on_2_by_2_real_matrix():
+def test_loop_hafnian_with_reduction_on_2_by_2_real_matrix():
     matrix = np.array(
         [
             [1, 500],
@@ -59,10 +85,30 @@ def test_loop_hafnian_on_2_by_2_real_matrix():
         dtype=float,
     )
 
-    assert np.isclose(loop_hafnian(matrix), 506.0)
+    assert np.isclose(
+        loop_hafnian_with_reduction(
+            matrix,
+            np.array([0.4, 0.6]),
+            occupation_numbers=np.array([2, 4]),
+        ),
+        19097766.06393626,
+    )
 
 
-def test_loop_hafnian_on_2_by_2_complex_matrix():
+def test_loop_hafnian_with_reduction_on_1_by_1_complex_matrix():
+    matrix = np.array([[1 + 1j]], dtype=complex)
+
+    assert np.isclose(
+        loop_hafnian_with_reduction(
+            matrix,
+            np.array([1j]),
+            occupation_numbers=np.array([6]),
+        ),
+        -16 - 45j,
+    )
+
+
+def test_loop_hafnian_with_reduction_on_2_by_2_complex_matrix():
     matrix = np.array(
         [
             [1, 500j],
@@ -71,10 +117,29 @@ def test_loop_hafnian_on_2_by_2_complex_matrix():
         dtype=complex,
     )
 
-    assert np.isclose(loop_hafnian(matrix), 6.0 + 500.0j)
+    assert np.isclose(
+        loop_hafnian_with_reduction(
+            matrix,
+            np.array([0.4, 0.6]),
+            occupation_numbers=np.array([4, 0]),
+        ),
+        3.9856,
+    )
 
 
-def test_loop_hafnian_on_3_by_3_real_matrix():
+def test_loop_hafnian_with_reduction_on_2_by_2_complex_matrix_8_particles():
+    A = np.array([[1 + 2j, 3 + 4j], [3 + 4j, 5 + 6j]])
+
+    diagonal = np.array([-1 - 2j, 3])
+
+    occupation_numbers = np.array([4, 4])
+
+    assert np.isclose(
+        loop_hafnian_with_reduction(A, diagonal, occupation_numbers), 12252 - 5184j
+    )
+
+
+def test_loop_hafnian_with_reduction_on_3_by_3_real_matrix():
     matrix = np.array(
         [
             [1, 2, 3],
@@ -84,10 +149,17 @@ def test_loop_hafnian_on_3_by_3_real_matrix():
         dtype=float,
     )
 
-    assert np.isclose(loop_hafnian(matrix), 49.0)
+    assert np.isclose(
+        loop_hafnian_with_reduction(
+            matrix,
+            np.array([0.1, 0.2, 0.3]),
+            occupation_numbers=np.array([1, 3, 1]),
+        ),
+        51.28824,
+    )
 
 
-def test_loop_hafnian_on_3_by_3_complex_matrix():
+def test_loop_hafnian_with_reduction_on_3_by_3_complex_matrix():
     matrix = np.array(
         [
             [1j, 2, 3j],
@@ -97,10 +169,17 @@ def test_loop_hafnian_on_3_by_3_complex_matrix():
         dtype=complex,
     )
 
-    assert np.isclose(loop_hafnian(matrix), 6 + 43j)
+    assert np.isclose(
+        loop_hafnian_with_reduction(
+            matrix,
+            np.array([0.1, 0.2j, 0.3]),
+            occupation_numbers=np.array([1, 3, 1]),
+        ),
+        12.468 + 16.90776j,
+    )
 
 
-def test_hafnian_on_4_by_4_real_matrix():
+def test_hafnian_with_reduction_on_4_by_4_real_matrix():
     matrix = np.array(
         [
             [1, 2, 3, 4],
@@ -111,10 +190,10 @@ def test_hafnian_on_4_by_4_real_matrix():
         dtype=float,
     )
 
-    assert np.isclose(hafnian(matrix), 60.0)
+    assert np.isclose(hafnian_with_reduction(matrix, np.array([2, 1, 0, 3])), 1344)
 
 
-def test_hafnian_on_4_by_4_complex_matrix():
+def test_hafnian_with_reduction_on_4_by_4_complex_matrix():
     matrix = np.array(
         [
             [1j, 2, 3j, 4],
@@ -125,10 +204,10 @@ def test_hafnian_on_4_by_4_complex_matrix():
         dtype=complex,
     )
 
-    assert np.isclose(hafnian(matrix), 12.0)
+    assert np.isclose(hafnian_with_reduction(matrix, np.array([2, 1, 0, 3])), 960j)
 
 
-def test_loop_hafnian_on_4_by_4_real_matrix():
+def test_loop_hafnian_with_reduction_on_4_by_4_real_matrix():
     matrix = np.array(
         [
             [1, 2, 3, 4],
@@ -139,10 +218,17 @@ def test_loop_hafnian_on_4_by_4_real_matrix():
         dtype=float,
     )
 
-    assert np.isclose(loop_hafnian(matrix), 572.0)
+    assert np.isclose(
+        loop_hafnian_with_reduction(
+            matrix,
+            np.array([0.1, 0.2, 0.3, 0.4]),
+            occupation_numbers=np.array([2, 1, 0, 4]),
+        ),
+        3226.0762112,
+    )
 
 
-def test_loop_hafnian_on_4_by_4_complex_matrix():
+def test_loop_hafnian_with_reduction_on_4_by_4_complex_matrix():
     matrix = np.array(
         [
             [1j, 2, 3j, 4],
@@ -153,10 +239,17 @@ def test_loop_hafnian_on_4_by_4_complex_matrix():
         dtype=complex,
     )
 
-    assert np.isclose(loop_hafnian(matrix), -284.0 + 72.0j)
+    assert np.isclose(
+        loop_hafnian_with_reduction(
+            matrix,
+            np.array([0.1, 0.2j, 0.3, 0.4 + 0.1j]),
+            occupation_numbers=np.array([1, 3, 1, 1]),
+        ),
+        205.376424 + 690.048304j,
+    )
 
 
-def test_hafnian_on_6_by_6_real_matrix():
+def test_hafnian_with_reduction_on_6_by_6_real_matrix():
     matrix = np.array(
         [
             [1, 2, 3, 4, 5, 6],
@@ -169,10 +262,10 @@ def test_hafnian_on_6_by_6_real_matrix():
         dtype=float,
     )
 
-    assert np.isclose(hafnian(matrix), 1262.0)
+    assert np.isclose(hafnian_with_reduction(matrix, np.ones(6, dtype=int)), 1262.0)
 
 
-def test_hafnian_on_6_by_6_complex_matrix():
+def test_hafnian_with_reduction_on_6_by_6_complex_matrix():
     matrix = np.array(
         [
             [1, 2, 3, 4j, 5, 6j],
@@ -185,10 +278,12 @@ def test_hafnian_on_6_by_6_complex_matrix():
         dtype=complex,
     )
 
-    assert np.isclose(hafnian(matrix), 387.0 + 707.0j)
+    assert np.isclose(
+        hafnian_with_reduction(matrix, np.array([1, 1, 1, 1, 0, 2])), -22 + 1192j
+    )
 
 
-def test_loop_hafnian_on_6_by_6_real_matrix():
+def test_loop_hafnian_with_reduction_on_6_by_6_real_matrix():
     matrix = np.array(
         [
             [1, 2, 3, 4, 5, 6],
@@ -201,10 +296,17 @@ def test_loop_hafnian_on_6_by_6_real_matrix():
         dtype=float,
     )
 
-    assert np.isclose(loop_hafnian(matrix), 15195.0)
+    assert np.isclose(
+        loop_hafnian_with_reduction(
+            matrix,
+            np.zeros(6),
+            occupation_numbers=np.ones(6, dtype=int),
+        ),
+        1262,
+    )
 
 
-def test_loop_hafnian_on_6_by_6_complex_matrix():
+def test_loop_hafnian_with_reduction_on_6_by_6_complex_matrix():
     matrix = np.array(
         [
             [1, 2, 3, 4j, 5, 6j],
@@ -217,34 +319,47 @@ def test_loop_hafnian_on_6_by_6_complex_matrix():
         dtype=complex,
     )
 
-    assert np.isclose(loop_hafnian(matrix), 2238.0 + 5273.0j)
+    assert np.isclose(
+        loop_hafnian_with_reduction(
+            matrix,
+            np.zeros(6),
+            occupation_numbers=np.array([1, 1, 1, 1, 0, 2]),
+        ),
+        -22.0 + 1192.0j,
+    )
 
 
 @pytest.mark.monkey
-def test_random_10_by_10_hafnian(generate_symmetric_matrix):
+def test_random_10_by_10_hafnian_with_reduction(generate_symmetric_matrix):
     matrix = generate_symmetric_matrix(10)
 
-    assert hafnian(matrix)
+    hafnian_with_reduction(matrix, np.random.randint(0, 2, 10))
 
 
 @pytest.mark.monkey
-def test_hafnian_of_complex_symmetric_matrix_with_odd_dimension_is_zero(
+def test_hafnian_with_reduction_of_complex_symmetric_matrix_with_odd_dimension_is_zero(
     generate_complex_symmetric_matrix,
 ):
     matrix = generate_complex_symmetric_matrix(3)
 
-    assert np.isclose(hafnian(matrix), 0.0)
+    assert np.isclose(hafnian_with_reduction(matrix, np.ones(3, dtype=int)), 0.0)
 
 
 @pytest.mark.monkey
-def test_loop_hafnian_of_complex_symmetric_block_diagonal_matrix(
+def test_loop_hafnian_with_reduction_of_complex_symmetric_block_diagonal_matrix(
     generate_complex_symmetric_matrix,
 ):
+    occupation_numbers = np.random.randint(0, 2, 5)
+
     submatrix = generate_complex_symmetric_matrix(5)
-    submatrix_loop_hafnian = loop_hafnian(submatrix)
+    submatrix_loop_hafnian = loop_hafnian_with_reduction(
+        submatrix, np.zeros(5), occupation_numbers
+    )
 
     matrix = block_diag(submatrix, np.conj(submatrix))
-    matrix_loop_hafnian = loop_hafnian(matrix)
+    matrix_loop_hafnian = loop_hafnian_with_reduction(
+        matrix, np.zeros(10), np.concatenate([occupation_numbers, occupation_numbers])
+    )
 
     assert np.isclose(
         np.conj(submatrix_loop_hafnian) * submatrix_loop_hafnian,
@@ -252,20 +367,101 @@ def test_loop_hafnian_of_complex_symmetric_block_diagonal_matrix(
     )
 
 
-def test_loop_hafnian_and_hafnian_with_zero_reduction():
-    matrix = np.array(
+def test_hafnian_with_reduction_6_particles():
+    A = np.array(
         [
-            [1j, 2, 3j, 4],
-            [2, 6, 7, 8j],
-            [3j, 7, 3, 4],
-            [4, 8j, 4, 8j],
-        ],
-        dtype=complex,
+            [0.06918447, 0.50455312, 0.52623749, 0.51119496],
+            [0.56996393, 0.62138659, 0.42424946, 0.6582932],
+            [0.79820529, 0.36861047, 0.91219376, 0.18621944],
+            [0.37366373, 0.3069308, 0.29075932, 0.60748435],
+        ]
     )
 
-    reduce_on = (1, 2)
+    A = A + A.T
 
-    assert np.isclose(
-        hafnian_with_reduction(matrix, reduce_on),
-        loop_hafnian_with_reduction(matrix, np.zeros(len(matrix)), reduce_on),
+    haf = hafnian_with_reduction(A, np.array([2, 0, 1, 3]))
+
+    assert np.isclose(haf, 11.024591504142506)
+
+
+def test_hafnian_with_reduction_12_particles():
+    A = np.array(
+        [
+            [0.06918447, 0.50455312, 0.52623749, 0.51119496],
+            [0.56996393, 0.62138659, 0.42424946, 0.6582932],
+            [0.79820529, 0.36861047, 0.91219376, 0.18621944],
+            [0.37366373, 0.3069308, 0.29075932, 0.60748435],
+        ]
     )
+
+    A = A + A.T
+
+    haf = hafnian_with_reduction(A, np.array([6, 3, 2, 3]))
+
+    assert np.isclose(haf, 37655.53201446679)
+
+
+def test_hafnian_with_reduction_12_particles_with_0():
+    A = np.array(
+        [
+            [0.06918447, 0.50455312, 0.52623749, 0.51119496],
+            [0.56996393, 0.62138659, 0.42424946, 0.6582932],
+            [0.79820529, 0.36861047, 0.91219376, 0.18621944],
+            [0.37366373, 0.3069308, 0.29075932, 0.60748435],
+        ]
+    )
+
+    A = A + A.T
+
+    haf = hafnian_with_reduction(A, np.array([7, 4, 0, 3]))
+
+    assert np.isclose(haf, 13629.353597466445)
+
+
+@pytest.mark.monkey
+def test_hafnian_with_reduction_equivalence():
+    for _ in range(10):
+        d = 5
+        max_photons = 4
+        A = np.random.rand(d, d) + 1j * np.random.rand(d, d)
+
+        A = A + A.T
+
+        occupation_numbers = np.random.randint(0, max_photons, d)
+
+        expected = hafnian_with_reduction(
+            reduce_(A, occupation_numbers),
+            np.ones(sum(occupation_numbers), dtype=int),
+        )
+        actual = hafnian_with_reduction(A, occupation_numbers)
+
+        assert np.isclose(expected, actual)
+
+
+@pytest.mark.monkey
+def test_loop_hafnian_with_reduction_equivalence():
+    for _ in range(100):
+        d = 5
+        max_photons = 6
+        A = np.random.rand(d, d) + 1j * np.random.rand(d, d)
+
+        A = A + A.T
+
+        occupation_numbers = np.random.randint(0, max_photons, d)
+
+        diagonal = np.random.rand(d) + 1j * np.random.rand(d)
+
+        reduced_A = reduce_(A, occupation_numbers)
+
+        reduced_diagonal = reduce_(diagonal, occupation_numbers)
+
+        np.fill_diagonal(reduced_A, reduced_diagonal)
+
+        expected = loop_hafnian_with_reduction(
+            reduced_A,
+            np.diag(reduced_A),
+            np.ones(sum(occupation_numbers), dtype=int),
+        )
+        actual = loop_hafnian_with_reduction(A, diagonal, occupation_numbers)
+
+        assert np.isclose(expected, actual)


### PR DESCRIPTION
The `hafnian` and `loop_hafnian` functions were rewritten to account for multiplicities, according to https://arxiv.org/abs/2108.01622.

The tests in `test_hafnian.py` were rewritten accordingly. Two benchmarks are included in `scripts`.

Source: https://arxiv.org/abs/2108.01622