### PR TITLE
feat(fermionic): `PureFockState.fock_probabilities_map`

### DIFF
--- a/piquasso/fermionic/fock/state.py
+++ b/piquasso/fermionic/fock/state.py
@@ -15,7 +15,11 @@
 
 from typing import Optional, TYPE_CHECKING
 
-from .._utils import get_cutoff_fock_space_dimension, get_fock_space_index
+from .._utils import (
+    get_cutoff_fock_space_dimension,
+    get_fock_space_index,
+    get_fock_space_basis,
+)
 
 from piquasso.api.exceptions import InvalidState
 
@@ -76,6 +80,14 @@ class PureFockState(State):
     def fock_probabilities(self) -> "np.ndarray":
         np = self._connector.np
         return np.conj(self._state_vector) * self._state_vector
+
+    @property
+    def fock_probabilities_map(self) -> dict:
+        fock_space_basis = get_fock_space_basis(self.d, self._config.cutoff)
+
+        occupation_numbers = [tuple(x) for x in fock_space_basis.tolist()]
+
+        return dict(zip(occupation_numbers, self.fock_probabilities))
 
     @property
     def norm(self) -> float:

--- a/tests/fermionic/fock/test_state.py
+++ b/tests/fermionic/fock/test_state.py
@@ -188,15 +188,10 @@ def test_PureFockState_fock_probabilities_map(connector):
 
     expected = {
         (0, 0): 0,
-        (0, 1): np.sin(theta) ** 2,
-        (1, 0): np.cos(theta) ** 2,
+        (1, 0): np.sin(theta) ** 2,
+        (0, 1): np.cos(theta) ** 2,
         (1, 1): 0,
     }
 
-    actual = state.fock_probabilities_map
-
-    for occupation_number, expected_probability in expected.items():
-        assert np.isclose(
-            actual[occupation_number],
-            expected_probability,
-        )
+    for occupation_number, probability in expected.items():
+        assert np.isclose(state.fock_probabilities_map[occupation_number], probability)

--- a/tests/fermionic/fock/test_state.py
+++ b/tests/fermionic/fock/test_state.py
@@ -170,3 +170,33 @@ def test_PureFockState_eq_different_type(connector):
     some_other_object = object()
 
     assert state != some_other_object
+
+
+@for_all_connectors
+def test_PureFockState_fock_probabilities_map(connector):
+    theta = np.pi / 5
+
+    U = np.array([[np.cos(theta), -np.sin(theta)], [np.sin(theta), np.cos(theta)]])
+
+    with pq.Program() as program:
+        pq.Q(0, 1) | pq.StateVector([0, 1])
+        pq.Q(0, 1) | pq.Interferometer(U)
+
+    simulator = pq.fermionic.PureFockSimulator(d=2, connector=connector)
+
+    state = simulator.execute(program).state
+
+    expected = {
+        (0, 0): 0,
+        (0, 1): np.sin(theta) ** 2,
+        (1, 0): np.cos(theta) ** 2,
+        (1, 1): 0,
+    }
+
+    actual = state.fock_probabilities_map
+
+    for occupation_number, expected_probability in expected.items():
+        assert np.isclose(
+            actual[occupation_number],
+            expected_probability,
+        )


### PR DESCRIPTION
In the `fermonic` package, the method `PureFockState.fock_probabilities` returns with the particle number detection probabilities for a generic pure state written in the Fock basis. However, the corresponding occupation numbers are not returned, but the ordering explained in the [documentation](https://piquasso.readthedocs.io/en/v6.0.1/experimental/fermionic.html#piquasso.fermionic.gaussian.GaussianState.fock_probabilities). This might be inconvenient for users.

To remedy this, the `PureFockState.fock_probabilities_map` method (practically a property, as `fock_probabilities`) is implemented, which returns `fock_probabilities` "zipped" with the corresponding occupation numbers.

Closes #435.