### PR TITLE
FIX(takagi): Scipy `sqrtm` behaviour change

### DIFF
--- a/piquasso/_simulators/connectors/tensorflow_/connector.py
+++ b/piquasso/_simulators/connectors/tensorflow_/connector.py
@@ -261,6 +261,14 @@ class TensorflowConnector(BuiltinConnector):
 
         return U, P
 
+    def schur(self, matrix):
+        # HACK: Lazy Schur decomposition, only works for normal matrices
+        _, vecs = self._tf.linalg.eig(matrix)
+        Q, _ = self._tf.linalg.qr(vecs)
+        D = self._tf.linalg.adjoint(Q) @ matrix @ Q
+
+        return D, Q
+
     def svd(self, matrix):
         # NOTE: Tensorflow 2.0 SVD has different return tuple.
 


### PR DESCRIPTION
**Problem**

In SciPy version 1.16, the `sqrtm` function has been rewritten, which caused a
the Takagi decomposition of Piquasso to yield wrong results in rare cases.

In the Takagi decomposition, the square root of a symmetric unitary matrix
(`Z`) is taken, and the code assumes that the `sqrtm` on such matrices results
in a unitary matrix. This is wrong, since nothing guarantees that a non-unitary
square root is returned, but practically, it was the case until SciPy version
1.16.

**Solution**

To avoid such errors, `sqrtm` has been replaced by using the Schur
decomposition implemented in `schur`, such that the "canonical" square root is
used obtained from the principal square roots of the eigenvalues.

Moreover, an extra test have been added where the adjacency matrix has
degenerate eigenvalues, a matrix where this issue was initially observed.
Another (monkey)test is written that uses randomly generated adjacency
matrices.

Finally, the tests of the Takagi decomposition got extended by testing with
`JaxConnector` as well, since `PureFockSimulator` supports `JaxConnector`,
which also uses the Takagi decomposition for the Euler (Bloch-Messiah)
decomposition.

Sources:
- https://docs.scipy.org/doc/scipy/release/1.16.0-notes.html
- https://github.com/scipy/scipy/pull/22406
- https://journals.aps.org/pra/abstract/10.1103/PhysRevA.94.062109