### PR TITLE
chore(fermionic): Fix docstring warning

### DIFF
--- a/piquasso/fermionic/fock/state.py
+++ b/piquasso/fermionic/fock/state.py
@@ -118,7 +118,7 @@ class PureFockState(State):
 
     @property
     def density_matrix(self) -> "np.ndarray":
-        """The density matrix of the state.
+        r"""The density matrix of the state.
 
         .. warning::
             The primary ordering of the Fock basis is by number of particles, and the


### PR DESCRIPTION
This fixes the following disturbing warning:
```
piquasso/fermionic/fock/state.py:131: SyntaxWarning: invalid escape sequence '\k'
    \ket{000},
```