### PR TITLE
perf: Delete OMP in torontonian calculations

### DIFF
--- a/scripts/loop_torontonian_benchmark.py
+++ b/scripts/loop_torontonian_benchmark.py
@@ -21,6 +21,8 @@ import time
 
 import piquasso as pq
 
+import json
+
 from piquasso._math.torontonian import loop_torontonian as pq_loop_torontonian
 from thewalrus import ltor as tw_loop_torontonian
 
@@ -38,9 +40,11 @@ if __name__ == "__main__":
     y = []
     z = []
 
-    ITER = 10
+    ITER = 100
 
-    for d in range(3, 20):
+    FILENAME = f"loop_torontonian_benchmark_{int(time.time())}.json"
+
+    for d in range(3, 30):
         print(d)
         x.append(d)
 
@@ -64,6 +68,7 @@ if __name__ == "__main__":
 
         sum_ = 0.0
 
+        print(pq_loop_torontonian(input_matrix, displacement_vector))
         for _ in range(ITER):
             print("|", end="", flush=True)
             start_time = time.time()
@@ -82,6 +87,7 @@ if __name__ == "__main__":
 
         sum_ = 0.0
 
+        print(tw_loop_torontonian(input_matrix, displacement_vector))
         for _ in range(ITER):
             print("-", end="", flush=True)
             start_time = time.time()
@@ -91,9 +97,14 @@ if __name__ == "__main__":
         z.append(sum_ / ITER)
         print()
 
+        with open(FILENAME, "w") as f:
+            json.dump(dict(x=x, y=y, z=z), f, indent=4)
+
     plt.scatter(x[1:], y[1:], label="Piquasso")
     plt.scatter(x[1:], z[1:], label="TheWalrus")
     plt.legend()
     plt.yscale("log")
+    plt.xlabel("d [-]")
+    plt.ylabel("Execution time [s]")
 
     plt.show()

--- a/scripts/torontonian_benchmark.py
+++ b/scripts/torontonian_benchmark.py
@@ -21,6 +21,8 @@ import time
 
 import piquasso as pq
 
+import json
+
 from piquasso._math.torontonian import torontonian as pq_torontonian
 from thewalrus import rec_torontonian as tw_torontonian
 
@@ -38,9 +40,11 @@ if __name__ == "__main__":
     y = []
     z = []
 
-    ITER = 10
+    ITER = 100
 
-    for d in range(3, 20):
+    FILENAME = f"torontonian_benchmark_{int(time.time())}.json"
+
+    for d in range(3, 30):
         print(d)
         x.append(d)
 
@@ -62,6 +66,7 @@ if __name__ == "__main__":
 
         sum_ = 0.0
 
+        print(pq_torontonian(input_matrix))
         for _ in range(ITER):
             print("|", end="", flush=True)
             start_time = time.time()
@@ -79,6 +84,7 @@ if __name__ == "__main__":
 
         sum_ = 0.0
 
+        print(tw_torontonian(input_matrix))
         for _ in range(ITER):
             print("-", end="", flush=True)
             start_time = time.time()
@@ -88,9 +94,14 @@ if __name__ == "__main__":
         z.append(sum_ / ITER)
         print()
 
-    plt.scatter(x[1:], y[1:], label="Piquasso")
-    plt.scatter(x[1:], z[1:], label="TheWalrus")
+        with open(FILENAME, "w") as f:
+            json.dump(dict(x=x, y=y, z=z), f, indent=4)
+
+    plt.scatter(x, y, label="Piquasso")
+    plt.scatter(x, z, label="TheWalrus")
     plt.legend()
     plt.yscale("log")
+    plt.xlabel("d [-]")
+    plt.ylabel("Execution time [s]")
 
     plt.show()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,23 +18,5 @@ add_library(
     ${CMAKE_CURRENT_SOURCE_DIR}/matrix.hpp
 )
 
-# Source: https://cliutils.gitlab.io/modern-cmake/chapters/packages/OpenMP.html
-find_package(OpenMP)
-if(OpenMP_CXX_FOUND)
-    target_link_libraries(torontonianboost PUBLIC OpenMP::OpenMP_CXX)
-    target_link_libraries(looptorontonianboost PUBLIC OpenMP::OpenMP_CXX)
-else()
-    # This could happen, because Apple disabled openmp in clang.
-    # One could install it via brew, but it would only works on the machine where it
-    # is compiled, see:
-    # https://cibuildwheel.pypa.io/en/stable/faq/#macos-library-dependencies-do-not-satisfy-target-macos
-    # One can download binaries from here:
-    # https://mac.r-project.org/openmp/
-    # If one would like to make this work, one would need to download the correct binary
-    # and compile the project for every macOS version. We will avoid this, and build on
-    # macOS without OpenMP.
-    message("OpenMP not found, building without it.")
-endif()
-
 target_include_directories(torontonianboost PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_include_directories(looptorontonianboost PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})


### PR DESCRIPTION
There seems to be a too big OMP overhead in the torontonian calculations, at least for smaller system sizes. It could be solved by coming up with a smarter schedule. For now, OMP is deleted from the code.

Moreover, some related benchmarks got updated.