### PR TITLE
fix(api): Deleting `_default_calculator_class` initial value

### DIFF
--- a/piquasso/api/simulator.py
+++ b/piquasso/api/simulator.py
@@ -48,7 +48,7 @@ class Simulator(Computer, _mixins.CodeMixin):
 
     _state_class: Type[State]
     _config_class: Type[Config] = Config
-    _default_calculator_class: Type[BaseCalculator] = BaseCalculator
+    _default_calculator_class: Type[BaseCalculator]
 
     def __init__(
         self,

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -87,7 +87,17 @@ def FakeConfig():
 
 
 @pytest.fixture
-def FakeSimulator(FakeState, FakeConfig, FakePreparation, FakeGate, FakeMeasurement):
+def FakeCalculator():
+    class FakeCalculator(pq.api.calculator.BaseCalculator):
+        pass
+
+    return FakeCalculator
+
+
+@pytest.fixture
+def FakeSimulator(
+    FakeState, FakeConfig, FakePreparation, FakeGate, FakeMeasurement, FakeCalculator
+):
     def fake_calculation(state: FakeState, instruction: pq.Instruction, shots: int):
         return pq.api.result.Result(state=state)
 
@@ -101,5 +111,7 @@ def FakeSimulator(FakeState, FakeConfig, FakePreparation, FakeGate, FakeMeasurem
             FakeGate: fake_calculation,
             FakeMeasurement: fake_calculation,
         }
+
+        _default_calculator_class = FakeCalculator
 
     return FakeSimulator


### PR DESCRIPTION
We should prevent users to write `Simulator` classes which uses the `BaseCalculator`, since `BaseCalculator` implements nothing.