### PR TITLE
Docs: add copybutton extension to docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -37,6 +37,7 @@ extensions = [
     "sphinx.ext.intersphinx",
     "nbsphinx",
     "sphinxcontrib.bibtex",
+    'sphinx_copybutton',
     "sphinx_design",
     "IPython.sphinxext.ipython_console_highlighting",
 ]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -37,7 +37,7 @@ extensions = [
     "sphinx.ext.intersphinx",
     "nbsphinx",
     "sphinxcontrib.bibtex",
-    'sphinx_copybutton',
+    "sphinx_copybutton",
     "sphinx_design",
     "IPython.sphinxext.ipython_console_highlighting",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ docs = [
   "nbsphinx~=0.9.5",
   "furo~=2024.8.6",
   "ipython>=8.12.3,<9.1.0",
+  "sphinx-copybutton~=0.5.2",
   "sphinx-design>=0.5,<0.7",
   "sphinxcontrib-bibtex==2.6.3",
 ]


### PR DESCRIPTION
**Context:**
There are many copy snippets on the Piquasso documentation websites, and it would be nice to make them copyable.

Closes #463.

**Description of the Change:**
Adds the ``sphinx-copybutton`` extension and the requirement for the extension.

**Benefits:**
Every code snippet becomes copyable via a button that appears in the top-right corner of the snippet box.

![Screenshot from 2025-06-06 18-26-48](https://github.com/user-attachments/assets/b8624e33-074f-4884-ba82-b5009c893b51)
