### PR TITLE
feat(simulator): Exact probabilities in `Result` using `shots=None`

### DIFF
--- a/piquasso/_simulators/fock/general/simulation_steps.py
+++ b/piquasso/_simulators/fock/general/simulation_steps.py
@@ -15,10 +15,7 @@
 
 from typing import Tuple, Mapping, List
 
-import random
 import numpy as np
-
-from fractions import Fraction
 
 from .state import FockState
 
@@ -29,7 +26,7 @@ from piquasso._math.decompositions import euler
 from piquasso.api.instruction import Instruction
 from piquasso.api.branch import Branch
 
-from piquasso._utils import get_counts
+from piquasso._utils import sample_from_probability_map
 
 from piquasso._math.indices import get_index_in_fock_space
 from piquasso._math.fock import (
@@ -135,17 +132,11 @@ def particle_number_measurement(
 
     probability_map = reduced_state.fock_probabilities_map
 
-    samples = random.choices(
-        population=list(probability_map.keys()),
-        weights=list(probability_map.values()),
-        k=shots,
-    )
-
-    binned_samples = get_counts(samples)
+    frequency_map = sample_from_probability_map(probability_map, shots)
 
     branches = []
 
-    for sample, multiplicity in binned_samples.items():
+    for sample, frequency in frequency_map.items():
         normalization = _get_normalization(probability_map, sample)
 
         new_state = _project_to_subspace(
@@ -155,7 +146,7 @@ def particle_number_measurement(
             normalization=normalization,
         )
 
-        branch = Branch(new_state, sample, Fraction(multiplicity, shots))
+        branch = Branch(new_state, sample, frequency)
 
         branches.append(branch)
 

--- a/piquasso/_simulators/fock/general/simulator.py
+++ b/piquasso/_simulators/fock/general/simulator.py
@@ -125,3 +125,7 @@ class FockSimulator(BuiltinSimulator):
     _state_class = FockState
 
     _default_connector_class = NumpyConnector
+
+    _measurement_classes_allowed_with_shots_none = (
+        measurements.ParticleNumberMeasurement,
+    )

--- a/piquasso/_simulators/fock/pure/simulation_steps/__init__.py
+++ b/piquasso/_simulators/fock/pure/simulation_steps/__init__.py
@@ -31,10 +31,7 @@ __all__ = [
 
 from typing import Optional, Tuple, Mapping, List
 
-import random
 import numpy as np
-
-from fractions import Fraction
 
 from .passive_linear import _apply_passive_linear
 from .utils import project_to_subspace
@@ -61,7 +58,7 @@ from piquasso.api.branch import Branch
 from piquasso.api.instruction import Instruction
 from piquasso.api.connector import BaseConnector
 from piquasso._math.validations import validate_occupation_numbers
-from piquasso._utils import get_counts
+from piquasso._utils import sample_from_probability_map
 
 
 def particle_number_measurement(
@@ -71,17 +68,11 @@ def particle_number_measurement(
 
     probability_map = reduced_state.fock_probabilities_map
 
-    samples = random.choices(
-        population=list(probability_map.keys()),
-        weights=list(probability_map.values()),
-        k=shots,
-    )
-
-    binned_samples = get_counts(samples)
+    frequency_map = sample_from_probability_map(probability_map, shots)
 
     branches = []
 
-    for sample, multiplicity in binned_samples.items():
+    for sample, frequency in frequency_map.items():
         normalization = _get_normalization(probability_map, sample)
 
         new_state = project_to_subspace(
@@ -91,7 +82,7 @@ def particle_number_measurement(
             normalization=normalization,
         )
 
-        branch = Branch(new_state, sample, frequency=Fraction(multiplicity, shots))
+        branch = Branch(new_state, sample, frequency=frequency)
 
         branches.append(branch)
 

--- a/piquasso/_simulators/fock/pure/simulator.py
+++ b/piquasso/_simulators/fock/pure/simulator.py
@@ -151,3 +151,8 @@ class PureFockSimulator(BuiltinSimulator):
         measurements.ParticleNumberMeasurement,
         measurements.PostSelectPhotons,
     )
+
+    _measurement_classes_allowed_with_shots_none = (
+        measurements.ParticleNumberMeasurement,
+        measurements.PostSelectPhotons,
+    )

--- a/piquasso/_utils.py
+++ b/piquasso/_utils.py
@@ -13,6 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import random
+
+import numpy as np
+
+from fractions import Fraction
+
 
 def get_counts(samples):
     counts_dct = {}
@@ -23,3 +29,43 @@ def get_counts(samples):
             counts_dct[sample] += 1
 
     return counts_dct
+
+
+def sample_from_probability_map(probability_map, shots):
+    """Generate samples from a probability map.
+
+    The samples are returned in a dict, where the keys are the possible outcomes, and
+    the values are the fraction of their occurrence divided by the total number of
+    samples taken.
+
+    If shots is None, return the full probability map as a frequency map, filtered to
+    non-zero probabilities.
+
+    Args:
+        probability_map (Dict[Tuple[int], float]): Mapping from samples to their
+            probabilities.
+        shots (Optional[int]): Number of samples to generate. If None, return the full
+            probability map as a frequency map, filtered to non-zero probabilities.
+
+    Returns:
+        Dict[Tuple[int], Fraction]: Mapping from samples to their frequencies.
+    """
+    if shots is None:
+        return {
+            sample: probability
+            for sample, probability in probability_map.items()
+            if not np.isclose(probability, 0.0)
+        }
+
+    samples = random.choices(
+        population=list(probability_map.keys()),
+        weights=list(probability_map.values()),
+        k=shots,
+    )
+
+    binned_samples = get_counts(samples)
+
+    return {
+        sample: Fraction(multiplicity, shots)
+        for sample, multiplicity in binned_samples.items()
+    }

--- a/piquasso/api/branch.py
+++ b/piquasso/api/branch.py
@@ -40,6 +40,10 @@ class Branch:
     performed, which is an approximation of the probability of observing this
     outcome.
 
+    If the simulation was run with `shots=None`, indicating that the exact probability
+    distribution was calculated instead of sampling, the frequency corresponds to the
+    exact probability of the outcome.
+
     The data in the branch is illustrated as follows. Consider the following setup,
     where a measurement is performed with two possible outcomes, 0 and 1:
 

--- a/tests/_simulators/fock/general/test_measurements.py
+++ b/tests/_simulators/fock/general/test_measurements.py
@@ -173,6 +173,29 @@ def test_measure_particle_number_with_multiple_shots():
     assert len(result.samples) == shots
 
 
+def test_ParticleNumberMeasurement_shots_None():
+    simulator = pq.FockSimulator(d=2, config=pq.Config(cutoff=3))
+
+    p = 1 / np.pi
+
+    with pq.Program() as program:
+        pq.Q() | pq.DensityMatrix(ket=[0, 1], bra=[0, 1]) * p
+        pq.Q() | pq.DensityMatrix(ket=[1, 0], bra=[1, 0]) * (1 - p)
+
+        pq.Q(0) | pq.ParticleNumberMeasurement()
+
+    result = simulator.execute(program, shots=None)
+
+    branches = result.branches
+    assert len(branches) == 2
+
+    assert branches[0].outcome == (0,)
+    assert np.isclose(branches[0].frequency, p)
+
+    assert branches[1].outcome == (1,)
+    assert np.isclose(branches[1].frequency, 1 - p)
+
+
 class TestMidCircuitMeasurements:
     """Test programs that contain mid-circuit measurements."""
 

--- a/tests/_simulators/fock/pure/test_measurements.py
+++ b/tests/_simulators/fock/pure/test_measurements.py
@@ -325,6 +325,29 @@ def test_ParticleNumberMeasurement_resulting_state():
     assert np.isclose(sum(result.state.fock_probabilities), 1)
 
 
+def test_ParticleNumberMeasurement_shots_None():
+    simulator = pq.PureFockSimulator(d=2, config=pq.Config(cutoff=3))
+
+    p = 1 / np.pi
+
+    with pq.Program() as program:
+        pq.Q() | pq.StateVector([0, 1]) * np.sqrt(p)
+        pq.Q() | pq.StateVector([1, 0]) * np.sqrt(1 - p)
+
+        pq.Q(0) | pq.ParticleNumberMeasurement()
+
+    result = simulator.execute(program, shots=None)
+
+    branches = result.branches
+    assert len(branches) == 2
+
+    assert branches[0].outcome == (0,)
+    assert np.isclose(branches[0].frequency, p)
+
+    assert branches[1].outcome == (1,)
+    assert np.isclose(branches[1].frequency, 1 - p)
+
+
 class TestMidCircuitMeasurements:
     """Test programs that contain mid-circuit measurements."""
 

--- a/tests/api/test_result.py
+++ b/tests/api/test_result.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import re
+
 import pytest
 
 import piquasso as pq
@@ -150,3 +152,53 @@ def test_Result_repr(FakeState):
         repr(result)
         == "Result(branches=[Branch(state=FakeState(d=3, config=Config(), connector=NumpyConnector()), outcome=(0,), frequency=498), Branch(state=FakeState(d=3, config=Config(), connector=NumpyConnector()), outcome=(1,), frequency=502)], config=Config(), shots=1000)"  # noqa: E501
     )
+
+
+def test_Result_samples_with_shots_None(FakeState):
+    state1 = FakeState(d=3, connector=pq.NumpyConnector())
+    state2 = FakeState(d=3, connector=pq.NumpyConnector())
+
+    f0 = 1 / 3
+    f1 = 2 / 3
+
+    branch1 = Branch(state=state1, outcome=(0,), frequency=f0)
+    branch2 = Branch(state=state2, outcome=(1,), frequency=f1)
+
+    branches = [branch1, branch2]
+
+    result = Result(branches=branches, config=pq.Config(), shots=None)
+
+    with pytest.raises(
+        pq.api.exceptions.NotImplementedCalculation,
+        match=re.escape(
+            "The 'Result.samples' property is not available with the exact probability "
+            "distribution (i.e., when 'shots=None' is used in the simulation). Please "
+            "execute the program with a finite number of shots to obtain samples."
+        ),
+    ):
+        _ = result.samples
+
+
+def test_Result_get_counts_with_shots_None(FakeState):
+    state1 = FakeState(d=3, connector=pq.NumpyConnector())
+    state2 = FakeState(d=3, connector=pq.NumpyConnector())
+
+    f0 = 1 / 3
+    f1 = 2 / 3
+
+    branch1 = Branch(state=state1, outcome=(0,), frequency=f0)
+    branch2 = Branch(state=state2, outcome=(1,), frequency=f1)
+
+    branches = [branch1, branch2]
+
+    result = Result(branches=branches, config=pq.Config(), shots=None)
+
+    with pytest.raises(
+        pq.api.exceptions.NotImplementedCalculation,
+        match=re.escape(
+            "The 'Result.samples' property is not available with the exact probability "
+            "distribution (i.e., when 'shots=None' is used in the simulation). Please "
+            "execute the program with a finite number of shots to obtain samples."
+        ),
+    ):
+        _ = result.get_counts()


### PR DESCRIPTION
The possibility of obtaining the exact probability distribution is enabled by specifying `shots=None` at execution. This type of execution bypasses the sampling stage, and instead returns with the full, exact probability distribution, along with all possible outcomes with corresponding post-measurement states. However, due to skipping sampling, `Result.samples` has to be disabled in this case.

To keep track of the measurements which support this, `Simulator._measurement_classes_allowed_with_shots_none` is created.