### PR TITLE
refact(_math): xpxp-xxpp basis changing rewritten

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -6,5 +6,6 @@ ignore:
   - piquasso/_math/combinatorics.py
   - piquasso/_math/fock.py
   - piquasso/_math/indices.py
+  - piquasso/_math/transformations.py
   - piquasso/_simulators/fock/calculations.py
   - piquasso/_simulators/connectors/numpy_/interferometer.py

--- a/piquasso/_math/decompositions.py
+++ b/piquasso/_math/decompositions.py
@@ -18,7 +18,7 @@ import numpy as np
 from scipy.optimize import root_scalar
 
 from piquasso._math.symplectic import xp_symplectic_form
-from piquasso._math.transformations import from_xxpp_to_xpxp_transformation_matrix
+from piquasso._math.transformations import xpxp_to_xxpp_indices
 
 from piquasso.api.exceptions import InvalidParameter
 from piquasso.api.connector import BaseConnector
@@ -176,9 +176,10 @@ def williamson(matrix: np.ndarray, connector: BaseConnector) -> tuple:
         output="real",
     )
 
+    indices = xpxp_to_xxpp_indices(d)
     basis_change = _rotation_to_positive_above_diagonals(
         block_diagonal_part, connector
-    ) @ from_xxpp_to_xpxp_transformation_matrix(d)
+    )[:, indices]
     ordered_block_diagonal = basis_change.T @ block_diagonal_part @ basis_change
 
     inverse_diagonal_matrix = connector.block_diag(

--- a/piquasso/_math/transformations.py
+++ b/piquasso/_math/transformations.py
@@ -13,40 +13,47 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import functools
 import numpy as np
+import numba as nb
 
 
-@functools.lru_cache()
-def from_xxpp_to_xpxp_transformation_matrix(d: int) -> np.ndarray:
+@nb.njit(cache=True)
+def xxpp_to_xpxp_indices(d: int) -> np.ndarray:
     r"""
-    Basis changing with the basis change operator.
-
-    This transformation will change the basis from xxpp-basis to xpxp-basis.
-
-    .. math::
-
-        T_{ij} = \delta_{j, 2i-1} + \delta_{j + 2d, 2i}
-
-    Intuitively, it changes the basis as
-
-    .. math::
-
-        T Y = T (x_1, \dots, x_d, p_1, \dots, p_d)^T
-            = (x_1, p_1, \dots, x_d, p_d)^T,
-
-    which is very helpful in :mod:`piquasso._simulators.gaussian.state`.
+    Indices for basis changing from the xxpp to the xpxp basis.
 
     Args:
         d (int): The number of modes.
 
     Returns:
-        numpy.ndarray: The basis changing matrix.
+        numpy.ndarray: The basis changing indices.
     """
 
-    T = np.zeros((2 * d, 2 * d), dtype=int)
-    for i in range(d):
-        T[2 * i, i] = 1
-        T[2 * i + 1, i + d] = 1
+    indices = np.empty(2 * d, dtype=nb.int32)
 
-    return T
+    for i in range(d):
+        indices[2 * i] = i
+        indices[2 * i + 1] = d + i
+
+    return indices
+
+
+@nb.njit(cache=True)
+def xpxp_to_xxpp_indices(d: int) -> np.ndarray:
+    r"""
+    Indices for basis changing from the xpxp to the xxpp basis.
+
+    Args:
+        d (int): The number of modes.
+
+    Returns:
+        numpy.ndarray: The basis changing indices.
+    """
+
+    indices = np.empty(2 * d, dtype=nb.int32)
+
+    for i in range(d):
+        indices[i] = 2 * i
+        indices[d + i] = 2 * i + 1
+
+    return indices

--- a/piquasso/fermionic/gaussian/calculations.py
+++ b/piquasso/fermionic/gaussian/calculations.py
@@ -22,7 +22,7 @@ from piquasso.instructions.gates import _PassiveLinearGate
 
 from piquasso._math.validations import all_zero_or_one
 from piquasso._math.transformations import (
-    from_xxpp_to_xpxp_transformation_matrix,
+    xxpp_to_xpxp_indices,
 )
 
 from ._misc import validate_fermionic_gaussian_hamiltonian
@@ -80,6 +80,7 @@ def gaussian_hamiltonian(
     validate_fermionic_gaussian_hamiltonian(H)
 
     np = state._connector.np
+    fallback_np = state._connector.fallback_np
 
     d = state.d
 
@@ -88,18 +89,14 @@ def gaussian_hamiltonian(
 
     A_plus_B = A + B
     A_minus_B = A - B
-    T = from_xxpp_to_xpxp_transformation_matrix(d)
+    indices = xxpp_to_xpxp_indices(d)
 
-    h = (
-        T
-        @ np.block(
-            [
-                [A_plus_B.imag, A_plus_B.real],
-                [-A_minus_B.real, A_minus_B.imag],
-            ]
-        )
-        @ T.T
-    )
+    h = np.block(
+        [
+            [A_plus_B.imag, A_plus_B.real],
+            [-A_minus_B.real, A_minus_B.imag],
+        ]
+    )[fallback_np.ix_(indices, indices)]
 
     SO = state._connector.expm(-2 * h)
 

--- a/tests/_math/test_torontonian.py
+++ b/tests/_math/test_torontonian.py
@@ -23,7 +23,7 @@ from itertools import chain, combinations
 
 
 from piquasso._math.torontonian import torontonian, loop_torontonian
-from piquasso._math.transformations import from_xxpp_to_xpxp_transformation_matrix
+from piquasso._math.transformations import xpxp_to_xxpp_indices
 
 
 def powerset(iterable):
@@ -38,9 +38,9 @@ def torontonian_naive(A: np.ndarray) -> complex:
     """
     d = A.shape[0] // 2
 
-    T = from_xxpp_to_xpxp_transformation_matrix(d)
+    indices = xpxp_to_xxpp_indices(d)
 
-    A = T.T @ A @ T
+    A = A[np.ix_(indices, indices)]
 
     if d == 0:
         return 1.0 + 0j
@@ -78,10 +78,10 @@ def loop_torontonian_naive(A, gamma):
 
     d = A.shape[0] // 2
 
-    T = from_xxpp_to_xpxp_transformation_matrix(d)
+    indices = xpxp_to_xxpp_indices(d)
 
-    A = T.T @ A @ T
-    gamma = T.T @ gamma
+    A = A[np.ix_(indices, indices)]
+    gamma = gamma[indices]
 
     if d == 0:
         return 1.0

--- a/tests/fermionic/gaussian/test_state.py
+++ b/tests/fermionic/gaussian/test_state.py
@@ -23,9 +23,7 @@ import pytest
 
 from scipy.linalg import block_diag
 
-from piquasso._math.transformations import (
-    from_xxpp_to_xpxp_transformation_matrix,
-)
+from piquasso._math.transformations import xxpp_to_xpxp_indices, xpxp_to_xxpp_indices
 
 from piquasso._math.linalg import is_selfadjoint, is_skew_symmetric
 from piquasso._math.validations import all_in_interval
@@ -163,10 +161,10 @@ def test_GaussianHamiltonian_covariance_and_correlation_matrix_equivalence(
 
     omega = get_omega(d, connector)
 
-    T = from_xxpp_to_xpxp_transformation_matrix(d)
+    indices = xpxp_to_xxpp_indices(d)
 
     assert np.allclose(
-        T.T @ state.covariance_matrix @ T,
+        state.covariance_matrix[np.ix_(indices, indices)],
         -1j
         * omega
         @ (2 * state.correlation_matrix - np.identity(2 * d))
@@ -1097,9 +1095,11 @@ def test_covariance_matrix_GaussianHamiltonian_equivalence_from_Vacuum(
 
     gate_hamiltonian_majorana = -1j * omega @ gate_hamiltonian @ omega.conj().T
 
-    T = from_xxpp_to_xpxp_transformation_matrix(d)
+    indices = xxpp_to_xpxp_indices(d)
 
-    covariance_unitary = T @ connector.expm(-2 * gate_hamiltonian_majorana) @ T.T
+    covariance_unitary = connector.expm(-2 * gate_hamiltonian_majorana)[
+        np.ix_(indices, indices)
+    ]
 
     assert np.allclose(
         final_state.covariance_matrix,


### PR DESCRIPTION
Sometimes we need to switch between the xxpp and xpxp basis. In Piquasso, this is implemented by a basis changing matrix. However, as this matrix only reorders rows/columns, it would be much nicer if the vectors/matrices would just be reindexed. Therefore, this approach is deleted in favour of basis changing indices.