### PR TITLE
feat(api): Handling number of modes mismatch

### DIFF
--- a/piquasso/api/simulator.py
+++ b/piquasso/api/simulator.py
@@ -167,8 +167,15 @@ class Simulator(Computer, _mixins.CodeMixin):
     def _validate_state(self, initial_state: State) -> None:
         if not isinstance(initial_state, self._state_class):
             raise InvalidState(
-                f"State specified with type '{type(initial_state)}', but it should be "
-                f"{self._state_class} for this simulator."
+                f"Initial state is specified with type '{type(initial_state)}', but it "
+                f"should be {self._state_class} for this simulator."
+            )
+
+        if initial_state.d != self.d:
+            raise InvalidState(
+                f"Mismatch in number of specified modes: According to the simulator, "
+                f"the number of modes should be '{self.d}', but the specified "
+                f"'initial_state' is defined on '{initial_state.d}' modes."
             )
 
     def validate(self, program: Program) -> None:

--- a/tests/api/test_simulator.py
+++ b/tests/api/test_simulator.py
@@ -242,8 +242,36 @@ def test_program_execution_with_initial_state_of_wrong_type_raises_InvalidState(
 
     other_simulator.validate(program)
 
-    with pytest.raises(pq.api.exceptions.InvalidState):
+    with pytest.raises(pq.api.exceptions.InvalidState) as exc:
         other_simulator.execute(program, initial_state=initial_state)
+
+    assert "Initial state is specified with type" in exc.value.args[0]
+
+
+def test_program_execution_with_initial_state_of_wrong_no_of_modes_raises_InvalidState(
+    FakeSimulator,
+):
+    single_mode_simulator = FakeSimulator(d=1)
+
+    with pq.Program() as program:
+        pass
+
+    single_mode_simulator.validate(program)
+
+    single_mode_initial_state = single_mode_simulator.execute(program).state
+
+    two_mode_simulator = FakeSimulator(d=2)
+
+    two_mode_simulator.validate(program)
+
+    expected_error_message = (
+        "Mismatch in number of specified modes: According to the simulator, "
+        "the number of modes should be '2', but the specified 'initial_state' "
+        "is defined on '1' modes."
+    )
+
+    with pytest.raises(pq.api.exceptions.InvalidState, match=expected_error_message):
+        two_mode_simulator.execute(program, initial_state=single_mode_initial_state)
 
 
 def test_Config_override(FakeSimulator, FakeConfig):


### PR DESCRIPTION
Passing in the `initial_state` argument to the `Simulator.execute` method such that the simulator instance's `d` attribute does not match the shape of `initial_state` raises an undescriptive error. This is handled by raising an `InvalidState` error in such cases.

Resolves #464.