### PR TITLE
feat(tests): Distributing CI test runs across multiple CPUs using `pytest-xdist`

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,8 @@ extras =
     py{38,39,310,311,312}: jax,dev,tensorflow,matplotlib,dask
     py313: jax,dev,matplotlib,dask
 deps =
-    pytest-cov,pytest-xdist
+    pytest-cov
+    pytest-xdist
 commands =
     flake8
     nbqa flake8 --ignore=E402 docs/tutorials


### PR DESCRIPTION
The test execution is distributed by `pytest-xdist` with the `-n auto` flag.

Documentation: https://pytest-xdist.readthedocs.io/en/stable/distribution.html