### PR TITLE
feat!(api): Make `BaseConnector` abstract

### DIFF
--- a/piquasso/_simulators/connectors/numpy_/connector.py
+++ b/piquasso/_simulators/connectors/numpy_/connector.py
@@ -17,12 +17,19 @@ import scipy
 
 import numpy as np
 
-from piquasso._math.permanent import permanent
+from piquasso._math.permanent import permanent as permanent_with_reduction
 from piquasso._math.hafnian import hafnian_with_reduction, loop_hafnian_with_reduction
 
 from ..connector import BuiltinConnector
 
 from .interferometer import calculate_interferometer_on_fock_space
+
+
+def instancemethod(func):
+    def wrapped(self, *args, **kwargs):
+        return func(*args, **kwargs)
+
+    return wrapped
 
 
 class NumpyConnector(BuiltinConnector):
@@ -31,26 +38,22 @@ class NumpyConnector(BuiltinConnector):
     This is enabled by default in the built-in simulators.
     """
 
-    def __init__(self):
-        self.np = np
-        self.fallback_np = np
-        self.forward_pass_np = np
-        self.block_diag = scipy.linalg.block_diag
-        self.block = np.block
-        self.logm = scipy.linalg.logm
-        self.expm = scipy.linalg.expm
-        self.powm = np.linalg.matrix_power
-        self.polar = scipy.linalg.polar
-        self.svd = np.linalg.svd
-        self.schur = scipy.linalg.schur
+    np = fallback_np = forward_pass_np = np
 
-        self.permanent = permanent
-        self.hafnian = hafnian_with_reduction
-        self.loop_hafnian = loop_hafnian_with_reduction
-
-        self.calculate_interferometer_on_fock_space = (
-            calculate_interferometer_on_fock_space
-        )
+    block_diag = instancemethod(scipy.linalg.block_diag)
+    block = instancemethod(np.block)
+    logm = instancemethod(scipy.linalg.logm)
+    expm = instancemethod(scipy.linalg.expm)
+    powm = instancemethod(np.linalg.matrix_power)
+    polar = instancemethod(scipy.linalg.polar)
+    svd = instancemethod(np.linalg.svd)
+    schur = instancemethod(scipy.linalg.schur)
+    permanent = instancemethod(permanent_with_reduction)
+    hafnian = instancemethod(hafnian_with_reduction)
+    loop_hafnian = instancemethod(loop_hafnian_with_reduction)
+    calculate_interferometer_on_fock_space = instancemethod(
+        calculate_interferometer_on_fock_space
+    )
 
     def sqrtm(self, matrix):
         return scipy.linalg.sqrtm(matrix).astype(np.complex128)

--- a/piquasso/_simulators/connectors/tensorflow_/connector.py
+++ b/piquasso/_simulators/connectors/tensorflow_/connector.py
@@ -337,3 +337,12 @@ class TensorflowConnector(BuiltinConnector):
                 return 1
 
         return _TrivialTraceType(self)
+
+    def permanent(self, matrix, rows, columns):
+        raise NotImplementedError()
+
+    def hafnian(self, matrix, reduce_on):
+        raise NotImplementedError()
+
+    def loop_hafnian(self, matrix, diagonal, reduce_on):
+        raise NotImplementedError()

--- a/piquasso/api/connector.py
+++ b/piquasso/api/connector.py
@@ -19,8 +19,6 @@ from typing import Any, Tuple
 
 import numpy
 
-from piquasso.api.exceptions import NotImplementedCalculation
-
 
 class BaseConnector(abc.ABC):
     """The base class for encapsulating a framework.
@@ -58,17 +56,19 @@ class BaseConnector(abc.ABC):
 
         return self
 
+    @abc.abstractmethod
     def preprocess_input_for_custom_gradient(self, value):
         """
         Applies modifications to inputs in custom gradients.
         """
-        raise NotImplementedCalculation()
 
+    @abc.abstractmethod
     def permanent(
         self, matrix: numpy.ndarray, rows: Tuple[int, ...], columns: Tuple[int, ...]
     ) -> float:
-        raise NotImplementedCalculation()
+        """Calculates the permanent of a matrix with row and column repetitions."""
 
+    @abc.abstractmethod
     def hafnian(self, matrix: numpy.ndarray, reduce_on: numpy.ndarray) -> float:
         r"""Calculates the hafnian of a matrix with prescribed reduction array.
 
@@ -83,8 +83,8 @@ class BaseConnector(abc.ABC):
         Returns:
             float: The hafnian of the matrix.
         """
-        raise NotImplementedCalculation()
 
+    @abc.abstractmethod
     def loop_hafnian(
         self, matrix: numpy.ndarray, diagonal: numpy.ndarray, reduce_on: numpy.ndarray
     ) -> float:
@@ -103,36 +103,37 @@ class BaseConnector(abc.ABC):
         Returns:
             float: The hafnian of the matrix.
         """
-        raise NotImplementedCalculation()
 
+    @abc.abstractmethod
     def assign(self, array, index, value):
         """Item assignment."""
-        raise NotImplementedCalculation()
 
+    @abc.abstractmethod
     def scatter(self, indices, updates, shape):
         """Filling an array of a given shape with the given indices and update values.
 
         Equivalent to :func:`tf.scatter_nd`.
         """
-        raise NotImplementedCalculation()
 
+    @abc.abstractmethod
     def embed_in_identity(self, matrix, indices, dim):
-        raise NotImplementedCalculation()
+        """Embeds a matrix in identity."""
 
+    @abc.abstractmethod
     def block(self, arrays):
         """Assembling submatrices into a single matrix.
 
         Equivalent to :func:`numpy.block`.
         """
-        raise NotImplementedCalculation()
 
+    @abc.abstractmethod
     def block_diag(self, *arrs):
         """Putting together matrices as a block diagonal matrix.
 
         Equivalent to :func:`scipy.linalg.block_diag`.
         """
-        raise NotImplementedCalculation()
 
+    @abc.abstractmethod
     def polar(self, matrix, side="right"):
         """Polar decomposition.
 
@@ -142,8 +143,8 @@ class BaseConnector(abc.ABC):
             matrix (numpy.ndarray): The input matrix
             side (str, optional): The order of the decomposition. Defaults to "right".
         """
-        raise NotImplementedCalculation()
 
+    @abc.abstractmethod
     def logm(self, matrix):
         """Matrix logarithm.
 
@@ -153,8 +154,7 @@ class BaseConnector(abc.ABC):
             matrix (numpy.ndarray): The input matrix.
         """
 
-        raise NotImplementedCalculation()
-
+    @abc.abstractmethod
     def expm(self, matrix):
         """Matrix exponential.
 
@@ -163,8 +163,8 @@ class BaseConnector(abc.ABC):
         Args:
             matrix (numpy.ndarray): The input matrix.
         """
-        raise NotImplementedCalculation()
 
+    @abc.abstractmethod
     def powm(self, matrix, power):
         """Matrix power.
 
@@ -173,48 +173,48 @@ class BaseConnector(abc.ABC):
         Args:
             matrix (numpy.ndarray): The input matrix.
         """
-        raise NotImplementedCalculation()
 
+    @abc.abstractmethod
     def custom_gradient(self, func):
         """Custom gradient wrapper.
 
         Args:
             func: The function for which custom gradient is defined.
         """
-        raise NotImplementedCalculation()
 
+    @abc.abstractmethod
     def accumulator(self, dtype, size, **kwargs):
         """Datatype to collect NumPy arrays.
 
         Common generalization of a Python list and
         `tf.TensorArray <https://www.tensorflow.org/api_docs/python/tf/TensorArray>`_.
         """
-        raise NotImplementedCalculation()
 
+    @abc.abstractmethod
     def write_to_accumulator(self, accumulator, index, value):
         """Append an element to the accumulator.
 
         Common generalization of a Python list appending and
         `tf.TensorArray.write <https://www.tensorflow.org/api_docs/python/tf/TensorArray#write>`_.
         """  # noqa: E501
-        raise NotImplementedCalculation()
 
+    @abc.abstractmethod
     def stack_accumulator(self, accumulator):
         """Stack elements in the accumulator.
 
         Common generalization of :func:`numpy.stack` and
         `tf.TensorArray.stack <https://www.tensorflow.org/api_docs/python/tf/TensorArray#stack>`_.
         """  # noqa: E501
-        raise NotImplementedCalculation()
 
+    @abc.abstractmethod
     def decorator(self, func):
         """Decorates heavy computations in Piquasso.
 
         Args:
             func: Function to decorate.
         """
-        raise NotImplementedCalculation()
 
+    @abc.abstractmethod
     def gather_along_axis_1(self, array, indices):
         """Gathering values along axis 1 of a matrix.
 
@@ -222,16 +222,16 @@ class BaseConnector(abc.ABC):
             Gather along axis 1 was terribly slow in Tensorflow, see
             https://github.com/tensorflow/ranking/issues/160.
         """
-        raise NotImplementedCalculation()
 
+    @abc.abstractmethod
     def transpose(self, matrix):
         """Matrix transposition.
 
         Args:
             matrix (numpy.ndarray): The input matrix.
         """
-        raise NotImplementedCalculation()
 
+    @abc.abstractmethod
     def calculate_interferometer_on_fock_space(self, interferometer, helper_indices):
         """Calculates the interferometer unitary matrix on the Fock space.
 
@@ -243,4 +243,3 @@ class BaseConnector(abc.ABC):
             All the n-particle unitary matrices corresponding to the interferometer up
             to cutoff.
         """
-        raise NotImplementedCalculation()

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -17,6 +17,8 @@ import pytest
 
 import numpy as np
 
+from unittest.mock import patch
+
 import piquasso as pq
 from piquasso.api.connector import BaseConnector
 
@@ -91,7 +93,10 @@ def FakeConnector():
     class FakeConnector(pq.api.connector.BaseConnector):
         pass
 
-    return FakeConnector
+    p = patch.multiple(FakeConnector, __abstractmethods__=set())
+    p.start()
+    yield FakeConnector
+    p.stop()
 
 
 @pytest.fixture

--- a/tests/api/test_connector.py
+++ b/tests/api/test_connector.py
@@ -13,154 +13,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
+from unittest.mock import patch
 
 import pytest
 
 import piquasso as pq
-from piquasso.api.exceptions import NotImplementedCalculation
 
 
-@pytest.fixture
-def dummy_matrix():
-    return np.array([[0.0]])
-
-
-@pytest.fixture
-def dummy_array():
-    return np.array([0.0])
-
-
-@pytest.fixture
-def dummy_occupation_number():
-    return (0,)
-
-
-@pytest.fixture
-def empty_connector():
-    class EmptyConnector(pq.api.connector.BaseConnector):
-        def __init__(self) -> None:
-            super().__init__()
-
-    return EmptyConnector()
-
-
-def test_BaseConnector_raises_NotImplementedCalculation_for_hafnian(
-    empty_connector,
-    dummy_matrix,
-    dummy_occupation_number,
-):
-    with pytest.raises(NotImplementedCalculation):
-        empty_connector.hafnian(dummy_matrix, dummy_occupation_number)
-
-
-def test_BaseConnector_raises_NotImplementedCalculation_for_loop_hafnian(
-    empty_connector, dummy_matrix, dummy_array, dummy_occupation_number
-):
-    with pytest.raises(NotImplementedCalculation):
-        empty_connector.loop_hafnian(dummy_matrix, dummy_array, dummy_occupation_number)
-
-
-def test_BaseConnector_raises_NotImplementedCalculation_for_assign(
-    empty_connector,
-    dummy_array,
-):
-    with pytest.raises(NotImplementedCalculation):
-        empty_connector.assign(dummy_array, index=0, value=3)
-
-
-def test_BaseConnector_raises_NotImplementedCalculation_for_scatter(
-    empty_connector,
-):
-    with pytest.raises(NotImplementedCalculation):
-        empty_connector.scatter(indices=[], updates=[], shape=(3, 3))
-
-
-def test_BaseConnector_raises_NotImplementedCalculation_for_block(
-    empty_connector,
-    dummy_matrix,
-):
-    with pytest.raises(NotImplementedCalculation):
-        empty_connector.block(
-            [[dummy_matrix, dummy_matrix], [dummy_matrix, dummy_matrix]]
-        )
-
-
-def test_BaseConnector_raises_NotImplementedCalculation_for_block_diag(
-    empty_connector,
-    dummy_matrix,
-):
-    with pytest.raises(NotImplementedCalculation):
-        empty_connector.block_diag(dummy_matrix, dummy_matrix)
-
-
-def test_BaseConnector_raises_NotImplementedCalculation_for_polar(
-    empty_connector,
-    dummy_matrix,
-):
-    with pytest.raises(NotImplementedCalculation):
-        empty_connector.polar(dummy_matrix, side="left")
-
-
-def test_BaseConnector_raises_NotImplementedCalculation_for_logm(
-    empty_connector,
-    dummy_matrix,
-):
-    with pytest.raises(NotImplementedCalculation):
-        empty_connector.logm(dummy_matrix)
-
-
-def test_BaseConnector_raises_NotImplementedCalculation_for_expm(
-    empty_connector,
-    dummy_matrix,
-):
-    with pytest.raises(NotImplementedCalculation):
-        empty_connector.expm(dummy_matrix)
-
-
-def test_BaseConnector_raises_NotImplementedCalculation_for_powm(
-    empty_connector,
-    dummy_matrix,
-):
-    with pytest.raises(NotImplementedCalculation):
-        empty_connector.powm(dummy_matrix, 42)
-
-
-def test_BaseConnector_raises_NotImplementedCalculation_for_accumulator(
-    empty_connector,
-):
-    with pytest.raises(NotImplementedCalculation):
-        empty_connector.accumulator(dtype=complex, size=5)
-
-
-def test_BaseConnector_raises_NotImplementedCalculation_for_write_to_accumulator(
-    empty_connector,
-):
-    with pytest.raises(NotImplementedCalculation):
-        empty_connector.write_to_accumulator(accumulator=[], index=0, value=1)
-
-
-def test_BaseConnector_raises_NotImplementedCalculation_for_stack_accumulator(
-    empty_connector,
-):
-    with pytest.raises(NotImplementedCalculation):
-        empty_connector.stack_accumulator(accumulator=[])
-
-
-def test_BaseConnector_raises_NotImplementedCalculation_gather_along_axis_1(
-    empty_connector, dummy_matrix
-):
-    with pytest.raises(NotImplementedCalculation):
-        empty_connector.gather_along_axis_1(
-            array=dummy_matrix, indices=[[1, 2], [3, 4]]
-        )
-
-
-def test_BaseConnector_raises_NotImplementedCalculation_transpose(
-    empty_connector, dummy_matrix
-):
-    with pytest.raises(NotImplementedCalculation):
-        empty_connector.transpose(matrix=dummy_matrix)
+def test_BaseConnector_cannot_be_instantiated():
+    with pytest.raises(Exception):
+        pq.api.connector.BaseConnector()
 
 
 def test_BaseConnector_with_overriding_defaults():
@@ -179,7 +41,11 @@ def test_BaseConnector_with_overriding_defaults():
 
             self.loop_hafnian = plugin_loop_hafnian
 
+    p = patch.multiple(PluginConnector, __abstractmethods__=set())
+
+    p.start()
     plugin_connector = PluginConnector()
+    p.stop()
 
     assert plugin_connector.loop_hafnian is plugin_loop_hafnian
 


### PR DESCRIPTION
`BaseConnector` was not abstact before, one could technically instantiate it, but basically all methods raise a `NotImplementedError`. This is wrong, since in theory if there is a plugin writing a custom `BaseConnector`, simulations could fail between minor versions, since we can't guarantee that we won't start using a connector method in a calculation not used before.