### PR TITLE
chore: Add Python 3.13 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ keywords = ["quantum computing", "photonic quantum computing", "boson sampling"]
 maintainers = [
   { name = "Budapest Quantum Computing Group", email = "kolarovszki@inf.elte.hu" },
 ]
-requires-python = ">=3.8,<3.13"
+requires-python = ">=3.8,<3.14"
 dependencies = [
   "numpy>=1.19.5",
   "scipy>=1.5.4",
@@ -54,6 +54,7 @@ dev = [
   "nbqa>=1.3.1,<1.10.0",
   "nbmake~=1.5.4",
   "black>=24.2,<25.2",
+  "pytest-lazy-fixtures==1.1.4",
 ]
 docs = [
   "sphinx>=7.1.2,<8.3.0",

--- a/tests/_math/test_decompositions.py
+++ b/tests/_math/test_decompositions.py
@@ -14,6 +14,9 @@
 # limitations under the License.
 
 import pytest
+
+from pytest_lazy_fixtures import lf
+
 import numpy as np
 
 import piquasso as pq
@@ -27,12 +30,11 @@ from piquasso._math.decompositions import (
 
 from piquasso._simulators.connectors import (
     NumpyConnector,
-    TensorflowConnector,
     JaxConnector,
 )
 
 
-@pytest.mark.parametrize("connector", [NumpyConnector(), TensorflowConnector()])
+@pytest.mark.parametrize("connector", [NumpyConnector(), lf("tensorflow_connector")])
 def test_takagi_on_real_symmetric_2_by_2_matrix(connector):
     matrix = np.array(
         [
@@ -49,7 +51,7 @@ def test_takagi_on_real_symmetric_2_by_2_matrix(connector):
     assert np.allclose(matrix, unitary @ np.diag(singular_values) @ unitary.transpose())
 
 
-@pytest.mark.parametrize("connector", [NumpyConnector(), TensorflowConnector()])
+@pytest.mark.parametrize("connector", [NumpyConnector(), lf("tensorflow_connector")])
 def test_takagi_on_complex_symmetric_2_by_2_matrix_with_multiplicities(connector):
     matrix = np.array(
         [
@@ -66,7 +68,7 @@ def test_takagi_on_complex_symmetric_2_by_2_matrix_with_multiplicities(connector
     assert np.allclose(matrix, unitary @ np.diag(singular_values) @ unitary.transpose())
 
 
-@pytest.mark.parametrize("connector", [NumpyConnector(), TensorflowConnector()])
+@pytest.mark.parametrize("connector", [NumpyConnector(), lf("tensorflow_connector")])
 def test_takagi_on_real_symmetric_3_by_3_matrix(connector):
     matrix = np.array(
         [
@@ -84,7 +86,7 @@ def test_takagi_on_real_symmetric_3_by_3_matrix(connector):
     assert np.allclose(matrix, unitary @ np.diag(singular_values) @ unitary.transpose())
 
 
-@pytest.mark.parametrize("connector", [NumpyConnector(), TensorflowConnector()])
+@pytest.mark.parametrize("connector", [NumpyConnector(), lf("tensorflow_connector")])
 def test_takagi_on_complex_symmetric_3_by_3_matrix(connector):
     matrix = np.array(
         [
@@ -102,7 +104,7 @@ def test_takagi_on_complex_symmetric_3_by_3_matrix(connector):
 
 
 @pytest.mark.monkey
-@pytest.mark.parametrize("connector", [NumpyConnector(), TensorflowConnector()])
+@pytest.mark.parametrize("connector", [NumpyConnector(), lf("tensorflow_connector")])
 def test_takagi_on_complex_symmetric_6_by_6_matrix_with_multiplicities(
     connector,
     generate_unitary_matrix,
@@ -127,7 +129,7 @@ def test_takagi_on_complex_symmetric_6_by_6_matrix_with_multiplicities(
 
 @pytest.mark.monkey
 @pytest.mark.parametrize("N", [2, 3, 4, 5, 6])
-@pytest.mark.parametrize("connector", [NumpyConnector(), TensorflowConnector()])
+@pytest.mark.parametrize("connector", [NumpyConnector(), lf("tensorflow_connector")])
 def test_takagi_on_complex_symmetric_N_by_N_matrix(
     N, connector, generate_complex_symmetric_matrix
 ):

--- a/tests/_simulators/fock/pure/test_state.py
+++ b/tests/_simulators/fock/pure/test_state.py
@@ -195,9 +195,7 @@ def test_mean_position():
 
     config = pq.Config(cutoff=cutoff)
 
-    simulator = pq.PureFockSimulator(
-        d=d, config=config, connector=pq.TensorflowConnector()
-    )
+    simulator = pq.PureFockSimulator(d=d, config=config)
 
     state = simulator.execute(program).state
     mean = state.mean_position(mode=0)

--- a/tests/_simulators/fock/test_gates.py
+++ b/tests/_simulators/fock/test_gates.py
@@ -18,26 +18,17 @@ import pytest
 import numpy as np
 
 import piquasso as pq
-import tensorflow as tf
 
-from functools import partial
+from pytest_lazy_fixtures import lf
+
 
 tf_purefock_simulators = (
-    partial(
-        pq.PureFockSimulator,
-        connector=pq.TensorflowConnector(),
-    ),
-    partial(
-        pq.PureFockSimulator,
-        connector=pq.TensorflowConnector(decorate_with=tf.function),
-    ),
+    lf("PureFockSimulator_with_tensorflow"),
+    lf("PureFockSimulator_with_tensorflow_tf_function"),
 )
 
 jax_purefock_simulator = [
-    partial(
-        pq.PureFockSimulator,
-        connector=pq.JaxConnector(),
-    ),
+    lf("PureFockSimulator_with_jax"),
 ]
 
 

--- a/tests/_simulators/tensorflow/test_batch_gradient.py
+++ b/tests/_simulators/tensorflow/test_batch_gradient.py
@@ -15,21 +15,18 @@
 
 import pytest
 
-import tensorflow as tf
-
 import numpy as np
 
 import piquasso as pq
 
+from pytest_lazy_fixtures import lf
 
-connectors = (
-    pq.TensorflowConnector(),
-    pq.TensorflowConnector(decorate_with=tf.function),
-)
+
+connectors = (lf("tensorflow_connector"), lf("tensorflow_connector_tf_function"))
 
 
 @pytest.mark.parametrize("connector", connectors)
-def test_batch_Beamsplitter_mean_position(connector):
+def test_batch_Beamsplitter_mean_position(connector, tf):
     theta = tf.Variable(np.pi / 3)
 
     with pq.Program() as first_preparation:
@@ -82,7 +79,7 @@ def test_batch_Beamsplitter_mean_position(connector):
 
 
 @pytest.mark.parametrize("connector", connectors)
-def test_batch_Squeezing_mean_position(connector):
+def test_batch_Squeezing_mean_position(connector, tf):
     r = tf.Variable(0.1)
 
     with pq.Program() as first_preparation:
@@ -138,7 +135,7 @@ def test_batch_Squeezing_mean_position(connector):
 
 
 @pytest.mark.parametrize("connector", connectors)
-def test_batch_Displacement_mean_position(connector):
+def test_batch_Displacement_mean_position(connector, tf):
     r = tf.Variable(0.1)
 
     with pq.Program() as first_preparation:
@@ -194,7 +191,7 @@ def test_batch_Displacement_mean_position(connector):
 
 
 @pytest.mark.parametrize("connector", connectors)
-def test_batch_Kerr_mean_position(connector):
+def test_batch_Kerr_mean_position(connector, tf):
     xi = tf.Variable(0.1)
 
     with pq.Program() as first_preparation:
@@ -250,7 +247,7 @@ def test_batch_Kerr_mean_position(connector):
 
 
 @pytest.mark.parametrize("connector", connectors)
-def test_batch_Phaseshifter_mean_position(connector):
+def test_batch_Phaseshifter_mean_position(connector, tf):
     phi = tf.Variable(np.pi / 5)
 
     with pq.Program() as first_preparation:
@@ -306,7 +303,7 @@ def test_batch_Phaseshifter_mean_position(connector):
 
 
 @pytest.mark.parametrize("connector", connectors)
-def test_batch_complex_circuit_mean_position(connector):
+def test_batch_complex_circuit_mean_position(connector, tf):
     theta1 = tf.Variable(np.pi / 3)
     phi1 = tf.Variable(np.pi / 4)
 
@@ -415,7 +412,7 @@ def test_batch_complex_circuit_mean_position(connector):
 
 
 @pytest.mark.parametrize("connector", connectors)
-def test_batch_complex_circuit_mean_position_with_batch_apply(connector):
+def test_batch_complex_circuit_mean_position_with_batch_apply(connector, tf):
     theta1 = tf.Variable(np.pi / 3)
     phi1 = tf.Variable(np.pi / 4)
 

--- a/tests/_simulators/tensorflow/test_connector.py
+++ b/tests/_simulators/tensorflow/test_connector.py
@@ -20,7 +20,7 @@ import pytest
 
 
 @pytest.fixture
-def raise_ImportError_when_importing_tensorflow():
+def raise_ImportError_when_importing_tensorflow(tf):
     real_import = builtins.__import__
 
     def fake_import(name, globals, locals, fromlist, level):
@@ -37,7 +37,7 @@ def raise_ImportError_when_importing_tensorflow():
 
 
 @pytest.fixture
-def unimport_tensorflow():
+def unimport_tensorflow(tf):
     """
     Deletes `tensorflow` from `sys.modules`.
     """
@@ -46,7 +46,7 @@ def unimport_tensorflow():
         del sys.modules["tensorflow"]
 
 
-def test_TensorflowConnector_imports_tensorflow_if_installed():
+def test_TensorflowConnector_imports_tensorflow_if_installed(tf):
     import piquasso as pq
 
     pq.TensorflowConnector()
@@ -56,6 +56,7 @@ def test_TensorflowConnector_imports_tensorflow_if_installed():
 
 def test_TensorflowConnector_raises_ImportError_if_TensorFlow_not_installed(
     raise_ImportError_when_importing_tensorflow,
+    tf,
 ):
     import piquasso as pq
 

--- a/tests/_simulators/tensorflow/test_gates.py
+++ b/tests/_simulators/tensorflow/test_gates.py
@@ -15,11 +15,10 @@
 
 import piquasso as pq
 import pytest
-import tensorflow as tf
 
 
 @pytest.mark.monkey
-def test_Interferometer_numpy_array_as_parameter(generate_unitary_matrix):
+def test_Interferometer_numpy_array_as_parameter(generate_unitary_matrix, tf):
     r = tf.Variable(0.01)
     d = 5
     interferometer = generate_unitary_matrix(d)

--- a/tests/_simulators/tensorflow/test_gradient.py
+++ b/tests/_simulators/tensorflow/test_gradient.py
@@ -15,8 +15,6 @@
 
 import pytest
 
-import tensorflow as tf
-
 import numpy as np
 
 import piquasso as pq
@@ -25,7 +23,7 @@ from scipy.stats import unitary_group
 from scipy.linalg import block_diag
 
 
-def test_Displacement_mean_photon_number_gradient_1_mode():
+def test_Displacement_mean_photon_number_gradient_1_mode(tf):
     r = tf.Variable(0.43)
 
     simulator = pq.PureFockSimulator(
@@ -48,7 +46,7 @@ def test_Displacement_mean_photon_number_gradient_1_mode():
     assert np.isclose(gradient, 2 * r)
 
 
-def test_Displacement_mean_photon_number_gradient_1_mode_with_phaseshift():
+def test_Displacement_mean_photon_number_gradient_1_mode_with_phaseshift(tf):
     r = 0.1
     phi = tf.Variable(np.pi / 5)
 
@@ -72,7 +70,7 @@ def test_Displacement_mean_photon_number_gradient_1_mode_with_phaseshift():
     assert np.isclose(gradient, -np.sqrt(2 * simulator.config.hbar) * r * np.sin(phi))
 
 
-def test_Displacement_mean_photon_number_gradient_2_modes():
+def test_Displacement_mean_photon_number_gradient_2_modes(tf):
     r = tf.Variable([0.15, 0.2])
 
     simulator = pq.PureFockSimulator(
@@ -100,7 +98,7 @@ def test_Displacement_mean_photon_number_gradient_2_modes():
     assert np.allclose(gradient, 2 * r)
 
 
-def test_Displacement_fock_probabilities_jacobian_2_modes():
+def test_Displacement_fock_probabilities_jacobian_2_modes(tf):
     r = tf.Variable([0.15, 0.2])
 
     simulator = pq.PureFockSimulator(
@@ -170,7 +168,7 @@ def test_Displacement_fock_probabilities_jacobian_2_modes():
     )
 
 
-def test_Squeezing_mean_photon_number_gradient_1_mode():
+def test_Squeezing_mean_photon_number_gradient_1_mode(tf):
     r = tf.Variable(0.1)
 
     simulator = pq.PureFockSimulator(
@@ -195,7 +193,7 @@ def test_Squeezing_mean_photon_number_gradient_1_mode():
     assert np.isclose(gradient, 2 * np.sinh(r) * np.cosh(r))
 
 
-def test_Squeezing_mean_photon_number_gradient_1_mode_with_phaseshift():
+def test_Squeezing_mean_photon_number_gradient_1_mode_with_phaseshift(tf):
     r = 0.1
     phi = tf.Variable(np.pi / 5)
 
@@ -221,7 +219,7 @@ def test_Squeezing_mean_photon_number_gradient_1_mode_with_phaseshift():
     assert np.isclose(gradient, np.sinh(2 * r) * np.sin(phi))
 
 
-def test_Beamsplitter_fock_probabilities_gradient_1_particle():
+def test_Beamsplitter_fock_probabilities_gradient_1_particle(tf):
     theta = tf.Variable(np.pi / 3)
 
     simulator = pq.PureFockSimulator(
@@ -253,7 +251,7 @@ def test_Beamsplitter_fock_probabilities_gradient_1_particle():
     )
 
 
-def test_Beamsplitter_fock_probabilities_gradient_1_particle_with_phaseshift():
+def test_Beamsplitter_fock_probabilities_gradient_1_particle_with_phaseshift(tf):
     theta = tf.Variable(np.pi / 3)
     phi = np.pi / 5
 
@@ -286,7 +284,7 @@ def test_Beamsplitter_fock_probabilities_gradient_1_particle_with_phaseshift():
     )
 
 
-def test_decomposed_Beamsplitter_state_vector_gradient_1_particle():
+def test_decomposed_Beamsplitter_state_vector_gradient_1_particle(tf):
     theta = tf.Variable(11 * np.pi / 17)
 
     simulator = pq.PureFockSimulator(
@@ -323,7 +321,7 @@ def test_decomposed_Beamsplitter_state_vector_gradient_1_particle():
     )
 
 
-def test_Beamsplitter_fock_probabilities_gradient_2_particles():
+def test_Beamsplitter_fock_probabilities_gradient_2_particles(tf):
     theta = tf.Variable(np.pi / 3)
 
     simulator = pq.PureFockSimulator(
@@ -367,7 +365,7 @@ def test_Beamsplitter_fock_probabilities_gradient_2_particles():
     )
 
 
-def test_multiple_Beamsplitter_state_vector_gradient_2_particles():
+def test_multiple_Beamsplitter_state_vector_gradient_2_particles(tf):
     theta_1 = np.pi / 7
     phi_1 = 5 * np.pi / 9
     theta = tf.Variable(np.pi / 5)
@@ -430,7 +428,7 @@ def test_multiple_Beamsplitter_state_vector_gradient_2_particles():
     )
 
 
-def test_multiple_Beamsplitter_state_vector_gradient_2_particles_reversed():
+def test_multiple_Beamsplitter_state_vector_gradient_2_particles_reversed(tf):
     theta_1 = np.pi / 7
     phi_1 = 5 * np.pi / 9
     theta = tf.Variable(np.pi / 5)
@@ -494,7 +492,7 @@ def test_multiple_Beamsplitter_state_vector_gradient_2_particles_reversed():
 
 
 @pytest.mark.monkey
-def test_jacobian_of_state_after_mixing_with_fix_Interferometer():
+def test_jacobian_of_state_after_mixing_with_fix_Interferometer(tf):
     c1 = tf.Variable(np.sqrt(0.2))
     c2 = tf.Variable(np.sqrt(0.3))
     c3 = tf.Variable(np.sqrt(0.5))
@@ -541,7 +539,7 @@ def test_jacobian_of_state_after_mixing_with_fix_Interferometer():
     )
 
 
-def test_Phaseshifter_density_matrix_gradient():
+def test_Phaseshifter_density_matrix_gradient(tf):
     phi = tf.Variable(np.pi / 3)
 
     simulator = pq.PureFockSimulator(
@@ -586,7 +584,7 @@ def test_Phaseshifter_density_matrix_gradient():
     )
 
 
-def test_Phaseshifter_density_matrix_gradient_is_zero_at_zero_phaseshift():
+def test_Phaseshifter_density_matrix_gradient_is_zero_at_zero_phaseshift(tf):
     phi = tf.Variable(0.0)
 
     simulator = pq.PureFockSimulator(
@@ -610,7 +608,7 @@ def test_Phaseshifter_density_matrix_gradient_is_zero_at_zero_phaseshift():
     assert np.allclose(jacobian, np.zeros_like(jacobian))
 
 
-def test_Interferometer_fock_probabilities():
+def test_Interferometer_fock_probabilities(tf):
     param = tf.Variable(0.0)
 
     config = pq.Config(cutoff=3)
@@ -655,7 +653,7 @@ def test_Interferometer_fock_probabilities():
     assert np.allclose(jacobian, expected_jacobian)
 
 
-def test_Squeezing2_mean_photon_number():
+def test_Squeezing2_mean_photon_number(tf):
     r = tf.Variable(0.1)
 
     simulator = pq.PureFockSimulator(
@@ -679,7 +677,7 @@ def test_Squeezing2_mean_photon_number():
     assert np.allclose(jacobian, [-0.19349256, 0.0, 0.0, 0.0, 0.19349256, 0.0])
 
 
-def test_Kerr_fock_probabilities_on_1_mode():
+def test_Kerr_fock_probabilities_on_1_mode(tf):
     xi = tf.Variable(0.1)
 
     simulator = pq.PureFockSimulator(
@@ -702,7 +700,7 @@ def test_Kerr_fock_probabilities_on_1_mode():
     assert np.allclose(jacobian, [0.0, 0.0, 0.0], atol=1e-6)
 
 
-def test_Kerr_density_matrix_on_1_mode():
+def test_Kerr_density_matrix_on_1_mode(tf):
     xi = tf.Variable(np.pi / 5)
 
     n = 2
@@ -737,7 +735,7 @@ def test_Kerr_density_matrix_on_1_mode():
     assert np.allclose(jacobian, np.real(excepted_jacobian))
 
 
-def test_CubicPhase_fock_probabilities_on_1_mode():
+def test_CubicPhase_fock_probabilities_on_1_mode(tf):
     gamma = tf.Variable(0.1)
 
     simulator = pq.PureFockSimulator(
@@ -760,7 +758,7 @@ def test_CubicPhase_fock_probabilities_on_1_mode():
     assert np.allclose(jacobian, [-0.16857366, 0.35571513, -0.5196387, 0.33249724])
 
 
-def test_CrossKerr_density_matrix():
+def test_CrossKerr_density_matrix(tf):
     xi = tf.Variable(0.1)
 
     simulator = pq.PureFockSimulator(
@@ -799,7 +797,7 @@ def test_CrossKerr_density_matrix():
     assert np.allclose(jacobian, expected_jacobian)
 
 
-def test_mean_position_Displacement_gradient_on_1_mode():
+def test_mean_position_Displacement_gradient_on_1_mode(tf):
     d = 1
     cutoff = 7
 
@@ -826,7 +824,7 @@ def test_mean_position_Displacement_gradient_on_1_mode():
     assert np.allclose(grad, np.sqrt(2 * config.hbar))
 
 
-def test_mean_position_Displacement_and_Squeezing_gradient_on_1_mode():
+def test_mean_position_Displacement_and_Squeezing_gradient_on_1_mode(tf):
     d = 1
     cutoff = 7
 
@@ -853,7 +851,7 @@ def test_mean_position_Displacement_and_Squeezing_gradient_on_1_mode():
     assert np.allclose(grad, [-0.019024614, 1.9024585382680494])
 
 
-def test_Displacement_state_vector_gradient():
+def test_Displacement_state_vector_gradient(tf):
     r = tf.Variable(0.1)
 
     simulator = pq.PureFockSimulator(
@@ -886,7 +884,7 @@ def test_Displacement_state_vector_gradient():
     assert np.allclose(jacobian, expected_jacobian)
 
 
-def test_complex_Displacement_state_vector_gradient():
+def test_complex_Displacement_state_vector_gradient(tf):
     r = tf.Variable(0.1)
     phi = tf.Variable(np.pi / 3)
 
@@ -937,7 +935,7 @@ def test_complex_Displacement_state_vector_gradient():
     assert np.allclose(jacobian, expected_jacobian)
 
 
-def test_Squeezing_state_vector_gradient():
+def test_Squeezing_state_vector_gradient(tf):
     r = tf.Variable(0.1)
 
     simulator = pq.PureFockSimulator(
@@ -973,7 +971,7 @@ def test_Squeezing_state_vector_gradient():
     assert np.allclose(jacobian, expected_jacobian)
 
 
-def test_complex_Squeezing_state_vector_gradient():
+def test_complex_Squeezing_state_vector_gradient(tf):
     r = tf.Variable(0.1)
     phi = tf.Variable(np.pi / 3)
 
@@ -1027,7 +1025,7 @@ def test_complex_Squeezing_state_vector_gradient():
     assert np.allclose(jacobian, expected_jacobian)
 
 
-def test_displaced_state_Squeezing_state_vector_gradient():
+def test_displaced_state_Squeezing_state_vector_gradient(tf):
     r = tf.Variable(0.1)
     phi = tf.Variable(np.pi / 3)
 
@@ -1070,7 +1068,7 @@ def test_displaced_state_Squeezing_state_vector_gradient():
     )
 
 
-def test_displaced_state_Beamsplitter_state_vector_gradient():
+def test_displaced_state_Beamsplitter_state_vector_gradient(tf):
     theta = tf.Variable(0.05)
     phi = tf.Variable(np.pi / 3)
 

--- a/tests/_simulators/tensorflow/test_measurements.py
+++ b/tests/_simulators/tensorflow/test_measurements.py
@@ -14,11 +14,10 @@
 # limitations under the License.
 
 import piquasso as pq
-import tensorflow as tf
 import numpy as np
 
 
-def test_PostSelectPhotons_gradient():
+def test_PostSelectPhotons_gradient(tf):
     def _calculate_loss(weights, connector, state_vector):
         np = connector.np
 
@@ -86,7 +85,7 @@ def test_PostSelectPhotons_gradient():
     assert np.allclose(grad, 0.0, atol=1e-7)
 
 
-def test_ImperfectPostSelectPhotons_gradient():
+def test_ImperfectPostSelectPhotons_gradient(tf):
     def _calculate_loss(weights, connector, state_vector):
         np = connector.np
 

--- a/tests/_simulators/test_simulator.py
+++ b/tests/_simulators/test_simulator.py
@@ -22,7 +22,7 @@ def test_GaussianSimulator_supports_NumpyConnector():
     pq.GaussianSimulator(d=1, connector=pq.NumpyConnector())
 
 
-def test_GaussianSimulator_does_not_support_TensorflowConnector():
+def test_GaussianSimulator_does_not_support_TensorflowConnector(tf):
     connector = pq.TensorflowConnector()
 
     with pytest.raises(pq.api.exceptions.InvalidSimulation) as error:
@@ -35,7 +35,7 @@ def test_SamplingSimulator_supports_NumpyConnector():
     pq.SamplingSimulator(d=1, connector=pq.NumpyConnector())
 
 
-def test_SamplingSimulator_does_not_support_TensorflowConnector():
+def test_SamplingSimulator_does_not_support_TensorflowConnector(tf):
     connector = pq.TensorflowConnector()
 
     with pytest.raises(pq.api.exceptions.InvalidSimulation) as error:
@@ -48,7 +48,7 @@ def test_FockSimulator_supports_NumpyConnector():
     pq.FockSimulator(d=1, connector=pq.NumpyConnector())
 
 
-def test_FockSimulator_does_not_support_TensorflowConnector():
+def test_FockSimulator_does_not_support_TensorflowConnector(tf):
     connector = pq.TensorflowConnector()
 
     with pytest.raises(pq.api.exceptions.InvalidSimulation) as error:
@@ -61,5 +61,5 @@ def test_PureFockSimulator_supports_NumpyConnector():
     pq.PureFockSimulator(d=1, connector=pq.NumpyConnector())
 
 
-def test_PureFockSimulator_supports_TensorflowConnector():
+def test_PureFockSimulator_supports_TensorflowConnector(tf):
     pq.PureFockSimulator(d=1, connector=pq.TensorflowConnector())

--- a/tests/_simulators/test_simulator_equivalence.py
+++ b/tests/_simulators/test_simulator_equivalence.py
@@ -16,11 +16,10 @@
 import pytest
 import numpy as np
 import piquasso as pq
-import tensorflow as tf
 
 import collections
 
-from functools import partial
+from pytest_lazy_fixtures import lf
 
 from scipy.stats import unitary_group
 from scipy.linalg import polar, sinhm, coshm, expm
@@ -38,21 +37,12 @@ def is_proportional(first, second, rtol=1e-5):
 
 
 tf_purefock_simulators = (
-    partial(
-        pq.PureFockSimulator,
-        connector=pq.TensorflowConnector(),
-    ),
-    partial(
-        pq.PureFockSimulator,
-        connector=pq.TensorflowConnector(decorate_with=tf.function),
-    ),
+    lf("PureFockSimulator_with_tensorflow"),
+    lf("PureFockSimulator_with_tensorflow_tf_function"),
 )
 
 jax_purefock_simulator = [
-    partial(
-        pq.PureFockSimulator,
-        connector=pq.JaxConnector(),
-    ),
+    lf("PureFockSimulator_with_jax"),
 ]
 
 

--- a/tests/decompositions/test_clements.py
+++ b/tests/decompositions/test_clements.py
@@ -14,12 +14,13 @@
 # limitations under the License.
 
 import pytest
+
+from pytest_lazy_fixtures import lf
+
 import numpy as np
 from scipy.stats import unitary_group
 
 import piquasso as pq
-
-import tensorflow as tf
 
 from jax import grad
 
@@ -262,7 +263,7 @@ def test_instructions_from_decomposition_using_piquasso_GaussianSimulator_random
 
 
 @pytest.mark.parametrize(
-    "connector", (pq.NumpyConnector(), pq.TensorflowConnector(), pq.JaxConnector())
+    "connector", (pq.NumpyConnector(), lf("tensorflow_connector"), pq.JaxConnector())
 )
 def test_clements_decomposition_roundtrip(connector, dummy_unitary):
     d = 5
@@ -276,7 +277,7 @@ def test_clements_decomposition_roundtrip(connector, dummy_unitary):
 
 
 @pytest.mark.parametrize(
-    "connector", (pq.NumpyConnector(), pq.TensorflowConnector(), pq.JaxConnector())
+    "connector", (pq.NumpyConnector(), lf("tensorflow_connector"), pq.JaxConnector())
 )
 def test_clements_decomposition_roundtrip_with_weights(connector, dummy_unitary):
     d = 6
@@ -296,7 +297,7 @@ def test_clements_decomposition_roundtrip_with_weights(connector, dummy_unitary)
 
 
 @pytest.mark.parametrize(
-    "connector", (pq.NumpyConnector(), pq.TensorflowConnector(), pq.JaxConnector())
+    "connector", (pq.NumpyConnector(), lf("tensorflow_connector"), pq.JaxConnector())
 )
 def test_weigths_to_interferometer_roundtrip(connector, dummy_unitary):
     d = 6
@@ -309,7 +310,7 @@ def test_weigths_to_interferometer_roundtrip(connector, dummy_unitary):
     assert np.allclose(U, new_U)
 
 
-def test_clements_decomposition_with_TensorflowConnector(dummy_unitary):
+def test_clements_decomposition_with_TensorflowConnector(dummy_unitary, tf):
     U = tf.Variable(dummy_unitary(2))
 
     with tf.GradientTape() as tape:
@@ -372,7 +373,9 @@ def test_clements_decomposition_with_JaxConnector(dummy_unitary):
     )
 
 
-def test_clements_decomposition_with_TensorflowConnector_from_weights(dummy_unitary):
+def test_clements_decomposition_with_TensorflowConnector_from_weights(
+    dummy_unitary, tf
+):
     d = 2
     U = dummy_unitary(d)
 

--- a/tests/slow/test_tf_function.py
+++ b/tests/slow/test_tf_function.py
@@ -17,14 +17,25 @@ import pytest
 
 import numpy as np
 import piquasso as pq
-import tensorflow as tf
+
+from pytest_lazy_fixtures import lf
+
+
+@pytest.fixture
+def tf_function(tf):
+    return tf.function
+
+
+@pytest.fixture
+def tf_function_jit(tf):
+    return tf.function(jit_compile=True)
 
 
 def noop_decorator(func):
     return func
 
 
-def test_tf_function_cvnn_layer_1_mode_1_layers():
+def test_tf_function_cvnn_layer_1_mode_1_layers(tf):
     d = 1
     cutoff = 3
 
@@ -60,7 +71,7 @@ def test_tf_function_cvnn_layer_1_mode_1_layers():
     )
 
 
-def test_tf_function_cvnn_layer_2_modes_2_layers():
+def test_tf_function_cvnn_layer_2_modes_2_layers(tf):
     d = 2
     cutoff = 3
 
@@ -162,7 +173,7 @@ def test_tf_function_cvnn_layer_2_modes_2_layers():
     )
 
 
-def test_tf_function_cvnn_layer_1_mode_1_layers_decorate_with_tf_function():
+def test_tf_function_cvnn_layer_1_mode_1_layers_decorate_with_tf_function(tf):
     d = 1
     cutoff = 3
 
@@ -198,7 +209,7 @@ def test_tf_function_cvnn_layer_1_mode_1_layers_decorate_with_tf_function():
     )
 
 
-def test_tf_function_cvnn_layer_2_modes_2_layers_decorate_with_tf_function():
+def test_tf_function_cvnn_layer_2_modes_2_layers_decorate_with_tf_function(tf):
     d = 2
     cutoff = 3
 
@@ -300,7 +311,7 @@ def test_tf_function_cvnn_layer_2_modes_2_layers_decorate_with_tf_function():
     )
 
 
-def test_tf_function_cvnn_layer_1_mode_1_layers_jit_compile():
+def test_tf_function_cvnn_layer_1_mode_1_layers_jit_compile(tf):
     d = 1
     cutoff = 3
 
@@ -338,7 +349,7 @@ def test_tf_function_cvnn_layer_1_mode_1_layers_jit_compile():
     )
 
 
-def test_tf_function_cvnn_layer_2_modes_2_layers_jit_compile():
+def test_tf_function_cvnn_layer_2_modes_2_layers_jit_compile(tf):
     d = 2
     cutoff = 3
 
@@ -443,9 +454,9 @@ def test_tf_function_cvnn_layer_2_modes_2_layers_jit_compile():
 
 
 @pytest.mark.parametrize(
-    "decorator", (noop_decorator, tf.function, tf.function(jit_compile=True))
+    "decorator", (noop_decorator, lf("tf_function"), lf("tf_function_jit"))
 )
-def test_tf_function_cvnn_layer_1_mode_1_layers_custom_initial_state(decorator):
+def test_tf_function_cvnn_layer_1_mode_1_layers_custom_initial_state(decorator, tf):
     d = 1
     cutoff = 3
 

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@
 [tox]
 requires =
     tox>=4
-env_list = py{38,39,310,311,312}
+env_list = py{38,39,310,311,312,313}
 
 [gh-actions]
 python =
@@ -15,9 +15,12 @@ python =
     3.10: py310
     3.11: py311
     3.12: py312
+    3.13: py313
 
 [testenv]
-extras = tensorflow,jax,dev
+extras =
+    py{38,39,310,311,312}: jax,dev,tensorflow
+    py313: jax,dev
 deps =
     pytest-cov
 commands =
@@ -33,7 +36,8 @@ commands =
     # `coverage`, because coverage already appends the pwd into `sys.path` that `pytest`
     # cannot delete.
     # Therefore, I had to use `pytest-cov`.
-    pytest --import-mode=append -vvv -s --cov={envsitepackagesdir}/piquasso tests
+    py313: pytest --import-mode=append -vvv -s --cov={envsitepackagesdir}/piquasso --skip-tensorflow tests
+    !py313: pytest --import-mode=append -vvv -s --cov={envsitepackagesdir}/piquasso tests
     coverage xml
     coverage report
 


### PR DESCRIPTION
Python 3.13 support is added in this patch.

It was a bit tricky, as TensorFlow is not released for Python 3.13 yet, so one has to disable all the tests that use TensorFlow on Python 3.13. This is done by creating a new `--skip-tensorflow` pytest option, which disables these tests. By putting the `tensorflow` import in a fixture, we can optionally skip those tests that try to use this fixture.

As there are many parametrized tests depending on `tensorflow` (e.g., through `TensorflowConnector`), we had to implement a mechanism to use fixtures in parametrized tests as parameters. This is enabled by the `pytest_lazy_fixtures` plugin.

The test `tests/_simulators/fock/pure/test_state.py::test_mean_position` mistakenly used `TensorflowConnector`, so this test has been rewritten to use the default `NumpyConnector` instead.

The `--skip-tensorflow` flag is specified in `tox.ini` conditionally.

Source:
- [Pytest lazy fixtures plugin](https://github.com/dev-petrov/pytest-lazy-fixtures)
- [tox conditional settings](https://tox.wiki/en/latest/config.html#conditional-settings)