### PR TITLE
chore: Avoid printing unnecessary help in test logs

### DIFF
--- a/tests/test_extras.py
+++ b/tests/test_extras.py
@@ -22,11 +22,11 @@ def test_import_piquasso_works_without_tensorflow_dependency():
     with mock.patch.dict(sys.modules, {"tensorflow": None}):
         import piquasso
 
-        help(piquasso)
+        print(piquasso)
 
 
 def test_import_piquasso_works_without_jax_dependency():
     with mock.patch.dict(sys.modules, {"jax": None}):
         import piquasso
 
-        help(piquasso)
+        print(piquasso)


### PR DESCRIPTION
During testing, the `help(piquasso)` is called, which - using the `-s` flag in `pytest` - prints out the entire help. Unfortunately, the pipeline uses this flag. To avoid printing it, just a simple `print` is called instead of `help`.