### PR TITLE
perf(fermionic): Minor improvements

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -9,6 +9,7 @@ ignore:
   - piquasso/_math/transformations.py
   - piquasso/_simulators/fock/calculations.py
   - piquasso/_simulators/connectors/connections.py
-  - piquasso/_simulators/connectors/jax_/connections.py
+  - piquasso/_simulators/connectors/_utils.py
   - piquasso/_simulators/connectors/numpy_/interferometer.py
+  - piquasso/_simulators/connectors/numpy_/connections.py
   - piquasso/fermionic/_utils.py

--- a/piquasso/_math/combinatorics.py
+++ b/piquasso/_math/combinatorics.py
@@ -36,9 +36,11 @@ def comb(n, k):
 
     prod = 1
 
+    k = min(k, n - k)
+
     for i in range(k):
         prod *= n - i
-        prod = prod // (i + 1)
+        prod //= i + 1
 
     return prod
 

--- a/piquasso/_simulators/connectors/_utils.py
+++ b/piquasso/_simulators/connectors/_utils.py
@@ -1,0 +1,44 @@
+#
+# Copyright 2021-2024 Budapest Quantum Computing Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+
+import numba as nb
+
+from piquasso.fermionic._utils import (
+    get_fock_subspace_dimension,
+    get_fock_subspace_index_first_quantized,
+    next_first_quantized,
+)
+
+
+@nb.njit(cache=True)
+def precalculate_fermionic_passive_linear_indices(n, d):
+    dim = get_fock_subspace_dimension(d, n)
+
+    laplace_indices = np.empty((dim, n), dtype=np.int64)
+    deleted_indices = np.empty((dim, n), dtype=np.int64)
+
+    first_quantized = np.arange(n)
+    for row_idx in range(dim):
+        for laplace_index in range(n):
+            deleted = np.delete(first_quantized, laplace_index)
+            deleted_idx = get_fock_subspace_index_first_quantized(deleted, d)
+            deleted_indices[row_idx, laplace_index] = deleted_idx
+            laplace_indices[row_idx, laplace_index] = first_quantized[laplace_index]
+
+        first_quantized = next_first_quantized(first_quantized, d)
+
+    return (laplace_indices, deleted_indices)

--- a/piquasso/_simulators/connectors/numpy_/connections.py
+++ b/piquasso/_simulators/connectors/numpy_/connections.py
@@ -1,0 +1,78 @@
+#
+# Copyright 2021-2024 Budapest Quantum Computing Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This file contains some common calculations for `NumpyConnector`.
+"""
+
+import numpy as np
+
+import numba as nb
+
+from .._utils import precalculate_fermionic_passive_linear_indices
+
+
+@nb.njit(cache=True)
+def calculate_interferometer_on_fermionic_fock_space(matrix, cutoff):
+    """Calculates the representation of the interferometer matrix on the Fock space.
+
+    This algorithm calculates the determinants of the submatrices recursively using
+    Laplace's expansion. For this, it is easiest to work in the first quantized picture.
+    """
+
+    d = len(matrix)
+
+    subspace_representations = []
+
+    subspace_representations.append(np.array([[1.0]], dtype=matrix.dtype))
+
+    if cutoff == 1:
+        return subspace_representations
+
+    subspace_representations.append(matrix)
+
+    if cutoff == 2:
+        return subspace_representations
+
+    for n in range(2, cutoff):
+        laplace_indices, deleted_indices = (
+            precalculate_fermionic_passive_linear_indices(n, d)
+        )
+
+        dim = laplace_indices.shape[0]
+
+        representation = np.zeros(shape=(dim, dim), dtype=matrix.dtype)
+
+        previous_representation = subspace_representations[n - 1]
+
+        for row_idx in range(dim):
+            matrix_row_idx = laplace_indices[row_idx, 0]
+            deleted_row_idx = deleted_indices[row_idx, 0]
+
+            for col_idx in range(dim):
+                for laplace_index in range(n):
+                    deleted_col_idx = deleted_indices[col_idx, laplace_index]
+
+                    representation[row_idx, col_idx] += (
+                        (-1) ** (laplace_index % 2)
+                        * matrix[
+                            matrix_row_idx, laplace_indices[col_idx, laplace_index]
+                        ]
+                        * previous_representation[deleted_row_idx, deleted_col_idx]
+                    )
+
+        subspace_representations.append(representation)
+
+    return subspace_representations

--- a/piquasso/_simulators/connectors/numpy_/connector.py
+++ b/piquasso/_simulators/connectors/numpy_/connector.py
@@ -27,6 +27,7 @@ from piquasso._math.hafnian import (
 from ..connector import BuiltinConnector, instancemethod
 
 from .interferometer import calculate_interferometer_on_fock_space
+from .connections import calculate_interferometer_on_fermionic_fock_space
 
 
 class NumpyConnector(BuiltinConnector):
@@ -51,6 +52,9 @@ class NumpyConnector(BuiltinConnector):
     loop_hafnian_batch = instancemethod(loop_hafnian_with_reduction_batch)
     calculate_interferometer_on_fock_space = instancemethod(
         calculate_interferometer_on_fock_space
+    )
+    calculate_interferometer_on_fermionic_fock_space = instancemethod(
+        calculate_interferometer_on_fermionic_fock_space
     )
 
     def sqrtm(self, matrix):

--- a/piquasso/fermionic/_utils.py
+++ b/piquasso/fermionic/_utils.py
@@ -207,13 +207,13 @@ def get_fock_subspace_index(occupation_numbers):
 def get_fock_subspace_index_first_quantized(first_quantized, d):
     n = len(first_quantized)
 
-    sum_ = 0
-    previous = 0
+    if n == 0:
+        return 0
+
+    sum_ = comb(d, n) - 1
 
     for i in range(n):
-        m = n - i
-        sum_ += comb(d - previous, m) - comb(d - first_quantized[i], m)
-        previous = first_quantized[i] + 1
+        sum_ -= comb(d - first_quantized[i] - 1, n - i)
 
     return sum_
 


### PR DESCRIPTION
A Numba implementation of `calculate_interferometer_on_fermionic_fock_space` is added. The `_precalculate_passive_linear_indices` got simplified, renamed, and moved to `piquasso/_simulators/connectors/_utils.py`. A minor improvement in `comb` has been added by using the symmetry of the binomial coefficients. Finally, the function `get_fock_subspace_index_first_quantized` is also simplified using Pascal's rule.