### PR TITLE
Add Python 3.13 support 

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,24 +11,30 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.13"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install tox tox-gh-actions
+        pip install tox tox-gh-actions pytest pytest-cov jax jaxlib
+        if [[ "${{ matrix.python-version }}" != "3.13" ]]; then
+          pip install tensorflow
+        fi
+    - name: Install project with extras
+      run: |
+        pip install -e .[jax,dev]
     - name: Test with tox
-      run: tox
+      run: |
+        tox -e py${{ matrix.python-version//./ }}
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v4
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       with:
         fail_ci_if_error: true
-

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ jobs:
         pip install -e .[jax,dev]
     - name: Test with tox
       run: |
-        tox -e py${{ matrix.python-version//./ }}
+        tox -e py${{ matrix.python-version//./ }} -- --cov-report=xml
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v4
       env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.13"]
 
     steps:
     - uses: actions/checkout@v4

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,7 @@
 [pytest]
 markers =
     monkey: marks tests with stochastic inputs.
+    requires_tensorflow: mark tests that require TensorFlow
 
 python_functions = test_* *_benchmark *_script
 python_files = test_*.py *_benchmark.py *_script.py

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,7 @@
 [pytest]
 markers =
     monkey: marks tests with stochastic inputs.
-    requires_tensorflow: mark tests that require TensorFlow
+    requires_tensorflow: mark tests that require TensorFlow and should be skipped if unavailable
 
 python_functions = test_* *_benchmark *_script
 python_files = test_*.py *_benchmark.py *_script.py

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -267,3 +267,18 @@ def generate_random_fock_state():
         return occupation_numbers
 
     return func
+
+def is_python_313():
+    return sys.version_info >= (3, 13)
+
+def is_tensorflow_unavailable():
+    try:
+        import tensorflow  # noqa: F401
+        return False
+    except ImportError:
+        return True
+
+@pytest.fixture
+def pytest_runtest_setup(item):
+    if "requires_tensorflow" in item.keywords and is_python_313():
+        pytest.skip("Skipping TensorFlow-related test on Python 3.13 (TensorFlow not supported)")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -274,18 +274,31 @@ def is_python_313():
 
 @pytest.fixture(autouse=False, scope="function")
 def tensorflow_backend():
+    """Fixture providing Tensorflow module; skips if unavailable or on Python 3.13."""
     if is_python_313():
         pytest.skip("TensorFlow backend tests are skipped on Python 3.13")
     try:
-        import tensorflow as tf
+        import tensorflow as tf  # noqa: F401
         return tf
     except ImportError:
         pytest.skip("TensorFlow not available")
 
-
 def pytest_collection_modifyitems(config, items):
-    if is_python_313():
-        skip_tensorflow = pytest.mark.skip(reason="TensorFlow backend tests are skipped on Python 3.13")
-        for item in items:
-            if "requires_tensorflow" in item.keywords or "tensorflow_backend" in item.fixturenames:
-                item.add_marker(skip_tensorflow)
+    """Skip Tensorflow-related test cases on Python 3.13 during collection."""
+    if not is_python_313():
+        return
+    skip_tensorflow = pytest.mark.skip(reason="TensorFlow backend tests are skipped on Python 3.13")
+    for item in items:
+        # Handle parametrized tests
+        if hasattr(item, "callspec"):
+            for mark in item.iter_markers(name="parametrize"):
+                param_values = mark.args[1]
+                for idx, param in enumerate(param_values):
+                    if isinstance(param, pytest.param) and any(m.name == "requires_tensorflow" for m in param.marks):
+                        # Create a new item for non-Tensorflow params only
+                        if idx < len(item.callspec.params[list(item.callspec.params.keys())[0]]):
+                            continue
+                        item.add_marker(skip_tensorflow)
+        # Skip tests with explicit Tensorflow dependency
+        if "requires_tensorflow" in item.keywords or "tensorflow_backend" in item.fixturenames:
+            item.add_marker(skip_tensorflow)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import os
+import sys
 import pytest
 import numpy as np
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -283,3 +283,8 @@ def is_tensorflow_unavailable():
 def pytest_runtest_setup(item):
     if "requires_tensorflow" in item.keywords and is_python_313():
         pytest.skip("Skipping TensorFlow-related test on Python 3.13 (TensorFlow not supported)")
+
+def pytest_collection_modifyitems(config, items):
+    for item in items:
+        if "tests/_simulators/tensorflow/" in str(item.fspath):
+            item.add_marker(pytest.mark.requires_tensorflow)

--- a/tox.ini
+++ b/tox.ini
@@ -20,15 +20,21 @@ python =
 [testenv:py313]
 extras = jax,dev
 deps =
+    pytest
     pytest-cov
+    jax
+    jaxlib
 commands =
-    pytest --import-mode=append -vvv -s --cov={envsitepackagesdir}/piquasso tests
-    coverage report
+    pytest --import-mode=append -vvv -s --cov={envsitepackagesdir}/piquasso --cov-report=xml tests
 
 [testenv]
 extras = tensorflow,jax,dev
-deps =
+deps =    
+    pytest
     pytest-cov
+    jax
+    jaxlib
+    tensorflow; python_version < "3.13"
 commands =
     flake8
     nbqa flake8 --ignore=E402 docs/tutorials
@@ -42,8 +48,7 @@ commands =
     # `coverage`, because coverage already appends the pwd into `sys.path` that `pytest`
     # cannot delete.
     # Therefore, I had to use `pytest-cov`.
-    pytest --import-mode=append -vvv -s --cov={envsitepackagesdir}/piquasso tests
-    coverage xml
+    pytest --import-mode=append -vvv -s --cov={envsitepackagesdir}/piquasso --cov-report=xml tests
     coverage report
 
 [tox:.package]

--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,7 @@ commands =
     pytest --import-mode=append -vvv -s --cov={envsitepackagesdir}/piquasso --cov-report=xml tests
 
 [testenv]
-extras = tensorflow,jax,dev
+extras = jax,dev
 deps =    
     pytest
     pytest-cov

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@
 [tox]
 requires =
     tox>=4
-env_list = py{38,39,310,311,312}
+env_list = py{38,39,310,311,312,313}
 
 [gh-actions]
 python =
@@ -15,6 +15,15 @@ python =
     3.10: py310
     3.11: py311
     3.12: py312
+    3.13: py313
+
+[testenv:py313]
+extras = jax,dev
+deps =
+    pytest-cov
+commands =
+    pytest --import-mode=append -vvv -s --cov={envsitepackagesdir}/piquasso tests
+    coverage report
 
 [testenv]
 extras = tensorflow,jax,dev


### PR DESCRIPTION
This PR adds Python 3.13 support to Piquasso by conditionally skipping TensorFlow tests. I have added @pytest.mark.requires_tensorflow to mark TensorFlow-dependent tests.
I have also update the conftest.py to skip the tests on Python 3.13 if TensorFlow is not importable.

issue #441 

