### PR TITLE
fix(_math): Avoid forcecasting

### DIFF
--- a/piquasso/_math/permanent.cpp
+++ b/piquasso/_math/permanent.cpp
@@ -24,7 +24,7 @@ namespace py = pybind11;
 
 template <typename TScalar>
 py::object permanent_np(
-    py::array_t<std::complex<TScalar>, py::array::c_style | py::array::forcecast> matrix,
+    py::array_t<std::complex<TScalar>, py::array::c_style> matrix,
     py::array_t<int, py::array::c_style | py::array::forcecast> row_mult_arr,
     py::array_t<int, py::array::c_style | py::array::forcecast> col_mult_arr
 )

--- a/piquasso/_math/pfaffian.cpp
+++ b/piquasso/_math/pfaffian.cpp
@@ -24,7 +24,7 @@ namespace py = pybind11;
 
 template <typename TScalar>
 py::object pfaffian_np(
-    py::array_t<TScalar, py::array::c_style | py::array::forcecast> matrix)
+    py::array_t<TScalar, py::array::c_style> matrix)
 {
     Matrix<TScalar> native_matrix = numpy_to_matrix(matrix);
 

--- a/piquasso/_math/torontonian.cpp
+++ b/piquasso/_math/torontonian.cpp
@@ -25,7 +25,7 @@ namespace py = pybind11;
 
 template <typename TScalar>
 py::object torontonian_np(
-    py::array_t<TScalar, py::array::c_style | py::array::forcecast> matrix)
+    py::array_t<TScalar, py::array::c_style> matrix)
 {
     Matrix<TScalar> native_matrix = numpy_to_matrix(matrix);
 
@@ -36,8 +36,8 @@ py::object torontonian_np(
 
 template <typename TScalar>
 py::object loop_torontonian_np(
-    py::array_t<TScalar, py::array::c_style | py::array::forcecast> matrix,
-    py::array_t<TScalar, py::array::c_style | py::array::forcecast> displacement_vector)
+    py::array_t<TScalar, py::array::c_style> matrix,
+    py::array_t<TScalar, py::array::c_style> displacement_vector)
 {
     Matrix<TScalar> native_matrix = numpy_to_matrix(matrix);
     Vector<TScalar> native_displacement_vector = numpy_to_vector(displacement_vector);

--- a/src/numpy_utils.hpp
+++ b/src/numpy_utils.hpp
@@ -51,9 +51,9 @@ py::object create_numpy_scalar(TScalar input)
 /**
  * Creates a Matrix from a numpy array with shared memory.
  */
-template <typename TScalar>
+template <typename TScalar, int Flags>
 Matrix<TScalar> numpy_to_matrix(
-    py::array_t<TScalar, py::array::c_style | py::array::forcecast> numpy_array)
+    py::array_t<TScalar, Flags> numpy_array)
 {
     py::buffer_info bufferinfo = numpy_array.request();
 
@@ -71,9 +71,9 @@ Matrix<TScalar> numpy_to_matrix(
 /**
  * Creates a Vector from a numpy array with shared memory.
  */
-template <typename TScalar>
+template <typename TScalar, int Flags>
 Vector<TScalar> numpy_to_vector(
-    py::array_t<TScalar, py::array::c_style | py::array::forcecast> numpy_array)
+    py::array_t<TScalar, Flags> numpy_array)
 {
     py::buffer_info bufferinfo = numpy_array.request();
 

--- a/tests/_math/test_permanent.py
+++ b/tests/_math/test_permanent.py
@@ -249,6 +249,39 @@ def test_permanent_equivalence_without_repetitions(
     )
 
 
+def test_permanent_equivalence_without_repetitions_integer_matrix():
+    n = 10
+
+    rows = np.array([0, 0, 0, 0, 0, 3, 4, 0, 3, 0], dtype=int)
+    cols = np.array([1, 0, 0, 0, 0, 0, 1, 7, 0, 1], dtype=int)
+
+    matrix = np.array(
+        [
+            [0.0, 0.0, -1.0, -1.0, -1.0, 0.0, -1.0, 0.0, 0.0, -1.0],
+            [-1.0, -1.0, -1.0, -1.0, 0.0, 0.0, -1.0, -1.0, -1.0, -1.0],
+            [-1.0, 0.0, -1.0, -1.0, -1.0, 0.0, 0.0, -1.0, 0.0, -1.0],
+            [-1.0, 0.0, -1.0, -1.0, -1.0, -1.0, 0.0, -1.0, -1.0, -1.0],
+            [-1.0, 0.0, 0.0, -1.0, -1.0, -1.0, -1.0, -1.0, 0.0, -1.0],
+            [0.0, -1.0, 0.0, 0.0, -1.0, -1.0, -1.0, -1.0, 0.0, -1.0],
+            [-1.0, 0.0, 0.0, 0.0, -1.0, -1.0, -1.0, -1.0, 0.0, -1.0],
+            [0.0, 0.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0, -1.0, -1.0, -1.0, 0.0, 0.0, -1.0, -1.0],
+            [0.0, 0.0, 0.0, 0.0, -1.0, 0.0, -1.0, -1.0, -1.0, 0.0],
+        ],
+        dtype=np.complex128,
+    )
+
+    ones = np.ones(n, dtype=int)
+
+    direct_value = permanent(matrix, rows=rows, cols=cols)
+    indirect_value = permanent(assym_reduce(matrix, rows, cols), ones, ones)
+
+    assert direct_value.dtype == np.complex128
+
+    assert np.isclose(direct_value, indirect_value)
+    assert np.isclose(direct_value, 0.0)
+
+
 def test_permanent_asymmetric_matrix():
     unitary = np.array(
         [


### PR DESCRIPTION
The problem with the flag `py::array::forcecast` is that, e.g., in a scenario where the scalars in the input array has a dtype which is equivalent to `double` in C++, `pybind` will go through the signatures, and if the first signature is specified with `float` and `forcecast` is also specified, the `double`s will be converted to `float`s here, instead of checking the next signature. This results in a decrease in precision.

To resolve this, the `forcecast` flag is deleted. However, casting still needs to be done for integer array arguments, therefore the functions `numpy_to_matrix` and `numpy_to_vector` got extended with an additional template argument `Flags`.