### PR TITLE
FIX: `jax` dependency fix

### DIFF
--- a/piquasso/_simulators/connectors/jax_/connector.py
+++ b/piquasso/_simulators/connectors/jax_/connector.py
@@ -17,12 +17,7 @@ import numpy as np
 
 from functools import partial
 
-from ..connector import BuiltinConnector, instancemethod
-
-from .connections import (
-    calculate_interferometer_on_fermionic_fock_space,
-    apply_fermionic_passive_linear_to_state_vector,
-)
+from ..connector import BuiltinConnector
 
 
 class JaxConnector(BuiltinConnector):
@@ -76,14 +71,6 @@ class JaxConnector(BuiltinConnector):
     # don't work together, when the condition depends on a tracer. Therefore,
     # conditionals must be disabled in this case
     allow_conditionals = False
-
-    calculate_interferometer_on_fermionic_fock_space = instancemethod(
-        calculate_interferometer_on_fermionic_fock_space
-    )
-
-    apply_fermionic_passive_linear_to_state_vector = instancemethod(
-        apply_fermionic_passive_linear_to_state_vector
-    )
 
     def __init__(self):
         try:
@@ -168,3 +155,21 @@ class JaxConnector(BuiltinConnector):
 
     def loop_hafnian_batch(self, matrix, diagonal, reduce_on, cutoff):
         raise NotImplementedError()
+
+    def calculate_interferometer_on_fermionic_fock_space(self, matrix, cutoff):
+        from .connections import (
+            calculate_interferometer_on_fermionic_fock_space,
+        )
+
+        return calculate_interferometer_on_fermionic_fock_space(matrix, cutoff)
+
+    def apply_fermionic_passive_linear_to_state_vector(
+        self, representations, state_vector, modes, d, cutoff
+    ):
+        from .connections import (
+            apply_fermionic_passive_linear_to_state_vector,
+        )
+
+        return apply_fermionic_passive_linear_to_state_vector(
+            representations, state_vector, modes, d, cutoff
+        )

--- a/tests/test_extras.py
+++ b/tests/test_extras.py
@@ -1,0 +1,32 @@
+#
+# Copyright 2021-2025 Budapest Quantum Computing Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+
+from unittest import mock
+
+
+def test_import_piquasso_works_without_tensorflow_dependency():
+    with mock.patch.dict(sys.modules, {"tensorflow": None}):
+        import piquasso
+
+        help(piquasso)
+
+
+def test_import_piquasso_works_without_jax_dependency():
+    with mock.patch.dict(sys.modules, {"jax": None}):
+        import piquasso
+
+        help(piquasso)


### PR DESCRIPTION
Importing piquasso raised an `ImportError` when `jax` was not installed, due to a wrong import. This has been fixed in this patch, and tests are also included to test correct functioning without `tensorflow` or `jax`.