### PR TITLE
docs: Add `.readthedocs.yaml`

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,18 @@
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.12"
+
+sphinx:
+  configuration: docs/conf.py
+
+python:
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ pip install -e ".[dev]"
 
 For document generation one should use
 ```
-pip install -e ".[doc]"
+pip install -e ".[docs]"
 ```
 and for running files under `benchmarks/` or `scripts/`, please issue
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dev = [
   "nbmake~=1.3.0",
   "black~=24.2.0",
 ]
-doc = ["sphinx~=7.1.2", "nbsphinx~=0.8.8", "furo~=2024.1.29"]
+docs = ["sphinx~=7.1.2", "nbsphinx~=0.8.8", "furo~=2024.1.29"]
 benchmark = [
   "matplotlib~=3.7.5",
   "pytest-profiling~=1.7.0",


### PR DESCRIPTION
We finally decided to host the Piquasso documentation on ReadtheDocs, therefore a `.readthedocs.yaml` file got written. Also, the `doc` extras got renamed to `docs`.