### PR TITLE
feat(sampling): Make `get_particle_detection_probability_gradient` differentiable

### DIFF
--- a/piquasso/_simulators/sampling/state.py
+++ b/piquasso/_simulators/sampling/state.py
@@ -93,18 +93,21 @@ class SamplingState(State):
                 f"occupation_number='{occupation_number}'."
             )
 
-        output_number_of_particles = np.sum(occupation_number)
+        np = self._connector.np
+        fallback_np = self._connector.fallback_np
+
+        output_number_of_particles = fallback_np.sum(occupation_number)
 
         sum_ = 0.0
 
         for index, input_occupation_number in enumerate(self._occupation_numbers):
-            if output_number_of_particles != np.sum(input_occupation_number):
+            if output_number_of_particles != fallback_np.sum(input_occupation_number):
                 continue
 
             inner_product = calculate_inner_product(
                 interferometer=self.interferometer,
                 input=input_occupation_number,
-                output=np.array(occupation_number),
+                output=fallback_np.array(occupation_number),
                 connector=self._connector,
             )
             coefficient = self._coefficients[index]


### PR DESCRIPTION
In this patch, `SamplingState.get_particle_detection_probability_gradient` is made differentiable through JAX by using JAX's NumPy interface. A simple test got written testing this feature.