### PR TITLE
fix: Numba reflected list warning

### DIFF
--- a/piquasso/fermionic/fock/state.py
+++ b/piquasso/fermionic/fock/state.py
@@ -82,7 +82,9 @@ class PureFockState(State):
         return self._connector.np.sum(self.fock_probabilities)
 
     def get_particle_detection_probability(self, occupation_number):
-        index = get_fock_space_index(occupation_number)
+        index = get_fock_space_index(
+            self._connector.fallback_np.array(occupation_number, dtype=int)
+        )
 
         return self._connector.np.abs(self._state_vector[index]) ** 2
 


### PR DESCRIPTION
We have encountered the following warning:
```
Encountered the use of a type that is scheduled for deprecation: type 'reflected list' found for argument 'occupation_numbers' of function 'get_fock_space_index'.
```
To fix this, one has to convert all inputs to arrays from lists.