### PR TITLE
perf(sampling): Enhance classical BS simulation

### DIFF
--- a/piquasso/_math/linalg.py
+++ b/piquasso/_math/linalg.py
@@ -100,12 +100,12 @@ def assym_reduce(array, row_reduce_on, col_reduce_on):
 
     for index in range(len(row_reduce_on)):
         row_multiplier = row_reduce_on[index]
-        col_multiplier = col_reduce_on[index]
-
         proper_row_index[row_stride : row_stride + row_multiplier] = index
-        proper_col_index[col_stride : col_stride + col_multiplier] = index
-
         row_stride += row_multiplier
+
+    for index in range(len(col_reduce_on)):
+        col_multiplier = col_reduce_on[index]
+        proper_col_index[col_stride : col_stride + col_multiplier] = index
         col_stride += col_multiplier
 
     return array[np.ix_(proper_row_index, proper_col_index)]

--- a/piquasso/_math/permanent.py
+++ b/piquasso/_math/permanent.py
@@ -17,144 +17,247 @@ import numpy as np
 
 import numba as nb
 
+from numba import int32
+
 from piquasso._math.combinatorics import comb
 
 
+@nb.njit(cache=True, parallel=True)
 def permanent(matrix, rows, cols):
     """Calculates the permanent of a matrix given row and column repetitions.
 
-    Translated from PiquassoBoost.
+    Translated from PiquassoBoost, original implementation:
+    https://github.com/Budapest-Quantum-Computing-Group/piquassoboost/blob/main/piquassoboost/sampling/source/BBFGPermanentCalculatorRepeated.hpp
 
     Implements Eq. (8) from https://arxiv.org/pdf/2309.07027.pdf.
-    """
-    mtx2 = 2 * matrix
+    """  # noqa: E501
 
-    delta_limits, minimal_index = _calculate_delta_limits_and_minimal_index(rows)
+    rows = rows.astype(np.int32)
+    cols = cols.astype(np.int32)
 
-    if minimal_index == len(rows):
+    # Determine minimal nonzero element
+    min_idx = 0
+    minelem = 0
+    for i in range(len(rows)):
+        if minelem == 0 or rows[i] < minelem and rows[i] != 0:
+            minelem = rows[i]
+            min_idx = i
+
+    if len(rows) > 0 and minelem != 0:
+        rows_ = np.empty(len(rows) + 1, dtype=np.int32)
+        rows_[0] = 1
+        rows_[1:] = rows
+        rows_[1 + min_idx] -= 1
+
+        matrix_ = np.empty(
+            shape=(matrix.shape[0] + 1, matrix.shape[1]), dtype=matrix.dtype
+        )
+
+        matrix_[0] = matrix[min_idx]
+
+        matrix_[1:] = matrix
+        rows = rows_
+        matrix = matrix_
+
+    sum_rows = np.sum(rows)
+    sum_cols = np.sum(cols)
+
+    if matrix.shape[0] == 0 or matrix.shape[1] == 0 or sum_rows == 0 or sum_cols == 0:
         return 1.0
 
-    col_sum = rows @ matrix
+    if matrix.shape[0] == 1:
+        ret = 1.0
+        for idx in range(len(cols)):
+            for _ in range(cols[idx]):
+                ret *= matrix[idx, 0]
 
-    permanent = _iterate_over_deltas(
-        col_sum,
-        minimal_index,
-        cols,
-        mtx2,
-        delta_limits,
-    )
+        return ret
 
-    sum_multiplicities = sum(rows)
+    mtx2 = matrix * 2
 
-    permanent = permanent / 2 ** (sum_multiplicities - 1)
+    n_ary_limits = np.empty(len(rows) - 1, dtype=np.int32)
+
+    for idx in range(len(n_ary_limits)):
+        n_ary_limits[idx] = rows[idx + 1] + 1
+
+    idx_max = n_ary_limits[0]
+    for idx in range(1, len(n_ary_limits)):
+        idx_max *= n_ary_limits[idx]
+
+    nthreads = nb.config.NUMBA_NUM_THREADS
+
+    concurrency = min(nthreads, idx_max, 32)
+
+    permanent = 0.0
+
+    for job_idx in nb.prange(concurrency):
+        partial_permanent = 0.0
+
+        work_batch = idx_max // concurrency
+        initial_offset = job_idx * work_batch
+        offset_max = (job_idx + 1) * work_batch - 1
+        if job_idx == concurrency - 1:
+            offset_max = idx_max - 1
+
+        gcode_counter = NaryGrayCodeCounter(n_ary_limits, initial_offset)
+
+        gcode_counter.offset_max = offset_max
+        gcode = gcode_counter.gray_code
+        binomial_coeff = 1
+
+        colsum = np.copy(matrix[0])
+
+        minus_signs_all = 0
+
+        row_idx = 1
+
+        for idx in range(len(gcode)):
+            minus_signs = gcode[idx]
+            rows_current = rows[idx + 1]
+
+            for col_idx in range(len(cols)):
+                colsum[col_idx] += matrix[row_idx, col_idx] * (
+                    rows_current - 2 * minus_signs
+                )
+
+            minus_signs_all += minus_signs
+
+            binomial_coeff *= comb(rows_current, minus_signs)
+
+            row_idx += 1
+
+        parity = 1 if (minus_signs_all % 2 == 0) else -1
+
+        colsum_prod = parity
+        for idx in range(len(cols)):
+            for _ in range(cols[idx]):
+                colsum_prod *= colsum[idx]
+
+        partial_permanent += colsum_prod * binomial_coeff
+
+        for idx in range(initial_offset + 1, offset_max + 1):
+            flag, changed_index, value_prev, value = gcode_counter.next()
+            if flag:
+                break
+
+            parity = -parity
+
+            row_offset = changed_index + 1
+            colsum_prod = parity
+            for col_idx in range(len(cols)):
+                if value_prev < value:
+                    colsum[col_idx] -= mtx2[row_offset, col_idx]
+
+                else:
+                    colsum[col_idx] += mtx2[row_offset, col_idx]
+
+                for _ in range(cols[col_idx]):
+                    colsum_prod *= colsum[col_idx]
+
+            rows_current = rows[changed_index + 1]
+            binomial_coeff = (
+                (binomial_coeff * value_prev / (rows_current - value))
+                if value < value_prev
+                else (binomial_coeff * (rows_current - value_prev) / value)
+            )
+
+            partial_permanent += colsum_prod * binomial_coeff
+
+        permanent += partial_permanent
+
+    permanent /= 2 ** (sum_rows - 1)
 
     return permanent
 
 
-@nb.njit(cache=True)
-def _calculate_delta_limits_and_minimal_index(rows):
-    minimal_index = rows.shape[0]
+@nb.experimental.jitclass(
+    [
+        ("gray_code", int32[:]),
+        ("n_ary_limits", int32[:]),
+        ("counter_chain", int32[:]),
+        ("offset_max", int32),
+        ("offset", int32),
+    ]
+)
+class NaryGrayCodeCounter(object):
+    def __init__(self, n_ary_limits_in, initial_offset):
+        self.n_ary_limits = np.copy(n_ary_limits_in)
+        if len(self.n_ary_limits) == 0:
+            self.offset_max = 0
+            self.offset = 0
+            return
 
-    delta_limits = np.zeros(minimal_index, dtype=rows.dtype)
+        self.offset_max = self.n_ary_limits[0]
+        for idx in range(1, len(self.n_ary_limits)):
+            self.offset_max *= self.n_ary_limits[idx]
 
-    for i in range(0, rows.shape[0]):
-        if rows[i] > 0:
-            if minimal_index > i:
-                delta_limits[i] = rows[i] - 1
-                minimal_index = i
-            else:
-                delta_limits[i] = rows[i]
-        else:
-            delta_limits[i] = 0
+        self.offset_max -= 1
+        self.offset = initial_offset
 
-    return delta_limits, minimal_index
+        self._initialize(initial_offset)
 
+    def _initialize(self, initial_offset):
+        if initial_offset < 0 or initial_offset > self.offset_max:
+            raise
 
-@nb.njit(parallel=True, cache=True)
-def _iterate_over_deltas(
-    col_sum,
-    index_min,
-    cols,
-    mtx2,
-    delta_limits,
-):
-    outer_sum = 0.0
+        self.counter_chain = np.empty_like(self.n_ary_limits)
 
-    sign = 1
-    current_multiplicity = 1
+        for idx in range(len(self.n_ary_limits)):
+            self.counter_chain[idx] = initial_offset % self.n_ary_limits[idx]
+            initial_offset /= self.n_ary_limits[idx]
 
-    for idx in nb.prange(index_min, mtx2.shape[0]):
-        local_sign = sign
-
-        col_sum_new = np.copy(col_sum)
-
-        inner_sum = 0.0
-
-        for index_of_multiplicity in range(1, delta_limits[idx] + 1):
-            col_sum_new -= mtx2[idx]
-
-            local_sign *= -1
-            # NOTE: Ideally, the function itself would be called, but Numba does not
-            # support recursion with parallelization. As a partial solution, only the
-            # outermost for loop is parallelized, and the same function is copied
-            # without the parallelization into `_iterate_over_deltas_recursively`, but
-            # containing a recursion call.
-            inner_sum += _iterate_over_deltas_recursively(
-                col_sum=col_sum_new,
-                sign=local_sign,
-                index_min=idx + 1,
-                current_multiplicity=(
-                    current_multiplicity
-                    * comb(delta_limits[idx], index_of_multiplicity)
-                ),
-                cols=cols,
-                mtx2=mtx2,
-                delta_limits=delta_limits,
+        self.gray_code = np.empty_like(self.n_ary_limits)
+        parity = 0
+        for jdx in range(len(self.n_ary_limits) - 1, -1, -1):
+            self.gray_code[jdx] = (
+                self.n_ary_limits[jdx] - 1 - self.counter_chain[jdx]
+                if parity
+                else self.counter_chain[jdx]
             )
+            parity = parity ^ (self.gray_code[jdx] & 1)
 
-        outer_sum += inner_sum
+    def next(self):
+        changed_index = 0
 
-    return outer_sum + current_multiplicity * sign * np.prod(col_sum**cols)
+        if self.offset >= self.offset_max:
+            return True, 0, 0, 0
 
+        update_counter = True
+        counter_chain_idx = 0
+        while update_counter:
 
-@nb.njit(cache=True)
-def _iterate_over_deltas_recursively(
-    col_sum,
-    sign,
-    index_min,
-    current_multiplicity,
-    cols,
-    mtx2,
-    delta_limits,
-):
-    # NOTE: This is exactly the same function as `_iterate_over_deltas`, but not
-    # parallelized, since Numba does not handle recursion and `parallel=True` well.
-    outer_sum = 0.0
+            if (
+                self.counter_chain[counter_chain_idx]
+                < self.n_ary_limits[counter_chain_idx] - 1
+            ):
+                self.counter_chain[counter_chain_idx] += 1
+                update_counter = False
 
-    for idx in range(index_min, mtx2.shape[0]):
-        local_sign = sign
+            elif (
+                self.counter_chain[counter_chain_idx]
+                == self.n_ary_limits[counter_chain_idx] - 1
+            ):
+                self.counter_chain[counter_chain_idx] = 0
+                update_counter = True
 
-        col_sum_new = np.copy(col_sum)
+            counter_chain_idx += 1
 
-        inner_sum = 0.0
-
-        for index_of_multiplicity in range(1, delta_limits[idx] + 1):
-            col_sum_new -= mtx2[idx]
-
-            local_sign *= -1
-            inner_sum += _iterate_over_deltas_recursively(
-                col_sum=col_sum_new,
-                sign=local_sign,
-                index_min=idx + 1,
-                current_multiplicity=(
-                    current_multiplicity
-                    * comb(delta_limits[idx], index_of_multiplicity)
-                ),
-                cols=cols,
-                mtx2=mtx2,
-                delta_limits=delta_limits,
+        parity = 0
+        for jdx in range(len(self.n_ary_limits) - 1, -1, -1):
+            gray_code_new_val = (
+                self.n_ary_limits[jdx] - 1 - self.counter_chain[jdx]
+                if parity
+                else self.counter_chain[jdx]
             )
+            parity = parity ^ (gray_code_new_val & 1)
 
-        outer_sum += inner_sum
+            if gray_code_new_val != self.gray_code[jdx]:
+                value_prev = self.gray_code[jdx]
+                value = gray_code_new_val
+                self.gray_code[jdx] = gray_code_new_val
+                changed_index = jdx
+                break
 
-    return outer_sum + current_multiplicity * sign * np.prod(col_sum**cols)
+        self.offset += 1
+
+        return False, changed_index, value_prev, value

--- a/piquasso/_simulators/sampling/calculations.py
+++ b/piquasso/_simulators/sampling/calculations.py
@@ -15,8 +15,6 @@
 
 from typing import Tuple
 
-from functools import partial
-
 import numpy as np
 from piquasso._simulators.sampling.state import SamplingState
 
@@ -154,23 +152,21 @@ def particle_number_measurement(
     singular_values = interferometer_svd[1]
 
     if not state.is_lossy:
-        calculate_permanent = partial(
-            state._connector.permanent, matrix=state.interferometer
-        )
         samples = generate_lossless_samples(
-            initial_state, shots, calculate_permanent, state._config.rng
+            initial_state,
+            shots,
+            state._connector.permanent,
+            state.interferometer,
+            state._config.rng,
         )
     elif np.all(np.isclose(singular_values, singular_values[0])):
         uniform_transmission_probability = singular_values[0] ** 2
 
-        calculate_permanent = partial(
-            state._connector.permanent, matrix=state.interferometer
-        )
-
         samples = generate_uniform_lossy_samples(
             initial_state,
             shots,
-            calculate_permanent,
+            state._connector.permanent,
+            state.interferometer,
             uniform_transmission_probability,
             state._config.rng,
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ benchmark = [
   "matplotlib~=3.7.5",
   "pytest-profiling~=1.7.0",
   "pytest-benchmark~=4.0.0",
+  "perceval-quandela~=0.11.2",
 ]
 
 [tool.scikit-build]

--- a/scripts/boson_sampling_benchmark.py
+++ b/scripts/boson_sampling_benchmark.py
@@ -1,0 +1,151 @@
+#
+# Copyright 2021-2024 Budapest Quantum Computing Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import time
+
+import random
+
+import matplotlib.pyplot as plt
+
+import numpy as np
+
+import perceval as pcvl
+from perceval.algorithm import Sampler
+
+import piquasso as pq
+
+
+n = 2  # number of photons at the input
+m = 4  # number of modes
+N = 100  # number of samplings
+
+
+# Copied from: https://perceval.quandela.net/docs/v0.11/notebooks/Boson_sampling.html
+
+
+def Generating_Input(n, m):
+    "This function randomly chooses an input with n photons in m modes."
+    modes = sorted(random.sample(range(m), n))
+
+    state = "|"
+    for i in range(m):
+        state = (
+            state + "0" * (1 - (i in modes)) + "1" * (i in modes) + "," * (i < m - 1)
+        )
+    return pcvl.BasicState(state + ">")
+
+
+mzi = (
+    pcvl.BS()
+    // (0, pcvl.PS(phi=pcvl.Parameter("φ_a")))
+    // pcvl.BS()
+    // (1, pcvl.PS(phi=pcvl.Parameter("φ_b")))
+)
+
+
+def get_perceval_samples(unitary):
+    m = len(unitary)
+
+    n = m // 2
+
+    Linear_Circuit = pcvl.Circuit.decomposition(
+        unitary,
+        mzi,
+        phase_shifter_fn=pcvl.PS,
+        shape=pcvl.InterferometerShape.TRIANGLE,
+    )
+
+    QPU = pcvl.Processor("CliffordClifford2017", Linear_Circuit)
+
+    input_state = Generating_Input(n, m)
+    QPU.with_input(input_state)
+
+    # Keep all outputs
+    QPU.min_detected_photons_filter(0)
+
+    sampler = Sampler(QPU)
+
+    return sampler.samples(N)["results"]
+
+
+def generate_random_fock_state(m, n):
+    modes = sorted(random.sample(range(m), n))
+
+    state_vector = []
+    for i in range(m):
+        if i in modes:
+            state_vector.append(1)
+        else:
+            state_vector.append(0)
+
+    return state_vector
+
+
+def get_piquasso_samples(unitary):
+    m = len(unitary)
+    n = m // 2
+
+    input_state = generate_random_fock_state(m=m, n=n)
+    program = pq.Program(
+        instructions=[
+            pq.StateVector(input_state),
+            pq.Interferometer(unitary),
+            pq.ParticleNumberMeasurement(),
+        ]
+    )
+
+    simulator = pq.SamplingSimulator(d=m)
+
+    return simulator.execute(program, shots=N).samples
+
+
+if __name__ == "__main__":
+
+    # Warmup
+    m = 2
+    unitary = pcvl.Matrix.random_unitary(m)
+    get_perceval_samples(unitary)
+    get_piquasso_samples(np.array(unitary))
+    ####
+
+    x = []
+    pv_times = []
+    pq_times = []
+
+    for m in range(2, 30):
+        print("m=", m)
+        x.append(m)
+        unitary = pcvl.Matrix.random_unitary(m)
+
+        start_time = time.time()
+        get_perceval_samples(unitary)
+        runtime = time.time() - start_time
+        print("PV:", runtime)
+        pv_times.append(runtime)
+
+        start_time = time.time()
+        get_piquasso_samples(np.array(unitary))
+        runtime = time.time() - start_time
+        print("PQ:", runtime)
+        pq_times.append(runtime)
+
+    plt.scatter(x, pv_times, label="Perceval")
+    plt.scatter(x, pq_times, label="Piquasso")
+
+    plt.yscale("log")
+
+    plt.legend()
+    plt.show()

--- a/scripts/boson_sampling_hist.py
+++ b/scripts/boson_sampling_hist.py
@@ -1,0 +1,68 @@
+#
+# Copyright 2021-2024 Budapest Quantum Computing Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import piquasso as pq
+
+from piquasso._math.combinatorics import partitions
+
+import numpy as np
+
+
+if __name__ == "__main__":
+    unitary = np.array(
+        [
+            [
+                0.90939407 + 0.26443525j,
+                0.00450261 + 0.01880791j,
+                0.31670376 + 0.0490014j,
+            ],
+            [
+                0.19639913 + 0.19652978j,
+                0.23847303 + 0.39887995j,
+                -0.67825584 - 0.49678752j,
+            ],
+            [
+                -0.10943493 - 0.11791454j,
+                0.35197974 + 0.81225714j,
+                0.3122759 + 0.30488117j,
+            ],
+        ]
+    )
+
+    input_state = np.array([3, 1, 1], dtype=int)
+
+    loss_transmittance = 1.0
+
+    n = sum(input_state)
+    d = len(input_state)
+
+    N = 10000
+
+    program = pq.Program(
+        instructions=[
+            pq.StateVector(input_state),
+            pq.Interferometer(unitary),
+            *[pq.Loss(loss_transmittance).on_modes(i) for i in range(d)],
+            pq.ParticleNumberMeasurement(),
+        ]
+    )
+
+    simulator = pq.SamplingSimulator(d=len(unitary), config=pq.Config(seed_sequence=42))
+
+    samples = [tuple(sample) for sample in simulator.execute(program, shots=N).samples]
+
+    for partition in partitions(d, n):
+        print(partition, samples.count(tuple(partition)))

--- a/scripts/permanent_benchmark.py
+++ b/scripts/permanent_benchmark.py
@@ -1,0 +1,77 @@
+#
+# Copyright 2021-2024 Budapest Quantum Computing Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Benchmarking the Piquasso vs. TheWalrus hafnian with repetitions.
+"""
+
+import time
+
+import json
+
+from piquasso._math.permanent import permanent
+
+import matplotlib.pyplot as plt
+
+import numpy as np
+
+np.set_printoptions(suppress=True, linewidth=200)
+
+
+if __name__ == "__main__":
+    x = []
+    y = []
+
+    ITER = 100
+
+    FILENAME = f"permanent_benchmark_{int(time.time())}.json"
+
+    # Compilation
+    d = 2
+    A = np.random.rand(d, d) + 1j * np.random.rand(d, d)
+    A = A + A.T
+    occupation_numbers = 2 * np.ones(d, dtype=int)
+    permanent(A, occupation_numbers, occupation_numbers)
+    ###
+
+    for d in range(2, 20 + 1):
+        print(d)
+        x.append(d)
+        A = np.random.rand(d, d) + 1j * np.random.rand(d, d)
+
+        A = A + A.T
+
+        occupation_numbers = 2 * np.ones(d, dtype=int)
+        sum_ = 0.0
+
+        for _ in range(ITER):
+            print("|", end="", flush=True)
+            start_time = time.time()
+            permanent(A, occupation_numbers, occupation_numbers)
+            sum_ += time.time() - start_time
+
+        y.append(sum_ / ITER)
+        print()
+
+        with open(FILENAME, "w") as f:
+            json.dump(dict(x=x, y=y), f, indent=4)
+
+    plt.scatter(x, y, label="Piquasso")
+    plt.legend()
+    plt.yscale("log")
+    plt.xlabel("d [-]")
+    plt.ylabel("Execution time [s]")
+
+    plt.show()

--- a/tests/_simulators/sampling/test_measurements.py
+++ b/tests/_simulators/sampling/test_measurements.py
@@ -180,7 +180,7 @@ def test_general_loss():
     simulator.execute(program, shots=1)
 
 
-def test_Interferometer_fock_probabilities():
+def test_boson_sampling_seeded():
     seed_sequence = 123
 
     U = np.array(
@@ -234,32 +234,32 @@ def test_Interferometer_fock_probabilities():
     samples = simulator.execute(program, shots=20).samples
 
     expected_samples = [
-        (4, 0, 0, 1, 0),
-        (0, 1, 0, 0, 4),
-        (0, 2, 1, 2, 0),
-        (0, 0, 2, 1, 2),
-        (2, 2, 1, 0, 0),
-        (1, 2, 1, 0, 1),
-        (0, 1, 0, 0, 4),
-        (0, 2, 0, 1, 2),
-        (1, 1, 3, 0, 0),
-        (2, 3, 0, 0, 0),
-        (4, 1, 0, 0, 0),
-        (0, 0, 2, 1, 2),
-        (0, 0, 3, 2, 0),
-        (2, 1, 1, 0, 1),
-        (1, 0, 4, 0, 0),
-        (0, 0, 3, 2, 0),
-        (4, 0, 0, 1, 0),
+        (3, 0, 0, 0, 2),
+        (0, 0, 1, 2, 2),
+        (0, 1, 0, 4, 0),
+        (1, 0, 0, 0, 4),
         (0, 1, 0, 1, 3),
+        (1, 0, 0, 3, 1),
+        (2, 0, 3, 0, 0),
+        (3, 1, 1, 0, 0),
+        (0, 1, 0, 3, 1),
+        (1, 2, 0, 0, 2),
+        (1, 0, 4, 0, 0),
+        (0, 1, 1, 2, 1),
+        (0, 0, 1, 1, 3),
+        (0, 2, 0, 1, 2),
+        (2, 0, 1, 0, 2),
+        (0, 0, 3, 1, 1),
+        (0, 0, 4, 1, 0),
         (2, 0, 0, 0, 3),
-        (3, 0, 1, 0, 1),
+        (0, 0, 2, 1, 2),
+        (1, 1, 0, 1, 2),
     ]
 
     assert samples == expected_samples
 
 
-def test_LossyInterferometer_fock_probabilities():
+def test_LossyInterferometer_boson_sampling_seeded():
     seed_sequence = 123
 
     U = np.array(
@@ -317,32 +317,32 @@ def test_LossyInterferometer_fock_probabilities():
     samples = simulator.execute(program, shots=20).samples
 
     expected_samples = [
-        (1, 2, 0, 0, 1),
+        (0, 0, 3, 0, 0),
+        (0, 0, 1, 1, 0),
+        (0, 0, 1, 1, 0),
+        (1, 0, 0, 1, 0),
         (0, 0, 1, 0, 0),
-        (0, 0, 2, 0, 0),
         (0, 0, 1, 0, 0),
+        (1, 1, 1, 0, 0),
+        (0, 2, 0, 0, 2),
+        (0, 0, 1, 0, 0),
+        (1, 0, 1, 0, 2),
+        (1, 0, 0, 0, 3),
+        (0, 0, 1, 1, 2),
+        (0, 0, 0, 1, 0),
+        (0, 0, 0, 1, 2),
+        (0, 1, 1, 1, 0),
         (0, 1, 2, 0, 0),
-        (1, 0, 0, 0, 1),
-        (0, 0, 1, 0, 0),
-        (0, 0, 0, 2, 0),
-        (2, 0, 1, 0, 0),
-        (2, 0, 0, 1, 1),
-        (1, 1, 1, 0, 2),
-        (0, 0, 0, 1, 1),
-        (0, 0, 0, 1, 3),
-        (1, 0, 0, 0, 2),
-        (1, 0, 0, 0, 4),
-        (0, 0, 0, 0, 3),
-        (2, 1, 0, 0, 1),
-        (0, 0, 0, 1, 1),
-        (1, 0, 1, 0, 0),
-        (0, 3, 0, 0, 1),
+        (0, 1, 0, 0, 1),
+        (1, 0, 0, 1, 1),
+        (0, 0, 2, 1, 0),
+        (0, 1, 1, 0, 0),
     ]
 
     assert samples == expected_samples
 
 
-def test_LossyInterferometer_fock_probabilities_uniform_losses():
+def test_LossyInterferometer_boson_sampling_uniform_losses():
     seed_sequence = 123
 
     U = np.array(
@@ -400,26 +400,26 @@ def test_LossyInterferometer_fock_probabilities_uniform_losses():
     samples = simulator.execute(program, shots=20).samples
 
     expected_samples = [
-        (2, 0, 0, 0, 2),
-        (0, 1, 0, 1, 1),
-        (0, 2, 2, 0, 1),
-        (0, 1, 0, 0, 3),
-        (0, 0, 1, 2, 2),
-        (1, 3, 1, 0, 0),
-        (0, 1, 1, 1, 0),
-        (1, 0, 3, 0, 0),
-        (3, 0, 2, 0, 0),
-        (0, 1, 0, 0, 2),
-        (1, 2, 0, 1, 0),
-        (0, 0, 2, 2, 0),
-        (0, 0, 2, 3, 0),
+        (1, 0, 2, 0, 0),
+        (1, 0, 0, 1, 1),
         (0, 2, 1, 0, 2),
-        (1, 1, 1, 0, 1),
-        (0, 2, 0, 0, 2),
+        (1, 0, 0, 0, 2),
+        (5, 0, 0, 0, 0),
+        (0, 2, 2, 0, 1),
+        (0, 3, 2, 0, 0),
+        (0, 1, 1, 2, 1),
+        (1, 1, 0, 0, 3),
+        (0, 0, 0, 2, 2),
+        (0, 2, 1, 0, 2),
         (2, 0, 2, 0, 0),
-        (1, 1, 0, 0, 1),
-        (0, 0, 0, 3, 2),
-        (0, 2, 1, 1, 1),
+        (0, 1, 0, 0, 3),
+        (0, 1, 3, 0, 0),
+        (1, 1, 0, 0, 2),
+        (0, 0, 4, 1, 0),
+        (1, 3, 0, 0, 1),
+        (2, 1, 1, 0, 1),
+        (0, 2, 1, 0, 2),
+        (0, 1, 1, 0, 2),
     ]
 
     assert samples == expected_samples


### PR DESCRIPTION
The classical simulation of Boson Sampling is implemented with a rudimentary algorithm, but it got reimplemented using the Clifford&Clifford algorithm B, see https://arxiv.org/abs/1706.01260.

Moreover, the implementation for the repeated BB/FG formula with n-ary Gray code has been copied from PiquassoBoost.

Additional tests were written for the permanent, and additional scripts were written for both the permanent and for BS as well. In `boson_sampling_benchmark.py`, Piquasso is compared with Perceval in BS.

Some seeded tests in `tests/_simulators/sampling` had to be modified  due to the modification of the sampling algorithm.