### PR TITLE
fix(fermionic): Majorana string sorting fix

### DIFF
--- a/piquasso/_math/combinatorics.py
+++ b/piquasso/_math/combinatorics.py
@@ -43,20 +43,17 @@ def comb(n, k):
     return prod
 
 
-def is_even_permutation(permutation):
-    permutation = list(permutation)
-    length = len(permutation)
-    elements_seen = [False] * length
-    cycles = 0
-    for index, already_seen in enumerate(elements_seen):
-        if already_seen:
-            continue
-        cycles += 1
-        current = index
-        while not elements_seen[current]:
-            elements_seen[current] = True
-            current = permutation[current]
-    return (length - cycles) % 2 == 0
+@nb.njit(cache=True)
+def sort_and_get_parity(array):
+    n = len(array)
+    parity = 1
+    for n in range(n - 1, 0, -1):
+        for i in range(n):
+            if array[i] > array[i + 1]:
+                array[i], array[i + 1] = array[i + 1], array[i]
+                parity *= -1
+
+    return array, parity
 
 
 @nb.njit(cache=True)


### PR DESCRIPTION
The sorting of the Majorana string was done with `np.argsort`, but the required permutation might be ambiguous when multiplicities are present, messing up the parity term. When commuting Majorana operators, one would naively do a bubble sort, which avoids commuting equal elements that would introduce an unwanted extra term. Faster sorting algorithms might not adhere to this, and the resulting permutation might not reflect the parity of the string. In `numpy<2.0.0`, the resulting permutation of the sorting algorithm had a proper parity, but in `numpy==2.0.2`, the algorithm is changed and results in the wrong parity. Therefore, the sorting is reimplemented with a bubble sort, which also calculates the parity term.