### PR TITLE
fix: Allow for nested program definition

### DIFF
--- a/piquasso/api/mode.py
+++ b/piquasso/api/mode.py
@@ -107,10 +107,10 @@ class Q:
             (Q): The current qumode.
         """
 
-        if _context.current_program is None:
+        if len(_context.program_stack) == 0:
             raise PiquassoException(
-                "The current program is None; therefore, it is not possible to register"
-                " the parameters on the given modes.\n"
+                "There is no `Program` instance available; it is not possible to"
+                " register the parameters on the specified modes.\n"
                 "Please use `Q(...) | ...` only inside `with pq.Program() as program:` "
                 "blocks, e.g.\n"
                 "\n"
@@ -118,7 +118,7 @@ class Q:
                 "    pq.Q(0, 1) | pq.Squeezing(r=0.5)"
             )
 
-        rhs._apply_to_program_on_register(_context.current_program, register=self)
+        rhs._apply_to_program_on_register(_context.program_stack[-1], register=self)
 
         return self
 

--- a/piquasso/api/program.py
+++ b/piquasso/api/program.py
@@ -92,12 +92,12 @@ class Program(_mixins.DictMixin, _mixins.RegisterMixin, _mixins.CodeMixin):
             )
 
     def __enter__(self) -> "Program":
-        _context.current_program = self
+        _context.program_stack.append(self)
 
         return self
 
     def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
-        _context.current_program = None
+        _context.program_stack.pop()
 
     @classmethod
     def from_dict(cls, dict_: dict) -> "Program":

--- a/piquasso/core/_context.py
+++ b/piquasso/core/_context.py
@@ -16,9 +16,9 @@
 """Global context variables."""
 
 import typing
-from typing import Optional
+from typing import List
 
 if typing.TYPE_CHECKING:
     from piquasso.api.program import Program
 
-current_program: Optional["Program"] = None
+program_stack: List["Program"] = []

--- a/tests/api/program/test_program_stacking.py
+++ b/tests/api/program/test_program_stacking.py
@@ -81,3 +81,30 @@ def test_mixed_index_program_stacking(FakeGate):
 
     assert program.instructions[1].modes == (1, 3)
     assert program.instructions[1].params == {"param": 100}
+
+
+def test_program_stacking_with_nested_definition(FakeGate):
+
+    def create_subprogram():
+        with pq.Program() as sub_program:
+            pq.Q(0, 1) | FakeGate(param=1)
+            pq.Q(2, 3) | FakeGate(param=2)
+
+        return sub_program
+
+    with pq.Program() as program:
+        pq.Q(0, 1) | FakeGate(param=0)
+        pq.Q(0, 2, 1, 3) | create_subprogram()
+        pq.Q(0, 3) | FakeGate(param=3)
+
+    assert program.instructions[0].modes == (0, 1)
+    assert program.instructions[0].params == {"param": 0}
+
+    assert program.instructions[1].modes == (0, 2)
+    assert program.instructions[1].params == {"param": 1}
+
+    assert program.instructions[2].modes == (1, 3)
+    assert program.instructions[2].params == {"param": 2}
+
+    assert program.instructions[3].modes == (0, 3)
+    assert program.instructions[3].params == {"param": 3}


### PR DESCRIPTION
In previous versions, if someone wanted to create a program within the program definition of another program using the `with pq.Program() as program` pattern, Piquasso threw a weird error.

This can be solved by storing multiple `Program` instances in `_context.current_program` using a FIFO queue, which has been renamed to `_context.program_stack` accordingly.

Closes #467.