### PR TITLE
feat(config): `validate` flag

### DIFF
--- a/piquasso/_simulators/fock/calculations.py
+++ b/piquasso/_simulators/fock/calculations.py
@@ -56,7 +56,7 @@ def attenuator(state: BaseFockState, instruction: Instruction, shots: int) -> Re
 
     modes = instruction.modes
 
-    if len(modes) != 1:
+    if state._config.validate and len(modes) != 1:
         raise InvalidInstruction(
             f"The instruction should be specified for '{len(modes)}' "
             f"modes: instruction={instruction}"
@@ -64,7 +64,7 @@ def attenuator(state: BaseFockState, instruction: Instruction, shots: int) -> Re
 
     mean_thermal_excitation = instruction._all_params["mean_thermal_excitation"]
 
-    if not np.isclose(mean_thermal_excitation, 0.0):
+    if state._config.validate and not np.isclose(mean_thermal_excitation, 0.0):
         raise InvalidParameter(
             "Non-zero mean thermal excitation is not supported in this backend. "
             f"mean_thermal_excitation={mean_thermal_excitation}"

--- a/piquasso/_simulators/fock/general/state.py
+++ b/piquasso/_simulators/fock/general/state.py
@@ -125,7 +125,7 @@ class FockState(BaseFockState):
     def get_particle_detection_probability(
         self, occupation_number: np.ndarray
     ) -> float:
-        if len(occupation_number) != self.d:
+        if self._config.validate and len(occupation_number) != self.d:
             raise PiquassoException(
                 f"The specified occupation number should have length '{self.d}': "
                 f"occupation_number='{occupation_number}'."
@@ -214,7 +214,9 @@ class FockState(BaseFockState):
         Raises:
             RuntimeError: Raised if the current norm of the state is too close to 0.
         """
-        if np.isclose(self.norm, 0):
+        norm = self.norm
+
+        if self._config.validate and np.isclose(norm, 0):
             raise InvalidState("The norm of the state is 0.")
 
         self._density_matrix = self._density_matrix / self.norm
@@ -227,6 +229,9 @@ class FockState(BaseFockState):
                 Raised, if the density matrix is not positive semidefinite, not
                 self-adjoint or the trace of the density matrix is not 1.
         """
+        if not self._config.validate:
+            return
+
         if not is_selfadjoint(self._density_matrix):
             raise InvalidState(
                 "The density matrix is not self-adjoint:\n"

--- a/piquasso/_simulators/fock/pure/batch_state.py
+++ b/piquasso/_simulators/fock/pure/batch_state.py
@@ -93,12 +93,15 @@ class BatchPureFockState(PureFockState):
     def normalize(self) -> None:
         norms = self.norm
 
-        if any(np.isclose(norm, 0) for norm in norms):
+        if self._config.validate and any(np.isclose(norm, 0) for norm in norms):
             raise InvalidState("The norm of a state in the batch is 0.")
 
         self.state_vector = self.state_vector / self._np.sqrt(norms)
 
     def validate(self) -> None:
+        if not self._config.validate:
+            return
+
         if not all(np.isclose(norm, 1.0) for norm in self.norm):
             raise InvalidState(
                 "The sum of probabilities is not close to 1.0 for at least one state "

--- a/piquasso/_simulators/fock/pure/calculations/homodyne.py
+++ b/piquasso/_simulators/fock/pure/calculations/homodyne.py
@@ -40,7 +40,7 @@ def homodyne_measurement(
 
     phi = instruction.params["phi"]
 
-    if not np.isclose(phi, 0.0):
+    if state._config.validate and not np.isclose(phi, 0.0):
         raise NotImplementedCalculation(
             "'HomodyneMeasurement' with nonzero rotation angle is not yet supported."
         )

--- a/piquasso/_simulators/fock/pure/state.py
+++ b/piquasso/_simulators/fock/pure/state.py
@@ -126,7 +126,7 @@ class PureFockState(BaseFockState):
     def get_particle_detection_probability(
         self, occupation_number: np.ndarray
     ) -> float:
-        if len(occupation_number) != self.d:
+        if self._config.validate and len(occupation_number) != self.d:
             raise PiquassoException(
                 f"The specified occupation number should have length '{self.d}': "
                 f"occupation_number='{occupation_number}'."
@@ -189,7 +189,7 @@ class PureFockState(BaseFockState):
     def normalize(self) -> None:
         norm = self.norm
 
-        if np.isclose(norm, 0):
+        if self._config.validate and np.isclose(norm, 0):
             raise InvalidState("The norm of the state is 0.")
 
         self.state_vector = self.state_vector / self._np.sqrt(norm)
@@ -201,6 +201,9 @@ class PureFockState(BaseFockState):
             InvalidState:
                 Raised, if the norm of the state vector is not close to 1.0.
         """
+        if not self._config.validate:
+            return
+
         sum_of_probabilities = sum(self.fock_probabilities)
 
         if not self._np.isclose(sum_of_probabilities, 1.0):

--- a/piquasso/_simulators/fock/state.py
+++ b/piquasso/_simulators/fock/state.py
@@ -31,7 +31,8 @@ class BaseFockState(State, abc.ABC):
     ) -> None:
         super().__init__(calculator=calculator, config=config)
         self._d = d
-        self._space = get_fock_space_basis(d=d, cutoff=config.cutoff)  # type: ignore
+        cutoff = self._config.cutoff
+        self._space = get_fock_space_basis(d=d, cutoff=cutoff)  # type: ignore
 
     @property
     def d(self) -> int:
@@ -156,7 +157,7 @@ class BaseFockState(State, abc.ABC):
         #    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
         #    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-        if self.d != 1 and (modes is None or len(modes) != 1):
+        if self._config.validate and self.d != 1 and (modes is None or len(modes) != 1):
             raise InvalidModes(
                 "The Wigner function can only be calculated for a single mode: "
                 f"modes={modes}."

--- a/piquasso/_simulators/gaussian/calculations.py
+++ b/piquasso/_simulators/gaussian/calculations.py
@@ -517,7 +517,6 @@ def threshold_measurement(
 
 def _generate_threshold_samples_using_torontonian(state, instruction, shots):
     is_displaced = state._is_displaced()
-
     rng = state._config.rng
     hbar = state._config.hbar
 
@@ -654,7 +653,7 @@ def deterministic_gaussian_channel(
     Y = instruction._all_params["Y"] * state._config.hbar
     modes = instruction.modes
 
-    if len(X) != 2 * len(modes) or len(Y) != 2 * len(modes):
+    if state._config.validate and len(X) != 2 * len(modes) or len(Y) != 2 * len(modes):
         raise InvalidInstruction(
             f"The instruction should be specified for '{len(modes)}' modes: "
             f"instruction={instruction}"

--- a/piquasso/_simulators/gaussian/state.py
+++ b/piquasso/_simulators/gaussian/state.py
@@ -118,12 +118,13 @@ class GaussianState(State):
                 - the covariance matrix doesn't fulfill the Robertson-Schrödinger
                   uncertainty relations.
         """
-
         self._validate_mean(self.xpxp_mean_vector, self.d)
         self._validate_cov(self.xpxp_covariance_matrix, self.d)
 
-    @staticmethod
-    def _validate_mean(mean: np.ndarray, d: int) -> None:
+    def _validate_mean(self, mean: np.ndarray, d: int) -> None:
+        if not self._config.validate:
+            return
+
         expected_shape = (2 * d,)
 
         if not mean.shape == expected_shape:
@@ -133,6 +134,9 @@ class GaussianState(State):
             )
 
     def _validate_cov(self, cov: np.ndarray, d: int) -> None:
+        if not self._config.validate:
+            return
+
         expected_shape = (2 * d,) * 2
 
         if not cov.shape == expected_shape:
@@ -800,7 +804,7 @@ class GaussianState(State):
 
         np = self._calculator.np
 
-        if not is_symmetric(A):
+        if self._config.validate and not is_symmetric(A):
             raise InvalidParameter("The specified matrix is not symmetric.")
 
         state = self.rotated(phi)
@@ -884,7 +888,7 @@ class GaussianState(State):
     def get_particle_detection_probability(
         self, occupation_number: np.ndarray
     ) -> float:
-        if len(occupation_number) != self.d:
+        if self._config.validate and len(occupation_number) != self.d:
             raise PiquassoException(
                 f"The specified occupation number should have length '{self.d}': "
                 f"occupation_number='{occupation_number}'."
@@ -916,7 +920,7 @@ class GaussianState(State):
             float: The threshold particle number detection probability.
         """
 
-        if len(occupation_number) != self.d:
+        if self._config.validate and len(occupation_number) != self.d:
             raise PiquassoException(
                 f"The specified occupation number should have length '{self.d}': "
                 f"occupation_number='{occupation_number}'."
@@ -924,7 +928,9 @@ class GaussianState(State):
 
         occupation_number_np = np.array(occupation_number)
 
-        if not np.array_equal(occupation_number_np, occupation_number_np.astype(bool)):
+        if self._config.validate and not np.array_equal(
+            occupation_number_np, occupation_number_np.astype(bool)
+        ):
             raise PiquassoException(
                 f"The specified occupation numbers must only contain '0' or '1': "
                 f"occupation_number='{occupation_number}'."

--- a/piquasso/_simulators/sampling/calculations.py
+++ b/piquasso/_simulators/sampling/calculations.py
@@ -43,7 +43,7 @@ def state_vector(state: SamplingState, instruction: Instruction, shots: int) -> 
     coefficient = instruction._all_params["coefficient"]
     occupation_numbers = instruction._all_params["occupation_numbers"]
 
-    if len(occupation_numbers) != state.d:
+    if state._config.validate and len(occupation_numbers) != state.d:
         raise InvalidState(
             f"The occupation numbers '{occupation_numbers}' are not well-defined "
             f"on '{state.d}' modes: instruction={instruction}"
@@ -135,8 +135,10 @@ def particle_number_measurement(
     algorithm.
     """
 
-    if len(state._occupation_numbers) != 1 and not np.isclose(
-        state._coefficients[0], 1.0
+    if (
+        state._config.validate
+        and len(state._occupation_numbers) != 1
+        and not np.isclose(state._coefficients[0], 1.0)
     ):
         raise NotImplementedCalculation(
             f"The instruction {instruction} is not supported for states defined using "

--- a/piquasso/_simulators/sampling/state.py
+++ b/piquasso/_simulators/sampling/state.py
@@ -58,6 +58,8 @@ class SamplingState(State):
             InvalidState: If the interferometer matrix is non-unitary, or the input
                 state is invalid.
         """
+        if not self._config.validate:
+            return
 
         if not is_unitary(self.interferometer):
             raise InvalidState("The interferometer matrix is not unitary.")
@@ -85,7 +87,7 @@ class SamplingState(State):
     def get_particle_detection_probability(
         self, occupation_number: np.ndarray
     ) -> float:
-        if len(occupation_number) != self.d:
+        if self._config.validate and len(occupation_number) != self.d:
             raise PiquassoException(
                 f"The specified occupation number should have length '{self.d}': "
                 f"occupation_number='{occupation_number}'."

--- a/piquasso/api/config.py
+++ b/piquasso/api/config.py
@@ -43,6 +43,12 @@ class Config(_mixins.CodeMixin):
         `False`.
     :ivar cache_size:
         The maximum size of the cache for certain algorithms. Defaults to `2.0`.
+    :ivar validate:
+        Validates computations during simulation. Defaults to `True`. If set to `False`,
+        it is not guaranteed that the calculations will be correct, and it is advised
+        to only turn it off when necessary. Moreover, it is also not guaranteed that all
+        validations are turned off by setting `validate=False` (e.g., specifying invalid
+        modes will still yield an error).
     """
 
     def __init__(
@@ -55,6 +61,7 @@ class Config(_mixins.CodeMixin):
         seed_sequence: Optional[Any] = None,
         use_torontonian: bool = False,
         cache_size: int = 32,
+        validate: bool = True,
     ):
         self._original_seed_sequence = seed_sequence
         self.seed_sequence = seed_sequence or int.from_bytes(
@@ -66,6 +73,7 @@ class Config(_mixins.CodeMixin):
         self.cutoff = cutoff
         self.measurement_cutoff = measurement_cutoff
         self.dtype = np.float64 if dtype is float else dtype
+        self.validate = validate
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, Config):
@@ -78,6 +86,7 @@ class Config(_mixins.CodeMixin):
             and self.cutoff == other.cutoff
             and self.measurement_cutoff == other.measurement_cutoff
             and self.dtype == other.dtype
+            and self.validate == other.validate
         )
 
     def _as_code(self) -> str:
@@ -98,6 +107,8 @@ class Config(_mixins.CodeMixin):
             non_default_params["measurement_cutoff"] = self.measurement_cutoff
         if self.dtype != default_config.dtype:
             non_default_params["dtype"] = "np." + self.dtype.__name__
+        if self.validate != default_config.validate:
+            non_default_params["validate"] = self.validate
 
         if len(non_default_params) == 0:
             return "pq.Config()"

--- a/tests/_simulators/fock/general/test_state.py
+++ b/tests/_simulators/fock/general/test_state.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
+
 import numpy as np
 
 import piquasso as pq
@@ -109,3 +111,30 @@ def test_FockState_quadratures_mean_variance():
     assert np.isclose(variance_on_1st, 0.9112844, rtol=1e-5)
     assert np.isclose(variance_on_2nd, 1, rtol=1e-5)
     assert np.isclose(variance_on_3rd, 1, rtol=1e-5)
+
+
+def test_FockState_non_selfadjoint_density_matrix_raises_InvalidState():
+
+    state = pq.FockState(d=1, calculator=pq.NumpyCalculator())
+
+    non_selfadjoint_matrix = np.array([[1, 2], [3, 4]])
+
+    state._density_matrix = non_selfadjoint_matrix
+
+    with pytest.raises(pq.api.exceptions.InvalidState) as error:
+        state.validate()
+
+    assert "The density matrix is not self-adjoint" in error.value.args[0]
+
+
+def test_FockState_non_selfadjoint_density_matrix_no_error_if_validate_False():
+
+    state = pq.FockState(
+        d=1, calculator=pq.NumpyCalculator(), config=pq.Config(validate=False)
+    )
+
+    non_selfadjoint_matrix = np.array([[1, 2], [3, 4]])
+
+    state._density_matrix = non_selfadjoint_matrix
+
+    state.validate()

--- a/tests/_simulators/fock/pure/test_batch.py
+++ b/tests/_simulators/fock/pure/test_batch.py
@@ -68,6 +68,27 @@ def test_BatchPureFockState_without_normalization():
     )
 
 
+def test_BatchPureFockState_without_normalization_but_validate_False():
+    with pq.Program() as first_preparation:
+        pq.Q() | pq.Vacuum()
+        pq.Q(1) | pq.Squeezing(r=0.1, phi=np.pi / 4)
+
+    with pq.Program() as second_preparation:
+        pq.Q() | pq.Vacuum()
+        pq.Q(0) | pq.Displacement(r=1.0, phi=np.pi / 10)
+
+    with pq.Program() as batch_program:
+        pq.Q() | pq.BatchPrepare([first_preparation, second_preparation])
+
+        pq.Q() | pq.Beamsplitter(theta=np.pi / 6, phi=np.pi / 3)
+
+    simulator = pq.PureFockSimulator(d=2, config=pq.Config(cutoff=5, validate=False))
+
+    batch_state = simulator.execute(batch_program).state
+
+    batch_state.validate()
+
+
 def test_invalid_BatchPureFockState_normalize():
     with pq.Program() as first_preparation:
         pq.Q() | pq.Vacuum()

--- a/tests/_simulators/fock/pure/test_state.py
+++ b/tests/_simulators/fock/pure/test_state.py
@@ -304,3 +304,44 @@ def test_PureFockState_displaced_state_variance_photon_number():
     variance = state.variance_photon_number()
 
     assert np.isclose(variance, r**2)
+
+
+def test_PureFockState_unnormalized_state_raises_InvalidState():
+    d = 1
+    low_cutoff = 3
+
+    high_displacement = 3.0
+
+    with pq.Program() as program:
+        pq.Q() | pq.Vacuum()
+
+        pq.Q(0) | pq.Displacement(high_displacement)
+
+    simulator = pq.PureFockSimulator(d=d, config=pq.Config(cutoff=low_cutoff))
+    state = simulator.execute(program).state
+
+    with pytest.raises(pq.api.exceptions.InvalidState) as error:
+        state.validate()
+
+    assert "The sum of probabilities is" in error.value.args[0]
+
+
+def test_PureFockState_unnormalized_state_validate_False():
+    d = 1
+    low_cutoff = 3
+
+    high_displacement = 3.0
+
+    with pq.Program() as program:
+        pq.Q() | pq.Vacuum()
+
+        pq.Q(0) | pq.Displacement(high_displacement)
+
+    simulator = pq.PureFockSimulator(
+        d=d, config=pq.Config(cutoff=low_cutoff, validate=False)
+    )
+    state = simulator.execute(program).state
+
+    assert not np.isclose(state.norm, 1.0)
+
+    state.validate()

--- a/tests/_simulators/gaussian/test_state.py
+++ b/tests/_simulators/gaussian/test_state.py
@@ -52,6 +52,39 @@ def test_xpxp_representation(state, assets):
     )
 
 
+def test_set_xpxp_mean_vector_invalid_shape_raises_InvalidState(state):
+    with pytest.raises(pq.api.exceptions.InvalidState) as error:
+        state.xpxp_mean_vector = np.array([1, 2, 3])
+
+    assert "Invalid 'mean' vector shape" in error.value.args[0]
+
+
+def test_set_xpxp_mean_vector_invalid_shape_validate_False():
+    state = pq.GaussianState(
+        2, calculator=pq.NumpyCalculator(), config=pq.Config(validate=False)
+    )
+
+    state.xpxp_mean_vector = np.array([1, 2, 3])
+
+
+def test_set_xpxp_covariance_matrix_invalid_shape_raises_InvalidState(state):
+    with pytest.raises(pq.api.exceptions.InvalidState) as error:
+        state.xpxp_covariance_matrix = np.array([1, 2, 3])
+
+    assert "Invalid 'cov' matrix shape" in error.value.args[0]
+
+
+def test_set_xpxp_covariance_matrix_invalid_shape_validate_False():
+    state = pq.GaussianState(
+        2, calculator=pq.NumpyCalculator(), config=pq.Config(validate=False)
+    )
+
+    with pytest.raises(Exception) as exc:
+        state.xpxp_covariance_matrix = np.array([1, 2, 3])
+
+    assert not isinstance(exc, pq.api.exceptions.PiquassoException)
+
+
 def test_representation_roundtrip(state):
     initial_mean_vector = state.xpxp_mean_vector
     initial_covariance_matrix = state.xpxp_covariance_matrix

--- a/tests/_simulators/sampling/test_preparations.py
+++ b/tests/_simulators/sampling/test_preparations.py
@@ -33,6 +33,16 @@ def test_initial_state_raises_InvalidState_for_nonnormalized_input_state():
     assert error.value.args[0] == "The state is not normalized: norm=0.25"
 
 
+def test_initial_state_for_nonnormalized_input_state_validate_False():
+    with pq.Program() as program:
+        pq.Q() | pq.StateVector([1, 1, 1, 0, 0]) * 0.5
+
+    simulator = pq.SamplingSimulator(d=5, config=pq.Config(validate=False))
+    state = simulator.execute(program).state
+
+    state.validate()
+
+
 def test_initial_state_raises_InvalidState_for_occupation_numbers_of_differing_length():
     with pq.Program() as program:
         pq.Q() | pq.StateVector([1, 1, 1, 0, 0]) * 1 / np.sqrt(2)

--- a/tests/api/test_config.py
+++ b/tests/api/test_config.py
@@ -48,6 +48,7 @@ def test_eq():
         use_torontonian=True,
         cutoff=6,
         measurement_cutoff=4,
+        validate=False,
     )
 
     assert config1 == config1
@@ -56,7 +57,7 @@ def test_eq():
     assert not (config1 == config3)
 
 
-def test_as_code():
+def test_as_code_dtype():
     conf_f32 = pq.Config(dtype=np.float32)
     conf_f64 = pq.Config(dtype=np.float64)
     conf_f = pq.Config(dtype=float)
@@ -68,6 +69,16 @@ def test_as_code():
     assert as_code_f32 == "pq.Config(dtype=np.float32)"
     assert as_code_f64 == "pq.Config()"
     assert as_code_f == "pq.Config()"
+
+
+def test_as_code_validate():
+    default = pq.Config()
+    default_2 = pq.Config(validate=True)
+    no_validate_config = pq.Config(validate=False)
+
+    assert default._as_code() == default_2._as_code()
+    assert default._as_code() == "pq.Config()"
+    assert no_validate_config._as_code() == "pq.Config(validate=False)"
 
 
 def test_complex_dtype():


### PR DESCRIPTION
In `Config`, a `validate` boolean flag is defined to enable users to turn off some validations during the simulation.

This may be useful for 2 reasons:
- Sometimes the validations are slow (e.g., `FockState.validate`) and unnecessary. Turning off validations could yield a slight performance increase in some cases.
- Disabling validations with TensorFlow or JAX can be useful, since some validations often cannot be compiled using XLA. It would be a win-win situation if one could validate user input while not hindering XLA compilation.