### PR TITLE
Add `Result.get_counts`

### DIFF
--- a/piquasso/api/result.py
+++ b/piquasso/api/result.py
@@ -41,9 +41,15 @@ class Result:
         return f"Result(samples={self.samples}, state={self.state})"
 
     def get_counts(self):
-        if any(not isinstance(sample, (int, np.integer)) for sample_tuple in self.samples for sample in sample_tuple):
-            raise NotImplementedError("The get_counts method only supports measurements that provide integer samples."\
-            "(like particle number measurements).")
+        if any(
+            not isinstance(sample, (int, np.integer))
+            for sample_tuple in self.samples
+            for sample in sample_tuple
+        ):
+            raise NotImplementedError(
+                "The get_counts method only supports measurements that provide integer samples."
+                "(like particle number measurements)."
+            )
 
         counts_dct = {}
         for sample in self.samples:

--- a/piquasso/api/result.py
+++ b/piquasso/api/result.py
@@ -17,8 +17,7 @@ from typing import List, Tuple, Optional, Union, TYPE_CHECKING
 
 from piquasso.api.state import State
 
-if TYPE_CHECKING:
-    import numpy as np
+import numpy as np
 
 
 class Result:
@@ -42,6 +41,10 @@ class Result:
         return f"Result(samples={self.samples}, state={self.state})"
 
     def get_counts(self):
+        if any(not isinstance(sample, (int, np.integer)) for sample_tuple in self.samples for sample in sample_tuple):
+            raise NotImplementedError("The get_counts method only supports measurements that provide integer samples."\
+            "(like particle number measurements).")
+
         counts_dct = {}
         for sample in self.samples:
             if sample not in counts_dct:

--- a/piquasso/api/result.py
+++ b/piquasso/api/result.py
@@ -41,14 +41,10 @@ class Result:
         return f"Result(samples={self.samples}, state={self.state})"
 
     def get_counts(self):
-        if any(
-            not isinstance(sample, (int, np.integer))
-            for sample_tuple in self.samples
-            for sample in sample_tuple
-        ):
+        if self.samples and not isinstance(self.samples[0][0], (int, np.integer)):
             raise NotImplementedError(
-                "The get_counts method only supports measurements that provide "
-                "integer samples. (like particle number measurements)."
+                "The 'Result.get_counts' method only supports samples that contain "
+                "integers (e.g., samples from 'ParticleNumberMeasurement')."
             )
 
         counts_dct = {}

--- a/piquasso/api/result.py
+++ b/piquasso/api/result.py
@@ -40,10 +40,11 @@ class Result:
     def __repr__(self) -> str:
         return f"Result(samples={self.samples}, state={self.state})"
 
-    def get_counts(self):
-        if isinstance(self.samples, np.ndarray) or (
-            self.samples and not isinstance(self.samples[0][0], (int, np.integer))
-        ):
+    def get_counts(self) -> dict:
+        if (
+            isinstance(self.samples, np.ndarray)
+            and self.samples.dtype not in (np.int32, np.int64)
+        ) or (self.samples and not isinstance(self.samples[0][0], (int, np.integer))):
             raise NotImplementedError(
                 "The 'Result.get_counts' method only supports samples that contain "
                 "integers (e.g., samples from 'ParticleNumberMeasurement')."

--- a/piquasso/api/result.py
+++ b/piquasso/api/result.py
@@ -41,7 +41,9 @@ class Result:
         return f"Result(samples={self.samples}, state={self.state})"
 
     def get_counts(self):
-        if self.samples and not isinstance(self.samples[0][0], (int, np.integer)):
+        if isinstance(self.samples, np.ndarray) or (
+            self.samples and not isinstance(self.samples[0][0], (int, np.integer))
+        ):
             raise NotImplementedError(
                 "The 'Result.get_counts' method only supports samples that contain "
                 "integers (e.g., samples from 'ParticleNumberMeasurement')."

--- a/piquasso/api/result.py
+++ b/piquasso/api/result.py
@@ -41,6 +41,15 @@ class Result:
     def __repr__(self) -> str:
         return f"Result(samples={self.samples}, state={self.state})"
 
+    def get_counts(self):
+        counts_dct = {}
+        for sample in self.samples:
+            if sample not in counts_dct:
+                counts_dct[sample] = 1
+            else:
+                counts_dct[sample] += 1
+        return counts_dct
+
     def to_subgraph_nodes(self) -> List[List[int]]:
         """Convert samples to subgraph modes.
 

--- a/piquasso/api/result.py
+++ b/piquasso/api/result.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List, Tuple, Optional, Union, TYPE_CHECKING
+from typing import List, Tuple, Optional, Union
 
 from piquasso.api.state import State
 
@@ -47,8 +47,8 @@ class Result:
             for sample in sample_tuple
         ):
             raise NotImplementedError(
-                "The get_counts method only supports measurements that provide integer samples."
-                "(like particle number measurements)."
+                "The get_counts method only supports measurements that provide "
+                "integer samples. (like particle number measurements)."
             )
 
         counts_dct = {}

--- a/tests/_simulators/sampling/test_measurements.py
+++ b/tests/_simulators/sampling/test_measurements.py
@@ -153,9 +153,7 @@ def test_counts_raises(simulator, measurement_class):
     simulator = simulator(d=3)
     res = simulator.execute(program, shots=shots)
     with pytest.raises(
-        NotImplementedError,
-        match="The get_counts method only supports measurements "
-        "that provide integer samples",
+        NotImplementedError, match="method only supports samples that contain integers"
     ):
         res.get_counts()
 

--- a/tests/_simulators/sampling/test_measurements.py
+++ b/tests/_simulators/sampling/test_measurements.py
@@ -130,10 +130,14 @@ def test_counts(input_state):
         assert r[0] == e[0]
         assert np.isclose(r[1] / shots, e[1] / shots)
 
-@pytest.mark.parametrize("simulator, measurement_class", [
-    (pq.PureFockSimulator, pq.HomodyneMeasurement),
-    (pq.GaussianSimulator, pq.HeterodyneMeasurement),
-    ])
+
+@pytest.mark.parametrize(
+    "simulator, measurement_class",
+    [
+        (pq.PureFockSimulator, pq.HomodyneMeasurement),
+        (pq.GaussianSimulator, pq.HeterodyneMeasurement),
+    ],
+)
 def test_counts_raises(simulator, measurement_class):
     shots = 100
 
@@ -148,7 +152,10 @@ def test_counts_raises(simulator, measurement_class):
 
     simulator = simulator(d=3)
     res = simulator.execute(program, shots=shots)
-    with pytest.raises(NotImplementedError, match="The get_counts method only supports measurements that provide integer samples"):
+    with pytest.raises(
+        NotImplementedError,
+        match="The get_counts method only supports measurements that provide integer samples",
+    ):
         counts = res.get_counts()
 
 

--- a/tests/_simulators/sampling/test_measurements.py
+++ b/tests/_simulators/sampling/test_measurements.py
@@ -105,6 +105,29 @@ def test_sampling_multiple_samples_for_permutation_interferometer(
         first_sample, second_sample
     ), f"Expected same samples, got: {first_sample} & {second_sample}"
 
+basis_states = [
+    (0, 1),
+    (1, 0),
+    (2, 0),
+]
+
+@pytest.mark.parametrize("input_state", basis_states)
+def test_counts(input_state):
+    shots = 100
+
+    expected = {input_state: shots}
+    with pq.Program() as program:
+        pq.Q() | pq.StateVector(input_state)
+        pq.Q() | pq.ParticleNumberMeasurement()
+
+    simulator = pq.SamplingSimulator(d=2)
+    res = simulator.execute(program, shots=shots)
+    counts = res.get_counts()
+    assert len(counts) == len(expected)
+    for r, e in zip(counts.items(), expected.items()):
+        assert r[0] == e[0]
+        assert np.isclose(r[1]/shots, e[1]/shots)
+
 
 def test_mach_zehnder():
     int_ = np.pi / 3

--- a/tests/_simulators/sampling/test_measurements.py
+++ b/tests/_simulators/sampling/test_measurements.py
@@ -154,7 +154,7 @@ def test_counts_raises(simulator, measurement_class):
     res = simulator.execute(program, shots=shots)
     with pytest.raises(
         NotImplementedError,
-        match="The get_counts method only supports measurements "\
+        match="The get_counts method only supports measurements "
         "that provide integer samples",
     ):
         res.get_counts()

--- a/tests/_simulators/sampling/test_measurements.py
+++ b/tests/_simulators/sampling/test_measurements.py
@@ -105,11 +105,13 @@ def test_sampling_multiple_samples_for_permutation_interferometer(
         first_sample, second_sample
     ), f"Expected same samples, got: {first_sample} & {second_sample}"
 
+
 basis_states = [
     (0, 1),
     (1, 0),
     (2, 0),
 ]
+
 
 @pytest.mark.parametrize("input_state", basis_states)
 def test_counts(input_state):
@@ -126,7 +128,7 @@ def test_counts(input_state):
     assert len(counts) == len(expected)
     for r, e in zip(counts.items(), expected.items()):
         assert r[0] == e[0]
-        assert np.isclose(r[1]/shots, e[1]/shots)
+        assert np.isclose(r[1] / shots, e[1] / shots)
 
 
 def test_mach_zehnder():

--- a/tests/_simulators/sampling/test_measurements.py
+++ b/tests/_simulators/sampling/test_measurements.py
@@ -154,9 +154,10 @@ def test_counts_raises(simulator, measurement_class):
     res = simulator.execute(program, shots=shots)
     with pytest.raises(
         NotImplementedError,
-        match="The get_counts method only supports measurements that provide integer samples",
+        match="The get_counts method only supports measurements "\
+        "that provide integer samples",
     ):
-        counts = res.get_counts()
+        res.get_counts()
 
 
 def test_mach_zehnder():


### PR DESCRIPTION
Adds the `Result.get_counts` method that depends on the `Result.samples` attribute.