### PR TITLE
chore!: Added/updated `__repr__` methods

### DIFF
--- a/piquasso/_simulators/fock/general/state.py
+++ b/piquasso/_simulators/fock/general/state.py
@@ -101,7 +101,7 @@ class FockState(BaseFockState):
                 tuple(col_occupation_numbers[index]),
             )
 
-    def __repr__(self) -> str:
+    def __str__(self) -> str:
         return " + ".join(
             [
                 str(coefficient) + str(basis)

--- a/piquasso/_simulators/fock/pure/batch_state.py
+++ b/piquasso/_simulators/fock/pure/batch_state.py
@@ -62,7 +62,7 @@ class BatchPureFockState(PureFockState):
             for state_vector in self._batch_state_vectors
         ]
 
-    def __repr__(self) -> str:
+    def __str__(self) -> str:
         partial_strings = []
         for partial_nonzero_elements in self.nonzero_elements:
             partial_strings.append(

--- a/piquasso/_simulators/fock/pure/state.py
+++ b/piquasso/_simulators/fock/pure/state.py
@@ -101,7 +101,7 @@ class PureFockState(BaseFockState):
             [str(coefficient) + str(basis) for coefficient, basis in nonzero_elements]
         )
 
-    def __repr__(self) -> str:
+    def __str__(self) -> str:
         return self._get_repr_for_single_state_vector(self.nonzero_elements)
 
     def __eq__(self, other: object) -> bool:

--- a/piquasso/api/config.py
+++ b/piquasso/api/config.py
@@ -153,3 +153,6 @@ class Config(_mixins.CodeMixin):
         config_copy.rng = self.rng
 
         return config_copy
+
+    def __repr__(self):
+        return self._as_code()[3:]

--- a/piquasso/api/connector.py
+++ b/piquasso/api/connector.py
@@ -56,6 +56,9 @@ class BaseConnector(abc.ABC):
 
         return self
 
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}()"
+
     @abc.abstractmethod
     def preprocess_input_for_custom_gradient(self, value):
         """

--- a/piquasso/api/instruction.py
+++ b/piquasso/api/instruction.py
@@ -182,7 +182,7 @@ class Instruction(_mixins.DictMixin, _mixins.RegisterMixin, _mixins.CodeMixin):
 
         classname = self.__class__.__name__
 
-        return f"<pq.{classname}({params}{modes})>"
+        return f"{classname}({params}{modes})"
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, Instruction):

--- a/piquasso/api/program.py
+++ b/piquasso/api/program.py
@@ -171,3 +171,6 @@ class Program(_mixins.DictMixin, _mixins.RegisterMixin, _mixins.CodeMixin):
             script += four_spaces + "pass"
 
         return script
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}(instructions={self.instructions})"

--- a/piquasso/api/result.py
+++ b/piquasso/api/result.py
@@ -39,7 +39,7 @@ class Result:
         )
 
     def __repr__(self) -> str:
-        return f"<Result samples={self.samples} state={self.state}>"
+        return f"Result(samples={self.samples}, state={self.state})"
 
     def to_subgraph_nodes(self) -> List[List[int]]:
         """Convert samples to subgraph modes.

--- a/piquasso/api/simulator.py
+++ b/piquasso/api/simulator.py
@@ -273,3 +273,6 @@ class Simulator(Computer, _mixins.CodeMixin):
         return self.execute_instructions(
             instructions, initial_state=initial_state, shots=shots
         )
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}(d={self.d}, config={self.config}, connector={self._connector})"  # noqa: E501

--- a/piquasso/api/state.py
+++ b/piquasso/api/state.py
@@ -98,3 +98,6 @@ class State(abc.ABC):
         Returns:
             float: The probability of detection.
         """
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}(d={self.d}, config={self._config}, connector={self._connector})"  # noqa: E501

--- a/tests/_simulators/sampling/test_measurements.py
+++ b/tests/_simulators/sampling/test_measurements.py
@@ -143,7 +143,7 @@ def test_multiple_StateVector_with_ParticleNumberMeasurement_raises_error():
         simulator.execute(program, shots=1)
 
     assert error.value.args[0] == (
-        "The instruction <pq.ParticleNumberMeasurement(modes=(0, 1, 2, 3, 4))> is "
+        "The instruction ParticleNumberMeasurement(modes=(0, 1, 2, 3, 4)) is "
         "not supported for states defined using multiple 'StateVector' instructions.\n"
         "If you need this feature to be implemented, please create an issue at "
         "https://github.com/Budapest-Quantum-Computing-Group/piquasso/issues"

--- a/tests/_simulators/sampling/test_preparations.py
+++ b/tests/_simulators/sampling/test_preparations.py
@@ -55,8 +55,8 @@ def test_initial_state_raises_InvalidState_for_occupation_numbers_of_differing_l
 
     assert error.value.args[0] == (
         "The occupation numbers '(1, 1, 1)' are not well-defined on '5' modes: "
-        "instruction=<pq.StateVector(occupation_numbers=(1, 1, 1), "
-        "coefficient=0.7071067811865475, modes=(0, 1, 2, 3, 4))>"
+        "instruction=StateVector(occupation_numbers=(1, 1, 1), "
+        "coefficient=0.7071067811865475, modes=(0, 1, 2, 3, 4))"
     )
 
 

--- a/tests/api/test_connector.py
+++ b/tests/api/test_connector.py
@@ -50,3 +50,18 @@ def test_BaseConnector_with_overriding_defaults():
     assert plugin_connector.loop_hafnian is plugin_loop_hafnian
 
     assert plugin_connector.loop_hafnian() == 43
+
+
+def test_BaseConnector_repr():
+
+    class PluginConnector(pq.api.connector.BaseConnector):
+        def __init__(self) -> None:
+            super().__init__()
+
+    p = patch.multiple(PluginConnector, __abstractmethods__=set())
+
+    p.start()
+    plugin_connector = PluginConnector()
+    p.stop()
+
+    assert repr(plugin_connector) == str(plugin_connector) == "PluginConnector()"

--- a/tests/api/test_result.py
+++ b/tests/api/test_result.py
@@ -15,16 +15,15 @@
 
 import piquasso as pq
 
-
-def test_program_copy():
-    program = pq.Program()
-
-    program_copy = program.copy()
-
-    assert program_copy is not program
+from piquasso.api.result import Result
 
 
-def test_program_repr():
-    program = pq.Program()
+def test_Result_repr(FakeState):
+    result = Result(
+        state=FakeState(d=3, connector=pq.NumpyConnector()), samples=[1, 2, 3]
+    )
 
-    assert repr(program) == "Program(instructions=[])"
+    assert (
+        repr(result)
+        == "Result(samples=[1, 2, 3], state=FakeState(d=3, config=Config(), connector=NumpyConnector()))"  # noqa: E501
+    )

--- a/tests/api/test_simulator.py
+++ b/tests/api/test_simulator.py
@@ -104,7 +104,7 @@ def test_program_execution_with_unregistered_instruction_raises_InvalidSimulatio
     error_message = error.value.args[0]
 
     assert "No such instruction implemented for this simulator." in error_message
-    assert "instruction=<pq.ImproperInstruction(modes=())>" in error_message
+    assert "instruction=ImproperInstruction(modes=())" in error_message
 
     with pytest.raises(pq.api.exceptions.InvalidSimulation) as error:
         simulator.execute(program)
@@ -112,7 +112,7 @@ def test_program_execution_with_unregistered_instruction_raises_InvalidSimulatio
     error_message = error.value.args[0]
 
     assert "No such instruction implemented for this simulator." in error_message
-    assert "instruction=<pq.ImproperInstruction(modes=())>" in error_message
+    assert "instruction=ImproperInstruction(modes=())" in error_message
 
 
 def test_program_execution_with_wrong_instruction_order_raises_InvalidSimulation(
@@ -255,3 +255,10 @@ def test_Config_override(FakeSimulator, FakeConfig):
 
     assert isinstance(simulator.config, FakeConfig)
     assert isinstance(state._config, FakeConfig)
+
+
+def test_Simulator_repr(FakeSimulator):
+    assert (
+        repr(FakeSimulator(d=3))
+        == "FakeSimulator(d=3, config=Config(), connector=FakeConnector())"
+    )

--- a/tests/api/test_state.py
+++ b/tests/api/test_state.py
@@ -16,15 +16,8 @@
 import piquasso as pq
 
 
-def test_program_copy():
-    program = pq.Program()
-
-    program_copy = program.copy()
-
-    assert program_copy is not program
-
-
-def test_program_repr():
-    program = pq.Program()
-
-    assert repr(program) == "Program(instructions=[])"
+def test_State_repr(FakeState):
+    assert (
+        repr(FakeState(d=3, connector=pq.NumpyConnector()))
+        == "FakeState(d=3, config=Config(), connector=NumpyConnector())"
+    )

--- a/tests/instructions/test_str.py
+++ b/tests/instructions/test_str.py
@@ -19,41 +19,40 @@ import piquasso as pq
 
 
 def test_str_of_preparations():
-    assert str(pq.Vacuum()) == "<pq.Vacuum(modes=())>"
+    assert str(pq.Vacuum()) == "Vacuum(modes=())"
     assert (
         str(pq.StateVector([1, 2]))
-        == "<pq.StateVector(occupation_numbers=(1, 2), coefficient=1.0, modes=())>"
+        == "StateVector(occupation_numbers=(1, 2), coefficient=1.0, modes=())"
     )
 
     assert (
         str(pq.StateVector([1, 2]).on_modes(0, 1))
-        == "<pq.StateVector(occupation_numbers=(1, 2), coefficient=1.0, modes=(0, 1))>"
+        == "StateVector(occupation_numbers=(1, 2), coefficient=1.0, modes=(0, 1))"
     )
 
     assert (
         str(pq.StateVector([1, 2]).on_modes(0, 1) * 0.2)
-        == "<pq.StateVector(occupation_numbers=(1, 2), coefficient=0.2, modes=(0, 1))>"
+        == "StateVector(occupation_numbers=(1, 2), coefficient=0.2, modes=(0, 1))"
     )
 
 
 def test_str_of_gates():
     assert (
         str(pq.Phaseshifter(phi=np.pi / 3))
-        == "<pq.Phaseshifter(phi=1.0471975511965976, modes=())>"
+        == "Phaseshifter(phi=1.0471975511965976, modes=())"
     )
 
     assert (
         str(pq.Phaseshifter(phi=np.pi / 3).on_modes(1))
-        == "<pq.Phaseshifter(phi=1.0471975511965976, modes=(1,))>"
+        == "Phaseshifter(phi=1.0471975511965976, modes=(1,))"
     )
 
-    assert str(pq.Squeezing(r=1.0)) == "<pq.Squeezing(r=1.0, phi=0.0, modes=())>"
+    assert str(pq.Squeezing(r=1.0)) == "Squeezing(r=1.0, phi=0.0, modes=())"
     assert (
-        str(pq.Displacement(r=1.0, phi=0.5))
-        == "<pq.Displacement(r=1.0, phi=0.5, modes=())>"
+        str(pq.Displacement(r=1.0, phi=0.5)) == "Displacement(r=1.0, phi=0.5, modes=())"
     )
 
     assert (
         str(pq.Beamsplitter(theta=0.2, phi=0.3))
-        == "<pq.Beamsplitter(theta=0.2, phi=0.3, modes=())>"
+        == "Beamsplitter(theta=0.2, phi=0.3, modes=())"
     )


### PR DESCRIPTION
The `__repr__` methods got updated and added in some cases, where it wasn't available. I tried to make it consistently of the form of `SomeClass(param=param)`. In `*FockState` classes, I reserved the original definition for `__str__`.