### PR TITLE
Add fock_probabilities_map to PureFockState (unitaryHACK)

### DIFF
--- a/piquasso/fermionic/fock/state.py
+++ b/piquasso/fermionic/fock/state.py
@@ -25,9 +25,24 @@ from piquasso.api.connector import BaseConnector
 
 if TYPE_CHECKING:
     import numpy as np
+from piquasso.fermionic._utils import get_fock_space_basis
 
 
 class PureFockState(State):
+
+    @property
+    def fock_probabilities_map(self) -> dict:
+        """
+        Build a dict mapping each Fock-basis occupation tuple 
+        to its detection probability. Uses get_fock_space_basis
+        under the hood to enumerate all basis states up to the cutoff.
+        """
+        # enumerate all basis states for current dimension & cutoff
+        basis = get_fock_space_basis(self.d, self._config.cutoff)
+        # convert array rows to tuples of occupation numbers
+        occ_nums = [tuple(x) for x in basis.tolist()]
+        # zip occupation tuples with their probabilities
+        return dict(zip(occ_nums, self.fock_probabilities))
     r"""A fermionic pure Fock state."""
 
     def __init__(


### PR DESCRIPTION
This PR implements the `fock_probabilities_map` method for the `PureFockState` class in the fermionic package as part of unitaryHACK 2025.  

- Adds `fock_probabilities_map` method to `state.py`
- Adds corresponding unit test in `test_state.py`

Note: Initially encountered a ValueError due to unpacking from the basis states iterator. This was resolved by properly matching the structure of each item returned from generate_fock_basis.