### PR TITLE
fix(docs): correct typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,7 +134,7 @@
 
 - Python 3.11 support.
 - Purification of Gaussian states.
-- `PureFockState.get_tensor_representation` for embeddng the state vector into
+- `PureFockState.get_tensor_representation` for embedding the state vector into
   a tensor with rank equal to the number of modes.
 - Batch processing of pure Fock states.
 - CVQNN module.

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ If you are doing research using Piquasso, please cite us as follows:
 
 ## Documentation
 
-The documentation is avaliable at [https://piquasso.readthedocs.io/](https://piquasso.readthedocs.io/).
+The documentation is available at [https://piquasso.readthedocs.io/](https://piquasso.readthedocs.io/).
 
 ## How to contribute?
 

--- a/piquasso/_simulators/gaussian/state.py
+++ b/piquasso/_simulators/gaussian/state.py
@@ -182,7 +182,7 @@ class GaussianState(State):
 
     @property
     def xxpp_covariance_matrix(self) -> np.ndarray:
-        r"""The xxpp-ordered coveriance matrix of the state.
+        r"""The xxpp-ordered covariance matrix of the state.
 
         The xxpp-ordered covariance matrix :math:`\sigma_{xp}` is defined by
 
@@ -284,7 +284,7 @@ class GaussianState(State):
 
     @property
     def xpxp_covariance_matrix(self) -> np.ndarray:
-        r"""The `xpxp`-ordered coveriance matrix of the state.
+        r"""The `xpxp`-ordered covariance matrix of the state.
 
         The `xpxp`-ordered covariance matrix :math:`\sigma` is defined by
 


### PR DESCRIPTION
Fix minor typos in
- `CHANGELOG.md`
- `README.md`
- `piquasso/_simulators/gaussian/state.py`