### PR TITLE
FIX(build.yml): Add Windows wheel repairing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,6 +81,9 @@ jobs:
           ## NOTE: --import-mode=importlib prevents pytest to import piquasso from
           ## directory
           # CIBW_TEST_COMMAND: "pytest -v --import-mode=importlib {project}/tests"
+        env:
+          CIBW_BEFORE_BUILD_WINDOWS: "pip install delvewheel"
+          CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "delvewheel repair -w {dest_dir} {wheel}"
 
       - uses: actions/upload-artifact@v4
         with:

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ pip install piquasso
 If you have problems installing Piquasso as above, try installing from source with
 
 ```
-pip install --no-binary piquasso
+pip install --no-binary=:all: piquasso
 ```
 
 When installing from source does not work on your machine, please open an issue in the

--- a/piquasso/_math/CMakeLists.txt
+++ b/piquasso/_math/CMakeLists.txt
@@ -2,4 +2,8 @@ pybind11_add_module(torontonian SHARED ${CMAKE_CURRENT_SOURCE_DIR}/torontonian.c
 
 target_link_libraries(torontonian PUBLIC torontonianboost looptorontonianboost)
 
-install(TARGETS torontonian LIBRARY DESTINATION piquasso/_math)
+install(
+    TARGETS torontonian
+    RUNTIME DESTINATION piquasso/_math
+    LIBRARY DESTINATION piquasso/_math
+)


### PR DESCRIPTION
The Windows wheels have not been repaired by `cibuildwheel` by default, see https://cibuildwheel.pypa.io/en/1.x/options/#repair-wheel-command

According to the `cibuildwheel` documentation, this could be fixed by enabling `delvewheel`.

Moreover, the `*.pyd` files are installed to the proper location via setting `RUNTIME DESTINATION` in cmake.

Fixes #389