### PR TITLE
perf: Rewrite `get_fock_space_basis`

### DIFF
--- a/piquasso/_simulators/fock/calculations.py
+++ b/piquasso/_simulators/fock/calculations.py
@@ -29,8 +29,8 @@ from piquasso.api.result import Result
 from piquasso.api.exceptions import InvalidInstruction, InvalidParameter
 
 from piquasso._math.fock import (
-    cutoff_cardinality,
-    cutoff_cardinality_array,
+    cutoff_fock_space_dim,
+    cutoff_fock_space_dim_array,
     operator_basis,
     get_fock_space_basis,
     nb_get_fock_space_basis,
@@ -116,7 +116,7 @@ def calculate_state_index_matrix_list(d, cutoff, mode):
 
     state_index_matrix_list = []
 
-    indices = cutoff_cardinality_array(cutoff=np.arange(cutoff + 1), d=d - 1)
+    indices = cutoff_fock_space_dim_array(cutoff=np.arange(cutoff + 1), d=d - 1)
 
     for n in range(cutoff):
         limit = cutoff - n
@@ -148,7 +148,7 @@ def calculate_state_index_matrix_list(d, cutoff, mode):
 def calculate_interferometer_helper_indices(d, cutoff):
     space = nb_get_fock_space_basis(d=d, cutoff=cutoff)
 
-    indices = cutoff_cardinality_array(cutoff=np.arange(1, cutoff + 1), d=d)
+    indices = cutoff_fock_space_dim_array(cutoff=np.arange(1, cutoff + 1), d=d)
 
     subspace_index_tensor = []
 
@@ -227,8 +227,8 @@ def calculate_index_list_for_appling_interferometer(
     subspace = get_fock_space_basis(d=len(modes), cutoff=cutoff)
     auxiliary_subspace = get_fock_space_basis(d=d - len(modes), cutoff=cutoff)
 
-    indices = cutoff_cardinality_array(cutoff=np.arange(cutoff + 1), d=len(modes))
-    auxiliary_indices = cutoff_cardinality_array(
+    indices = cutoff_fock_space_dim_array(cutoff=np.arange(cutoff + 1), d=len(modes))
+    auxiliary_indices = cutoff_fock_space_dim_array(
         cutoff=np.arange(cutoff + 1), d=d - len(modes)
     )
     auxiliary_modes = get_auxiliary_modes(d, modes)
@@ -258,7 +258,7 @@ def get_projection_operator_indices(d, cutoff, modes, basis_vector):
 
     boxes = d - len(modes)
 
-    card = cutoff_cardinality(cutoff=new_cutoff, d=boxes)
+    card = cutoff_fock_space_dim(cutoff=new_cutoff, d=boxes)
 
     basis = np.empty(shape=(card, d), dtype=int)
 

--- a/piquasso/_simulators/fock/general/state.py
+++ b/piquasso/_simulators/fock/general/state.py
@@ -21,7 +21,7 @@ from piquasso.api.connector import BaseConnector
 from piquasso.api.config import Config
 from piquasso.api.exceptions import InvalidState, PiquassoException
 from piquasso._math.linalg import is_selfadjoint
-from piquasso._math.fock import cutoff_cardinality, get_fock_space_basis
+from piquasso._math.fock import cutoff_fock_space_dim, get_fock_space_basis
 from piquasso._math.indices import (
     get_index_in_fock_space,
     get_index_in_fock_space_array,
@@ -53,7 +53,7 @@ class FockState(BaseFockState):
         self._density_matrix = self._get_empty()
 
     def _get_empty(self) -> np.ndarray:
-        state_vector_size = cutoff_cardinality(cutoff=self._config.cutoff, d=self.d)
+        state_vector_size = cutoff_fock_space_dim(cutoff=self._config.cutoff, d=self.d)
         return np.zeros(
             shape=(state_vector_size,) * 2, dtype=self._config.complex_dtype
         )
@@ -116,7 +116,7 @@ class FockState(BaseFockState):
 
     @property
     def density_matrix(self) -> np.ndarray:
-        cardinality = cutoff_cardinality(d=self.d, cutoff=self._config.cutoff)
+        cardinality = cutoff_fock_space_dim(d=self.d, cutoff=self._config.cutoff)
 
         return self._density_matrix[:cardinality, :cardinality]
 
@@ -178,7 +178,7 @@ class FockState(BaseFockState):
         )
 
         for inner_basis in inner_space:
-            size = cutoff_cardinality(
+            size = cutoff_fock_space_dim(
                 cutoff=cutoff - fallback_np.sum(inner_basis), d=outer_size
             )
 

--- a/piquasso/_simulators/fock/pure/state.py
+++ b/piquasso/_simulators/fock/pure/state.py
@@ -21,7 +21,7 @@ from piquasso.api.config import Config
 from piquasso.api.exceptions import InvalidState, PiquassoException
 from piquasso.api.connector import BaseConnector
 
-from piquasso._math.fock import cutoff_cardinality, get_fock_space_basis
+from piquasso._math.fock import cutoff_fock_space_dim, get_fock_space_basis
 from piquasso._math.linalg import vector_absolute_square
 from piquasso._math.indices import (
     get_index_in_fock_space,
@@ -63,11 +63,11 @@ class PureFockState(BaseFockState):
         self.state_vector = self._get_empty()
 
     def _get_empty_list(self) -> list:
-        state_vector_size = cutoff_cardinality(cutoff=self._config.cutoff, d=self.d)
+        state_vector_size = cutoff_fock_space_dim(cutoff=self._config.cutoff, d=self.d)
         return [0.0] * state_vector_size
 
     def _get_empty(self) -> np.ndarray:
-        state_vector_size = cutoff_cardinality(cutoff=self._config.cutoff, d=self.d)
+        state_vector_size = cutoff_fock_space_dim(cutoff=self._config.cutoff, d=self.d)
 
         return self._np.zeros(
             shape=(state_vector_size,), dtype=self._config.complex_dtype
@@ -111,7 +111,7 @@ class PureFockState(BaseFockState):
 
     @property
     def density_matrix(self) -> np.ndarray:
-        cardinality = cutoff_cardinality(d=self.d, cutoff=self._config.cutoff)
+        cardinality = cutoff_fock_space_dim(d=self.d, cutoff=self._config.cutoff)
 
         state_vector = self.state_vector[:cardinality]
 
@@ -154,7 +154,7 @@ class PureFockState(BaseFockState):
 
         unordered_modes = fallback_np.concatenate([modes, auxiliary_modes])
 
-        card = cutoff_cardinality(d=auxiliary_d, cutoff=auxiliary_cutoff)
+        card = cutoff_fock_space_dim(d=auxiliary_d, cutoff=auxiliary_cutoff)
         auxiliary_basis = get_fock_space_basis(d=auxiliary_d, cutoff=auxiliary_cutoff)
 
         repeated_occupation_numbers = fallback_np.repeat(
@@ -225,7 +225,7 @@ class PureFockState(BaseFockState):
         relevant_column = self._space[:, mode]
 
         nonzero_indices_on_mode = (relevant_column > 0).nonzero()[0]
-        upper_index = cutoff_cardinality(d=self.d, cutoff=self._config.cutoff - 1)
+        upper_index = cutoff_fock_space_dim(d=self.d, cutoff=self._config.cutoff - 1)
 
         multipliers = fallback_np.sqrt(
             fallback_np.concatenate(

--- a/piquasso/_simulators/sampling/state.py
+++ b/piquasso/_simulators/sampling/state.py
@@ -16,7 +16,7 @@
 from typing import Optional, List
 import numpy as np
 
-from piquasso._math.fock import cutoff_cardinality
+from piquasso._math.fock import cutoff_fock_space_dim
 from piquasso._math.linalg import is_unitary
 
 from piquasso.api.config import Config
@@ -122,16 +122,16 @@ class SamplingState(State):
         particle_numbers = fallback_np.sum(self._occupation_numbers, axis=1)
 
         state_vector = np.zeros(
-            shape=cutoff_cardinality(d=self.d, cutoff=self._config.cutoff),
+            shape=cutoff_fock_space_dim(d=self.d, cutoff=self._config.cutoff),
             dtype=self._config.complex_dtype,
         )
 
         for index in range(len(self._occupation_numbers)):
             particle_number = particle_numbers[index]
 
-            starting_index = cutoff_cardinality(d=self.d, cutoff=particle_number)
+            starting_index = cutoff_fock_space_dim(d=self.d, cutoff=particle_number)
 
-            ending_index = cutoff_cardinality(d=self.d, cutoff=particle_number + 1)
+            ending_index = cutoff_fock_space_dim(d=self.d, cutoff=particle_number + 1)
 
             coefficient = self._coefficients[index]
 

--- a/scripts/profile_cvnn_layer.py
+++ b/scripts/profile_cvnn_layer.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 import piquasso as pq
-from piquasso._math.fock import cutoff_cardinality
+from piquasso._math.fock import cutoff_fock_space_dim
 import tensorflow as tf
 import time
 import numpy as np
@@ -59,7 +59,7 @@ input = 0.01
 d = 2
 cutoff = 10
 
-target_state_vector = np.zeros(cutoff_cardinality(cutoff=cutoff, d=d), dtype=complex)
+target_state_vector = np.zeros(cutoff_fock_space_dim(cutoff=cutoff, d=d), dtype=complex)
 target_state_vector[1] = 1.0
 target_state = tf.constant(target_state_vector, dtype=tf.complex128)
 

--- a/scripts/profile_cvnn_layer_batch.py
+++ b/scripts/profile_cvnn_layer_batch.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 import piquasso as pq
-from piquasso._math.fock import cutoff_cardinality
+from piquasso._math.fock import cutoff_fock_space_dim
 import tensorflow as tf
 import time
 import numpy as np
@@ -61,7 +61,7 @@ def create_layer_parameters(d: int):
 
 expected_mean_positions = 0.01 * np.random.rand(number_of_inputs)
 
-target_state_vector = np.zeros(cutoff_cardinality(cutoff=cutoff, d=d), dtype=complex)
+target_state_vector = np.zeros(cutoff_fock_space_dim(cutoff=cutoff, d=d), dtype=complex)
 target_state_vector[1] = 1.0
 target_state = tf.constant(target_state_vector, dtype=tf.complex128)
 

--- a/tests/_math/test_torontonian.py
+++ b/tests/_math/test_torontonian.py
@@ -19,9 +19,16 @@ import piquasso as pq
 
 import numpy as np
 
+from itertools import chain, combinations
+
+
 from piquasso._math.torontonian import torontonian, loop_torontonian
-from piquasso._math.combinatorics import powerset
 from piquasso._math.transformations import from_xxpp_to_xpxp_transformation_matrix
+
+
+def powerset(iterable):
+    s = list(iterable)
+    return chain.from_iterable(combinations(iterable, r) for r in range(len(s) + 1))
 
 
 def torontonian_naive(A: np.ndarray) -> complex:
@@ -70,9 +77,6 @@ def loop_torontonian_naive(A, gamma):
     """
 
     d = A.shape[0] // 2
-
-    from piquasso._math.transformations import from_xxpp_to_xpxp_transformation_matrix
-    from piquasso._math.combinatorics import powerset
 
     T = from_xxpp_to_xpxp_transformation_matrix(d)
 


### PR DESCRIPTION
The logic for the function `get_fock_space_basis` got rewritten to reuse allocated memory and calculate array sizes in advance. For this, some functions in `fock.py` got JITted. Moreover, the utility function `cutoff_cardinality` got renamed to `cutoff_fock_space_dim` being a more fitting name. Moreover, `powerset` got deleted from the production code, since it is not used anymore.