### PR TITLE
FIX(docs): Jupyter notebooks were not downloadable

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -134,14 +134,12 @@ html_css_files = ["custom.css"]
 nbsphinx_prompt_width = "0"
 
 nbsphinx_prolog = r"""
-{% set docname = env.doc2path(env.docname, base=None) %}
-
 .. note::
     .. raw:: html
 
         <div>
             You can download this notebook
-            <a href="/{{ docname }}" download>here</a>.
+            <a href="{{ env.docname.split('/')|last|e + '.ipynb' }}" download>here</a>.
         </div>
 """  # TODO: get base path.
 


### PR DESCRIPTION
The links of the jupyter notebooks were not working on ReadtheDocs according to the specifications given in the nbsphinx documentation (https://nbsphinx.readthedocs.io/en/latest/prolog-and-epilog.html), so it had to be adjusted manually.