### PR TITLE
fix(fermionic): Change Majorana convention

### DIFF
--- a/piquasso/fermionic/__init__.py
+++ b/piquasso/fermionic/__init__.py
@@ -41,8 +41,8 @@ The Majorana operators are defined as
 
 .. math::
 
-    x_k &:= \frac{f_k + f_k^\dagger}{\sqrt{2}}, \\\\
-    p_k &:= \frac{f_k - f_k^\dagger}{i\sqrt{2}},
+    x_k &:= f_k + f_k^\dagger, \\\\
+    p_k &:= -i (f_k - f_k^\dagger),
 
 where :math:`f_k` and :math:`f_k^\dagger` denote the Dirac operators.
 

--- a/piquasso/fermionic/gaussian/state.py
+++ b/piquasso/fermionic/gaussian/state.py
@@ -69,7 +69,7 @@ class GaussianState(State):
 
         .. math::
 
-            \Sigma_{ij} := -i \operatorname{Tr} (\rho [\mathbf{m}_i, \mathbf{m}_j]).
+            \Sigma_{ij} := -i \operatorname{Tr} (\rho [\mathbf{m}_i, \mathbf{m}_j]) / 2.
 
         The covariance matrix is a real-valued, skew-symmetric matrix.
         """
@@ -454,13 +454,7 @@ class GaussianState(State):
 
         covariance_matrix_reduced = self.covariance_matrix[matrix_index]
 
-        # NOTE: This is due to the \sqrt{2} in the denominator of the Majorana operator
-        # definiton. We will drop this in the future.
-        majorana_convention_term = (1 / 2) ** (len(indices) // 2)
-
-        prefactor = (
-            parity * 1j ** (len(filtered_indices) // 2) * majorana_convention_term
-        )
+        prefactor = parity * 1j ** (len(filtered_indices) // 2)
 
         return prefactor * self._connector.pfaffian(covariance_matrix_reduced)
 
@@ -470,11 +464,11 @@ class GaussianState(State):
         The parity operator is defined as
 
         .. math::
-            P = (2i)^d m_1 \dots m_{2d} = (2i)^d x_1 \dots x_d p_1 \dots p_d.
+            P = i^d m_1 \dots m_{2d} = i^d x_1 \dots x_d p_1 \dots p_d.
         """
         fallback_np = self._connector.fallback_np
 
-        return 2j**self.d * self.get_majorana_monomial_expectation_value(
+        return 1j**self.d * self.get_majorana_monomial_expectation_value(
             fallback_np.arange(2 * self.d)
         )
 

--- a/tests/fermionic/conftest.py
+++ b/tests/fermionic/conftest.py
@@ -54,10 +54,10 @@ def get_majorana_operators():
         ms = []
 
         for i in range(d):
-            ms.append((fs[i] + fdags[i]) / np.sqrt(2))
+            ms.append(fs[i] + fdags[i])
 
         for i in range(d):
-            ms.append((fs[i] - fdags[i]) / (1j * np.sqrt(2)))
+            ms.append(-1j * (fs[i] - fdags[i]))
 
         return ms
 

--- a/tests/fermionic/gaussian/test_state.py
+++ b/tests/fermionic/gaussian/test_state.py
@@ -256,7 +256,7 @@ def test_vacuum_covariance_matrix_with_majorana_operators_and_density_matrix(
         for j in range(2 * d):
             assert np.isclose(
                 covariance_matrix[i, j],
-                -1j * np.trace(rho @ (m[i] @ m[j] - m[j] @ m[i])),
+                -1j * np.trace(rho @ (m[i] @ m[j] - m[j] @ m[i])) / 2,
             )
 
 
@@ -288,8 +288,8 @@ def test_covariance_matrix_with_majorana_operators_and_density_matrix(
 
     for i in range(2 * d):
         for j in range(2 * d):
-            expected_covariance_matrix[i, j] = -1j * np.trace(
-                rho @ (m[i] @ m[j] - m[j] @ m[i])
+            expected_covariance_matrix[i, j] = (
+                -1j * np.trace(rho @ (m[i] @ m[j] - m[j] @ m[i])) / 2
             )
 
     assert np.allclose(covariance_matrix, expected_covariance_matrix)


### PR DESCRIPTION
The convention for the Majorana operators is changed so that we do not divide by `\sqrt{2}`. The covariance matrix stays the same up to a factor of `2`.