### PR TITLE
Add `get_marginal_fock_probabilities` method to Fock and Gaussian

### DIFF
--- a/piquasso/_simulators/fock/state.py
+++ b/piquasso/_simulators/fock/state.py
@@ -226,6 +226,20 @@ class BaseFockState(State, abc.ABC):
         )
         return np.abs(np.sum(geometric_mean)) ** 2
 
+    def get_marginal_fock_probabilities(
+        self, modes: Tuple[int, ...]
+    ) -> np.ndarray:
+        """Return the particle number probabilities on a given subsystem.
+
+        Args:
+            modes (tuple[int, ...]): The indices of the modes to keep.
+
+        Returns:
+            numpy.ndarray: The marginal particle number detection probabilities.
+        """
+
+        return self.reduced(modes).fock_probabilities
+
     @abc.abstractmethod
     def get_purity(self):
         """The purity of the Fock state."""

--- a/piquasso/_simulators/fock/state.py
+++ b/piquasso/_simulators/fock/state.py
@@ -226,9 +226,7 @@ class BaseFockState(State, abc.ABC):
         )
         return np.abs(np.sum(geometric_mean)) ** 2
 
-    def get_marginal_fock_probabilities(
-        self, modes: Tuple[int, ...]
-    ) -> np.ndarray:
+    def get_marginal_fock_probabilities(self, modes: Tuple[int, ...]) -> np.ndarray:
         """Return the particle number probabilities on a given subsystem.
 
         Args:

--- a/piquasso/_simulators/gaussian/state.py
+++ b/piquasso/_simulators/gaussian/state.py
@@ -955,9 +955,7 @@ class GaussianState(State):
             get_fock_space_basis(d=self.d, cutoff=self._config.cutoff)
         )
 
-    def get_marginal_fock_probabilities(
-        self, modes: Tuple[int, ...]
-    ) -> np.ndarray:
+    def get_marginal_fock_probabilities(self, modes: Tuple[int, ...]) -> np.ndarray:
         """Return the particle number probabilities on a given subsystem."""
 
         return self.reduced(modes).fock_probabilities

--- a/piquasso/_simulators/gaussian/state.py
+++ b/piquasso/_simulators/gaussian/state.py
@@ -955,6 +955,13 @@ class GaussianState(State):
             get_fock_space_basis(d=self.d, cutoff=self._config.cutoff)
         )
 
+    def get_marginal_fock_probabilities(
+        self, modes: Tuple[int, ...]
+    ) -> np.ndarray:
+        """Return the particle number probabilities on a given subsystem."""
+
+        return self.reduced(modes).fock_probabilities
+
     def is_pure(self) -> bool:
         return bool(np.isclose(self.get_purity(), 1.0))
 

--- a/tests/_simulators/fock/general/test_state.py
+++ b/tests/_simulators/fock/general/test_state.py
@@ -98,7 +98,7 @@ def test_FockState_get_marginal_fock_probabilities():
     state = simulator.execute(program).state
 
     modes = (1,)
-    expected_probabilities = state.reduced(modes).fock_probabilities
+    expected_probabilities = np.array([0.5, 0.25, 0.25, 0.0])
     actual_probabilities = state.get_marginal_fock_probabilities(modes)
 
     assert np.allclose(actual_probabilities, expected_probabilities)

--- a/tests/_simulators/fock/general/test_state.py
+++ b/tests/_simulators/fock/general/test_state.py
@@ -84,6 +84,26 @@ def test_FockState_fock_probabilities_map():
         )
 
 
+def test_FockState_get_marginal_fock_probabilities():
+    with pq.Program() as program:
+        pq.Q() | pq.DensityMatrix(ket=(0, 1), bra=(0, 1)) / 4
+
+        pq.Q() | pq.DensityMatrix(ket=(0, 2), bra=(0, 2)) / 4
+        pq.Q() | pq.DensityMatrix(ket=(2, 0), bra=(2, 0)) / 2
+
+        pq.Q() | pq.DensityMatrix(ket=(0, 2), bra=(2, 0)) * np.sqrt(1 / 8)
+        pq.Q() | pq.DensityMatrix(ket=(2, 0), bra=(0, 2)) * np.sqrt(1 / 8)
+
+    simulator = pq.FockSimulator(d=2)
+    state = simulator.execute(program).state
+
+    modes = (1,)
+    expected_probabilities = state.reduced(modes).fock_probabilities
+    actual_probabilities = state.get_marginal_fock_probabilities(modes)
+
+    assert np.allclose(actual_probabilities, expected_probabilities)
+
+
 def test_FockState_quadratures_mean_variance():
     with pq.Program() as program:
         pq.Q() | pq.Vacuum()

--- a/tests/_simulators/fock/pure/test_state.py
+++ b/tests/_simulators/fock/pure/test_state.py
@@ -105,7 +105,7 @@ def test_PureFockState_get_marginal_fock_probabilities():
     state = simulator.execute(program).state
 
     modes = (1,)
-    expected_probabilities = state.reduced(modes).fock_probabilities
+    expected_probabilities = np.array([0.5, 0.25, 0.25, 0.0])
     actual_probabilities = state.get_marginal_fock_probabilities(modes)
 
     assert np.allclose(actual_probabilities, expected_probabilities)

--- a/tests/_simulators/fock/pure/test_state.py
+++ b/tests/_simulators/fock/pure/test_state.py
@@ -94,6 +94,23 @@ def test_PureFockState_fock_probabilities_map():
         )
 
 
+def test_PureFockState_get_marginal_fock_probabilities():
+    with pq.Program() as program:
+        pq.Q() | pq.StateVector([0, 1]) / 2
+
+        pq.Q() | pq.StateVector([0, 2]) / 2
+        pq.Q() | pq.StateVector([2, 0]) / np.sqrt(2)
+
+    simulator = pq.PureFockSimulator(d=2)
+    state = simulator.execute(program).state
+
+    modes = (1,)
+    expected_probabilities = state.reduced(modes).fock_probabilities
+    actual_probabilities = state.get_marginal_fock_probabilities(modes)
+
+    assert np.allclose(actual_probabilities, expected_probabilities)
+
+
 def test_PureFockState_quadratures_mean_variance():
     with pq.Program() as program:
         pq.Q() | pq.Vacuum()

--- a/tests/_simulators/gaussian/test_state.py
+++ b/tests/_simulators/gaussian/test_state.py
@@ -292,6 +292,27 @@ def test_reduced_state_inherits_config():
     assert reduced_state._config == state._config
 
 
+def test_GaussianState_get_marginal_fock_probabilities():
+    with pq.Program() as program:
+        pq.Q(0) | pq.Displacement(r=1.0)
+        pq.Q(1) | pq.Displacement(r=2.0)
+        pq.Q(2) | pq.Displacement(r=3.0, phi=np.pi / 2)
+
+        pq.Q(0, 1) | pq.Squeezing2(r=np.log(2.0), phi=0.0)
+
+        pq.Q(0, 1) | pq.Beamsplitter(theta=np.pi / 2, phi=0)
+
+    simulator = pq.GaussianSimulator(d=3, config=pq.Config(cutoff=5))
+    state = simulator.execute(program).state
+    state.validate()
+
+    modes = (0, 2)
+    expected_probabilities = state.reduced(modes).fock_probabilities
+    actual_probabilities = state.get_marginal_fock_probabilities(modes)
+
+    assert np.allclose(actual_probabilities, expected_probabilities)
+
+
 def test_vacuum_covariance_is_proportional_to_identity():
     d = 2
 


### PR DESCRIPTION
Resolves #436 
- Implemented a convenience method to obtain marginal particle number probabilities. The method calls `reduced` internally and returns `fock_probabilities` for the selected subsystem
- Added unit tests confirming that the new method gives the same results as reducing the state explicitly, covering Fock, PureFock, and Gaussian simulators