### PR TITLE
fix(fermionic): Fixing density matrix calculation

### DIFF
--- a/piquasso/fermionic/__init__.py
+++ b/piquasso/fermionic/__init__.py
@@ -25,26 +25,26 @@ Note:
 Basic notations
 ---------------
 
-Let :math:`a_k` and :math:`a_k^\dagger` denote the Dirac operators. These fulfill the
+Let :math:`f_k` and :math:`f_k^\dagger` denote the Dirac operators. These fulfill the
 CAR algebra, i.e.,
 
 .. math::
-    \{ a_i, a_j^\dagger \} &= I \delta_{ij}, \\\\
-    \{a_i, a_j \} &= \{ a_i^\dagger, a_j^\dagger \} = 0.
+    \{ f_i, f_j^\dagger \} &= I \delta_{ij}, \\\\
+    \{ f_i, f_j \} &= \{ f_i^\dagger, f_j^\dagger \} = 0.
 
-Let us define :math:`\mathbf{\alpha}` as
+Let us define :math:`\mathbf{f}` as
 
 .. math::
-    \mathbf{\alpha} = [a_1^\dagger, \dots, a_d^\dagger, a_1, \dots, a_d].
+    \mathbf{f} = [f_1^\dagger, \dots, f_d^\dagger, f_1, \dots, f_d].
 
 The Majorana operators are defined as
 
 .. math::
 
-    x_k &:= \frac{a_k + a_k^\dagger}{\sqrt{2}}, \\\\
-    p_k &:= \frac{a_k - a_k^\dagger}{i\sqrt{2}},
+    x_k &:= \frac{f_k + f_k^\dagger}{\sqrt{2}}, \\\\
+    p_k &:= \frac{f_k - f_k^\dagger}{i\sqrt{2}},
 
-where :math:`a_k` and :math:`a_k^\dagger` denote the Dirac operators.
+where :math:`f_k` and :math:`f_k^\dagger` denote the Dirac operators.
 
 :math:`\mathbf{m}` denotes the vector of Majorana operators, i.e.,
 

--- a/piquasso/fermionic/gaussian/__init__.py
+++ b/piquasso/fermionic/gaussian/__init__.py
@@ -19,14 +19,6 @@ Fermionic Gaussian Simulations
 ******************************
 
 This is a package for Fermionic Linear Optics (FLO) or Fermionic Gaussian states.
-
-Note:
-    For consistency, we tried to the conventions from the SciPost Physics Lecture Note
-    "Fermionic Gaussian states: an introduction to numerical approaches" from J. Surace
-    and L. Tagliacozzo, `arXiv:2111.08343 <https://arxiv.org/pdf/2111.08343>`_.
-    However, this article uses anti-lexicographic ordering (i.e. :math:`| 1 \langle` is
-    before :math:`| 0 \langle` in order), and we prefer lexicographic ordering,
-    therefore we changed some calculations accordingly.
 """
 
 from .simulator import GaussianSimulator

--- a/piquasso/fermionic/instructions.py
+++ b/piquasso/fermionic/instructions.py
@@ -30,13 +30,13 @@ class ParentHamiltonian(Preparation):
 
     .. math::
 
-        \rho = \frac{e^{-\hat{H}}}{\operatorname{Tr} e^{-\hat{H}}},
+        \rho = \frac{e^{\hat{H}}}{\operatorname{Tr} e^{\hat{H}}},
 
     where :math:`\hat{H}` is the parent Hamiltonian and has the form
 
     .. math::
 
-        \hat{H} &= \mathbf{\alpha}^\dagger H \mathbf{\alpha}, \\\\
+        \hat{H} &= \mathbf{f}^\dagger H \mathbf{f}, \\\\
         H &= \begin{bmatrix}
             - \overline{A} & B \\
             - \overline{B} & A
@@ -61,12 +61,11 @@ class GaussianHamiltonian(Gate):
     where
 
     .. math::
-
-        \hat{H} &= \mathbf{\alpha}^\dagger H \mathbf{\alpha}, \\\\
+        \hat{H} &= \mathbf{f} H \mathbf{f}^\dagger, \\\\
         H &= \begin{bmatrix}
-            - \overline{A} & B \\
-            - \overline{B} & A
-        \end{bmatrix}. \\\\
+            A & -\overline{B} \\
+            B & -\overline{A}
+        \end{bmatrix}.
 
     Here, :math:`A` is self-adjoint and :math:`B` is skew-symmetric.
     """

--- a/tests/fermionic/conftest.py
+++ b/tests/fermionic/conftest.py
@@ -46,25 +46,6 @@ def generate_passive_fermionic_gaussian_hamiltonian(generate_hermitian_matrix):
 
 
 @pytest.fixture
-def get_omega():
-    """
-    :math:`\Omega` in Eq. (10) from https://arxiv.org/pdf/2111.08343.
-    """
-
-    def func(d):
-        identity = np.identity(d)
-
-        return np.block(
-            [
-                [identity, identity],
-                [1j * identity, -1j * identity],
-            ]
-        ) / np.sqrt(2)
-
-    return func
-
-
-@pytest.fixture
 def get_majorana_operators():
 
     def func(d):
@@ -79,5 +60,16 @@ def get_majorana_operators():
             ms.append((fs[i] - fdags[i]) / (1j * np.sqrt(2)))
 
         return ms
+
+    return func
+
+
+@pytest.fixture
+def get_ladder_operators():
+
+    def func(d):
+        fs, fdags = _get_fs_fdags(d)
+
+        return fs + fdags
 
     return func


### PR DESCRIPTION
The methods `density_matrix` and `get_majorana_monomial_expectation_value` were incorrect, but they have been fixed. This mishap might have been caused by different conventions, and also https://arxiv.org/pdf/2111.08343 gets some equations wrong I think.

The documentation has been extended for clarity.