### PR TITLE
chore(tox): Ignoring `cvqnn-with-tensorflow.ipynb`

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,7 @@ commands =
     black --version
     black --check .
     mypy piquasso
-    pytest --nbmake docs
+    pytest --nbmake docs/tutorials --ignore=docs/tutorials/cvqnn-with-tensorflow.ipynb
     # NOTE: `coverage run -m pytest` imports the piquasso module from path, instead
     # of the installed piquasso. To remedy this, one usually uses the
     # `--import-mode=append` flag in case of pytest, but it fails to work with


### PR DESCRIPTION
The notebook `cvqnn-with-tensorflow.ipynb` testing is very slow, therefore it is best to ignore it in `tox`.