### PR TITLE
Add mode validation for instructions in simulator when executing a program

### DIFF
--- a/piquasso/api/simulator.py
+++ b/piquasso/api/simulator.py
@@ -29,6 +29,7 @@ from piquasso.api.exceptions import (
     InvalidInstruction,
     InvalidSimulation,
     InvalidState,
+    InvalidModes,
 )
 from piquasso.api.instruction import (
     Gate,
@@ -93,6 +94,16 @@ class Simulator(Computer, _mixins.CodeMixin):
     def _validate_instruction_existence(self, instructions: List[Instruction]) -> None:
         for instruction in instructions:
             self._get_calculation(instruction)
+
+    def _validate_instruction_modes(self, instructions: List[Instruction]) -> None:
+        for instruction in instructions:
+            modes = instruction.modes if instruction.modes else tuple(range(self.d))
+
+            for mode in modes:
+                if mode < 0 or mode >= self.d:
+                    raise InvalidModes(
+                        f"Mode {mode} is out of range for the simulator with {self.d} modes."
+                    )
 
     def _get_calculation(self, instruction: Instruction) -> Callable:
         for instruction_class, calculation in self._instruction_map.items():
@@ -162,6 +173,7 @@ class Simulator(Computer, _mixins.CodeMixin):
 
     def _validate_instructions(self, instructions: List[Instruction]) -> None:
         self._validate_instruction_existence(instructions)
+        self._validate_instruction_modes(instructions)
         self._validate_instruction_order(instructions)
 
     def _validate_state(self, initial_state: State) -> None:

--- a/tests/api/test_simulator.py
+++ b/tests/api/test_simulator.py
@@ -274,6 +274,26 @@ def test_program_execution_with_initial_state_of_wrong_no_of_modes_raises_Invali
         two_mode_simulator.execute(program, initial_state=single_mode_initial_state)
 
 
+def test_program_execution_with_invalid_modes_raises_InvalidModes(
+    FakeSimulator,
+    FakeGate,
+):
+    with pq.Program() as program:
+        pq.Q(0, 1) | FakeGate()
+
+    simulator = FakeSimulator(d=1)
+
+    expected_error_message = (
+        "Mode 1 is out of range for the simulator with 1 modes."
+    )
+
+    with pytest.raises(pq.api.exceptions.InvalidModes, match=expected_error_message):
+        simulator.validate(program)
+
+    with pytest.raises(pq.api.exceptions.InvalidModes, match=expected_error_message):
+        simulator.execute(program)
+
+
 def test_Config_override(FakeSimulator, FakeConfig):
     with pq.Program() as program:
         pass


### PR DESCRIPTION
Resolve #446 

Add `validate_instruction_modes` for giving instructive error message when calling `simulator.execute` as InvalidModes error

For example, this is the demo code for showing the error and passing with these changes

```python
import numpy as np
import piquasso as pq

s = 0.1

# This example uses an invalid mode index (2) while the simulator has only 2 modes
with pq.Program() as invalid_program:
    pq.Q() | pq.Vacuum()
    pq.Q(0, 1) | pq.ControlledZ(s)
    pq.Q(0, 1, 2) | pq.ParticleNumberMeasurement()

simulator = pq.GaussianSimulator(d=2, config=pq.Config(hbar=2))

print("Executing program with invalid modes...")
try:
    simulator.execute(invalid_program, shots=10)
except pq.api.exceptions.InvalidModes as exc:
    print(f"Caught expected error: {exc}")

# A corrected example running on three modes
with pq.Program() as valid_program:
    pq.Q() | pq.Vacuum()
    pq.Q(0, 1) | pq.ControlledZ(s)
    pq.Q(0, 1, 2) | pq.ParticleNumberMeasurement()

valid_simulator = pq.GaussianSimulator(d=3, config=pq.Config(hbar=2))

result = valid_simulator.execute(valid_program, shots=10)
print("Execution on valid simulator succeeded, first sample:", result.samples[0])
```

This gives
```
Executing program with invalid modes...
Caught expected error: Instruction ParticleNumberMeasurement(modes=(0, 1, 2)) uses mode 2, which is out of range for the simulator with 2 modes (allowed range: 0-1).
Execution on valid simulator succeeded, first sample: [0 0 0]
```