### PR TITLE
Remove whitespace between link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,48 +6,38 @@
   <a
     href="https://app.codecov.io/gh/Budapest-Quantum-Computing-Group/piquasso"
     style="text-decoration: none;"
-  >
-    <img
+  ><img
       alt="Coverage"
       src="https://img.shields.io/codecov/c/github/Budapest-Quantum-Computing-Group/piquasso"
-    />
-  </a>
+    /></a>
   <a
     href="https://github.com/Budapest-Quantum-Computing-Group/piquasso/blob/main/LICENSE.txt"
     style="text-decoration: none;"
-  >
-    <img
+  ><img
       alt="License"
       src="https://img.shields.io/github/license/Budapest-Quantum-Computing-Group/piquasso"
-    />
-  </a>
+    /></a>
   <a
     href="https://github.com/Budapest-Quantum-Computing-Group/piquasso/issues"
     style="text-decoration: none;"
-  >
-    <img
+  ><img
       alt="Issues"
       src="https://img.shields.io/github/issues/Budapest-Quantum-Computing-Group/piquasso"
-    />
-  </a>
+    /></a>
   <a
     href="https://github.com/Budapest-Quantum-Computing-Group/piquasso/pulls"
     style="text-decoration: none;"
-  >
-    <img
+  ><img
       alt="Pull requests"
       src="https://img.shields.io/github/issues-pr/Budapest-Quantum-Computing-Group/piquasso"
-    />
-  </a>
+    /></a>
   <a
     href="https://github.com/Budapest-Quantum-Computing-Group/piquasso/actions"
     style="text-decoration: none;"
-  >
-    <img
+  ><img
       alt="Tests"
       src="https://github.com/Budapest-Quantum-Computing-Group/piquasso/actions/workflows/tests.yml/badge.svg"
-    >
-  </a>
+    ></a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
This is minor change regarding style in README.md by removing the blue underline (whitespace) between the badges.
This PR will change 
<img width="743" height="246" alt="image" src="https://github.com/user-attachments/assets/92fe24fd-1e3c-4762-80e0-0c27c6e07aa3" />
to
<img width="641" height="217" alt="image" src="https://github.com/user-attachments/assets/b7c2c71a-ee04-4db2-8c79-e1318b532dd2" />

Fix README badge by removing whitespace inside <a> tags to prevent unwanted link underlines on GitHub.