### PR TITLE
feat(fermionic): `PureFockState.covariance_matrix`

### DIFF
--- a/piquasso/fermionic/__init__.py
+++ b/piquasso/fermionic/__init__.py
@@ -49,8 +49,8 @@ where :math:`f_k` and :math:`f_k^\dagger` denote the Dirac operators.
 :math:`\mathbf{m}` denotes the vector of Majorana operators, i.e.,
 
 .. math::
-
     \mathbf{m} := [x_1, \dots, x_d, p_1, \dots, p_d].
+    :label: majorana
 
 .. automodule:: piquasso.fermionic.instructions
    :members:

--- a/piquasso/fermionic/_utils.py
+++ b/piquasso/fermionic/_utils.py
@@ -281,6 +281,12 @@ def _to_second_quantized(first_quantized, d):
 
 
 def binary_to_fock_indices(d):
+    """Creating indices for changing the state vector ordering to Fock from binary.
+
+    Binary ordering goes as `000, 001, 010, 011, 100, 101, 110, 111`
+    Fock ordering goes as `000, 100, 010, 001, 110, 101, 011, 111`
+    """
+
     size = get_cutoff_fock_space_dimension(d, d + 1)
 
     power_array = np.empty(d, dtype=int)
@@ -303,6 +309,22 @@ def binary_to_fock_indices(d):
     return indices
 
 
+def fock_to_binary_indices(d):
+    """Creating indices for changing the state vector ordering to binary from Fock.
+
+    Binary ordering goes as `000, 001, 010, 011, 100, 101, 110, 111`
+    Fock ordering goes as `000, 100, 010, 001, 110, 101, 011, 111`
+    """
+
+    b2f = binary_to_fock_indices(d)
+    f2b = np.empty_like(b2f)
+
+    for fock_index, binary_index in enumerate(b2f):
+        f2b[binary_index] = fock_index
+
+    return f2b
+
+
 @nb.njit(cache=True)
 def get_fock_space_basis(d, cutoff):
     size = get_cutoff_fock_space_dimension(d, cutoff)
@@ -315,3 +337,28 @@ def get_fock_space_basis(d, cutoff):
         basis[i] = next_second_quantized(basis[i - 1])
 
     return basis
+
+
+def get_majorana_operators(d):
+    r"""Returns the list of Majorana operators on :math:`d` modes.
+
+    The list represents a formal vector of Majorana operators
+    :math:`\mathbf{m} := [m_0, \dots, m_{2d+1}]`, where
+
+    .. math::
+        m_{2k} &:= f_k + f_k^\dagger, \\\\
+        m_{2k+1} &:= -i (f_k - f_k^\dagger).
+
+    Args:
+        d (int): The number of modes.
+    """
+
+    fs, fdags = _get_fs_fdags(d)
+
+    ms = []
+
+    for i in range(d):
+        ms.append(fs[i] + fdags[i])
+        ms.append(-1j * (fs[i] - fdags[i]))
+
+    return ms

--- a/piquasso/fermionic/fock/state.py
+++ b/piquasso/fermionic/fock/state.py
@@ -19,6 +19,8 @@ from .._utils import (
     get_cutoff_fock_space_dimension,
     get_fock_space_index,
     get_fock_space_basis,
+    get_majorana_operators,
+    fock_to_binary_indices,
 )
 
 from piquasso.api.exceptions import InvalidState
@@ -115,8 +117,107 @@ class PureFockState(State):
             )
 
     @property
-    def density_matrix(self):
+    def density_matrix(self) -> "np.ndarray":
+        """The density matrix of the state.
+
+        .. warning::
+            The primary ordering of the Fock basis is by number of particles, and the
+            secondary is anti-lexicographic.
+
+            Example for 3 modes:
+
+            .. math ::
+
+                \ket{000},
+                \ket{100}, \ket{010}, \ket{001},
+                \ket{200}, \ket{110}, \ket{101}, \ket{020}, \ket{011}, \ket{002}, \dots
+
+            This is in contrast with
+            :meth:`~piquasso.fermionic.gaussian.state.GaussianState.density_matrix`,
+            where the primary ordering is lexicographic.
+
+        Returns:
+            np.ndarray: The density matrix.
+        """
         return self._connector.np.outer(self._state_vector, self._state_vector.conj())
+
+    @property
+    def covariance_matrix(self) -> "np.ndarray":
+        r"""The covariance matrix.
+
+        The covariance matrix is defined by
+
+        .. math::
+
+            \Sigma_{ij} := -i \operatorname{Tr} (\rho [\mathbf{m}_i, \mathbf{m}_j]) / 2,
+
+        where :math:`\mathbf{m}` is defined by Eq. :eq:`majorana`. The covariance matrix
+        is a real-valued, skew-symmetric matrix.
+
+        .. note::
+            The covariance matrix does not fully characterize this state in general,
+            only if it is a Gaussian state. For manipulating Gaussian states, visit
+            :class:`~piquasso.fermionic.gaussian.state.GaussianState`.
+
+        Returns:
+            np.ndarray: The covariance matrix.
+        """
+
+        connector = self._connector
+
+        ms = get_majorana_operators(self.d)
+
+        two_d = 2 * self.d
+
+        covariance_matrix = connector.np.zeros(
+            shape=(two_d, two_d), dtype=self._config.dtype
+        )
+
+        indices = fock_to_binary_indices(self.d)
+
+        state_vector_in_binary_ordering = self._state_vector[indices]
+
+        # TODO: This algorithm can be made much more efficient by avoiding using the
+        # Fock space representation of the Majorana operators.
+        for i in range(two_d):
+            for j in range(two_d):
+                if i == j:
+                    continue
+
+                covariance_matrix = connector.assign(
+                    covariance_matrix,
+                    (i, j),
+                    connector.np.real(
+                        -1j
+                        * state_vector_in_binary_ordering.conj()
+                        @ ms[i]
+                        @ ms[j]
+                        @ state_vector_in_binary_ordering
+                    ),
+                )
+
+        return covariance_matrix
+
+    def _get_nonzero_elements(self):
+        basis = get_fock_space_basis(self.d, self._config.cutoff)
+
+        np = self._connector.np
+        nonzero_indices = np.nonzero(self._state_vector)[0]
+
+        occupation_numbers = basis[nonzero_indices]
+
+        nonzero_elements = self._state_vector[nonzero_indices]
+
+        for index, coefficient in enumerate(nonzero_elements):
+            yield coefficient, tuple(occupation_numbers[index])
+
+    def __str__(self) -> str:
+        return " + ".join(
+            [
+                str(coefficient) + str(tuple(int(x) for x in basis))
+                for coefficient, basis in self._get_nonzero_elements()
+            ]
+        )
 
     def __eq__(self, other):
         if not isinstance(other, PureFockState):

--- a/piquasso/fermionic/gaussian/state.py
+++ b/piquasso/fermionic/gaussian/state.py
@@ -60,16 +60,21 @@ class GaussianState(State):
         return self._d
 
     @property
-    def covariance_matrix(self):
+    def covariance_matrix(self) -> "np.ndarray":
         r"""The covariance matrix.
+
         A fermionic Gaussian state can be fully characterized by its covariance matrix
         defined by
 
         .. math::
 
-            \Sigma_{ij} := -i \operatorname{Tr} (\rho [\mathbf{m}_i, \mathbf{m}_j]) / 2.
+            \Sigma_{ij} := -i \operatorname{Tr} (\rho [\mathbf{m}_i, \mathbf{m}_j]) / 2,
 
-        The covariance matrix is a real-valued, skew-symmetric matrix.
+        where :math:`\mathbf{m}` is defined by Eq. :eq:`majorana`. The covariance matrix
+        is a real-valued, skew-symmetric matrix.
+
+        Returns:
+            np.ndarray: The covariance matrix.
         """
 
         d = self.d

--- a/tests/fermionic/conftest.py
+++ b/tests/fermionic/conftest.py
@@ -46,23 +46,6 @@ def generate_passive_fermionic_gaussian_hamiltonian(generate_hermitian_matrix):
 
 
 @pytest.fixture
-def get_majorana_operators():
-
-    def func(d):
-        fs, fdags = _get_fs_fdags(d)
-
-        ms = []
-
-        for i in range(d):
-            ms.append(fs[i] + fdags[i])
-            ms.append(-1j * (fs[i] - fdags[i]))
-
-        return ms
-
-    return func
-
-
-@pytest.fixture
 def get_ladder_operators():
 
     def func(d):

--- a/tests/fermionic/fock/test_state.py
+++ b/tests/fermionic/fock/test_state.py
@@ -195,3 +195,21 @@ def test_PureFockState_fock_probabilities_map(connector):
 
     for occupation_number, probability in expected.items():
         assert np.isclose(state.fock_probabilities_map[occupation_number], probability)
+
+
+@for_all_connectors
+def test_PureFockState_str(connector):
+    with pq.Program() as program:
+        pq.Q(0, 1) | pq.StateVector([0, 0]) / 2
+        pq.Q(0, 1) | pq.StateVector([0, 1]) / 2
+        pq.Q(0, 1) | pq.StateVector([1, 0]) / 2
+        pq.Q(0, 1) | pq.StateVector([1, 1]) / 2
+
+    simulator = pq.fermionic.PureFockSimulator(d=2, connector=connector)
+
+    state = simulator.execute(program).state
+
+    assert (
+        str(state)
+        == "(0.5+0j)(0, 0) + (0.5+0j)(1, 0) + (0.5+0j)(0, 1) + (0.5+0j)(1, 1)"
+    )

--- a/tests/fermionic/gaussian/test_state.py
+++ b/tests/fermionic/gaussian/test_state.py
@@ -28,7 +28,11 @@ from piquasso._math.transformations import xxpp_to_xpxp_indices, xpxp_to_xxpp_in
 from piquasso._math.linalg import is_selfadjoint, is_skew_symmetric
 from piquasso._math.validations import all_in_interval
 
-from piquasso.fermionic._utils import get_omega, binary_to_fock_indices
+from piquasso.fermionic._utils import (
+    get_omega,
+    binary_to_fock_indices,
+    get_majorana_operators,
+)
 
 
 for_all_connectors = pytest.mark.parametrize(
@@ -237,9 +241,7 @@ def test_correlation_matrix_density_matrix_equivalence_random(
 
 
 @for_all_connectors
-def test_vacuum_covariance_matrix_with_majorana_operators_and_density_matrix(
-    connector, get_majorana_operators
-):
+def test_vacuum_covariance_matrix_with_majorana_operators_and_density_matrix(connector):
     d = 3
 
     with pq.Program() as program:
@@ -266,7 +268,7 @@ def test_vacuum_covariance_matrix_with_majorana_operators_and_density_matrix(
 @pytest.mark.monkey
 @for_all_connectors
 def test_covariance_matrix_with_majorana_operators_and_density_matrix(
-    connector, generate_fermionic_gaussian_hamiltonian, get_majorana_operators
+    connector, generate_fermionic_gaussian_hamiltonian
 ):
     d = 3
 
@@ -402,9 +404,7 @@ def test_vacuum_evolved_with_GaussianHamiltonian_correlation_matrix(connector):
 
 
 @for_all_connectors
-def test_get_majorana_monomial_expectation_value_2_terms_consecutive(
-    connector, get_majorana_operators
-):
+def test_get_majorana_monomial_expectation_value_2_terms_consecutive(connector):
     d = 3
 
     A = np.array([[1, 2j, 3j], [-2j, 5, 6], [-3j, 6, 7]])
@@ -433,9 +433,7 @@ def test_get_majorana_monomial_expectation_value_2_terms_consecutive(
 
 
 @for_all_connectors
-def test_get_majorana_monomial_expectation_value_2_terms(
-    connector, get_majorana_operators
-):
+def test_get_majorana_monomial_expectation_value_2_terms(connector):
     d = 3
 
     A = np.array([[1, 2j, 3j], [-2j, 5, 6], [-3j, 6, 7]])
@@ -464,9 +462,7 @@ def test_get_majorana_monomial_expectation_value_2_terms(
 
 
 @for_all_connectors
-def test_get_majorana_monomial_expectation_value_4_terms(
-    connector, get_majorana_operators
-):
+def test_get_majorana_monomial_expectation_value_4_terms(connector):
     d = 3
 
     A = np.array([[1, 2j, 3j], [-2j, 5, 6], [-3j, 6, 7]])
@@ -495,9 +491,7 @@ def test_get_majorana_monomial_expectation_value_4_terms(
 
 
 @for_all_connectors
-def test_get_majorana_monomial_expectation_value_4_terms_consecutive(
-    connector, get_majorana_operators
-):
+def test_get_majorana_monomial_expectation_value_4_terms_consecutive(connector):
     d = 3
 
     A = np.array([[1, 2j, 3j], [-2j, 5, 6], [-3j, 6, 7]])
@@ -526,9 +520,7 @@ def test_get_majorana_monomial_expectation_value_4_terms_consecutive(
 
 
 @for_all_connectors
-def test_get_majorana_monomial_expectation_value_4_terms_flipped(
-    connector, get_majorana_operators
-):
+def test_get_majorana_monomial_expectation_value_4_terms_flipped(connector):
     d = 3
 
     A = np.array([[1, 2j, 3j], [-2j, 5, 6], [-3j, 6, 7]])
@@ -562,9 +554,7 @@ def test_get_majorana_monomial_expectation_value_4_terms_flipped(
 
 
 @for_all_connectors
-def test_get_majorana_monomial_expectation_value_with_duplicates(
-    connector, get_majorana_operators
-):
+def test_get_majorana_monomial_expectation_value_with_duplicates(connector):
     d = 3
 
     A = np.array([[1, 2j, 3j], [-2j, 5, 6], [-3j, 6, 7]])
@@ -593,9 +583,7 @@ def test_get_majorana_monomial_expectation_value_with_duplicates(
 
 
 @for_all_connectors
-def test_get_majorana_monomial_expectation_value_with_triple(
-    connector, get_majorana_operators
-):
+def test_get_majorana_monomial_expectation_value_with_triple(connector):
     d = 3
 
     A = np.array([[1, 2j, 3j], [-2j, 5, 6], [-3j, 6, 7]])
@@ -628,7 +616,7 @@ def test_get_majorana_monomial_expectation_value_with_triple(
 @pytest.mark.monkey
 @for_all_connectors
 def test_get_majorana_monomial_expectation_value_random_without_multiplicities(
-    connector, get_majorana_operators, generate_fermionic_gaussian_hamiltonian
+    connector, generate_fermionic_gaussian_hamiltonian
 ):
     d = 3
 
@@ -685,7 +673,7 @@ def test_get_majorana_monomial_expectation_value_empty(
 @pytest.mark.monkey
 @for_all_connectors
 def test_get_majorana_monomial_expectation_value_random_with_possible_multiplicities(
-    connector, get_majorana_operators, generate_fermionic_gaussian_hamiltonian
+    connector, generate_fermionic_gaussian_hamiltonian
 ):
     d = 3
 


### PR DESCRIPTION
Implementation of `covariance_matrix` for pure fermionic quantum states.

For debugging purposes, the method `PureFockState.__str__` got also implemented.