### PR TITLE
fix(fermionic): Fix pfaffian function

### DIFF
--- a/piquasso/_simulators/connectors/connector.py
+++ b/piquasso/_simulators/connectors/connector.py
@@ -107,6 +107,9 @@ class BuiltinConnector(BaseConnector):
         Note:
             There are faster algorithms, but this is fine for now.
         """
+        if matrix.shape[0] == 0:
+            return 1.0
+
         if matrix.shape[0] % 2 == 1:
             return 0.0
 

--- a/tests/fermionic/gaussian/test_state.py
+++ b/tests/fermionic/gaussian/test_state.py
@@ -530,6 +530,31 @@ def test_get_majorana_monomial_expectation_value_random_without_multiplicities(
 
 @pytest.mark.monkey
 @for_all_connectors
+def test_get_majorana_monomial_expectation_value_empty(
+    connector, generate_fermionic_gaussian_hamiltonian
+):
+    d = 3
+
+    parent_hamiltonian = generate_fermionic_gaussian_hamiltonian(d)
+
+    program = pq.Program(
+        [pq.fermionic.ParentHamiltonian(hamiltonian=parent_hamiltonian)]
+    )
+    simulator = pq.fermionic.GaussianSimulator(d=d, connector=connector)
+    state = simulator.execute(program).state
+
+    density_matrix = state.density_matrix
+
+    empty_indices = np.array([], dtype=int)
+
+    assert np.isclose(
+        state.get_majorana_monomial_expectation_value(empty_indices),
+        np.trace(density_matrix),
+    )
+
+
+@pytest.mark.monkey
+@for_all_connectors
 def test_get_majorana_monomial_expectation_value_random_with_possible_multiplicities(
     connector, get_majorana_operators, generate_fermionic_gaussian_hamiltonian
 ):


### PR DESCRIPTION
The test
`test_get_majorana_monomial_expectation_value_random_with_possible_multiplicities` is flaky, because the schur decomposition in the pfaffian calculation got an empty matrix sometimes. The pfaffian function should return with 1.0 in this case, and this edge case has been added into `BuiltinConnector.pfaffian`.