### PR TITLE
feat(simulator): Inferring number of modes

### DIFF
--- a/piquasso/_simulators/simulator.py
+++ b/piquasso/_simulators/simulator.py
@@ -29,7 +29,7 @@ class BuiltinSimulator(Simulator):
 
     def __init__(
         self,
-        d: int,
+        d: Optional[int] = None,
         config: Optional[Config] = None,
         connector: Optional[BaseConnector] = None,
     ) -> None:

--- a/tests/api/utils/test_code_generation.py
+++ b/tests/api/utils/test_code_generation.py
@@ -376,3 +376,31 @@ def test_conditioned_instruction_code_generation_lambda_function():
         ),
     ):
         pq.as_code(program, simulator, shots=10)
+
+
+def test_code_generation_with_undefined_d():
+    with pq.Program() as program:
+        pq.Q(0) | pq.Fourier()
+        pq.Q(2, 3) | pq.Beamsplitter(theta=1, phi=0)
+
+    simulator = pq.FockSimulator()
+
+    code = pq.as_code(program, simulator, shots=10)
+    code_is_executable(code)
+
+    assert (
+        code
+        == f"""\
+import numpy as np
+import piquasso as pq
+
+
+with pq.Program() as program:
+    pq.Q(0) | pq.Fourier()
+    pq.Q(2, 3) | pq.Beamsplitter(theta=1, phi=0)
+
+simulator = pq.{pq.FockSimulator.__name__}()
+
+result = simulator.execute(program, shots=10)
+"""
+    )


### PR DESCRIPTION
Usually, a Piquasso program looks like
```
import piquasso as pq

with pq.Program() as program:
    pq.Q(0, 1) | pq.StateVector((2, 0))

    pq.Q(0, 1) | pq.Beamsplitter5050()

simulator = pq.PureFockSimulator(d=2)

result = simulator.execute(program)
```
However, the `d=2` can be inferred from the fact that only 2 modes are used in `program`.

This patch makes the `d` parameter optional, i.e., the following should be equivalent:
```
import piquasso as pq

with pq.Program() as program:
    pq.Q(0, 1) | pq.StateVector((2, 0))

    pq.Q(0, 1) | pq.Beamsplitter5050()

simulator = pq.PureFockSimulator()

result = simulator.execute(program)
```

To achieve this, a simple helper function called
`_infer_number_of_modes_from_instructions` is implemented, which infers the number of modes, when `Simulator.d` is not specified, and if possible using the instruction set to be executed. If neither `Simulator.d` is specified nor `_infer_number_of_modes_from_instructions` is successful, an `InvalidSimulation` is raised.

The methods `Simulator._as_code` and `Simulator.__repr__` are rewritten accordingly.

Resolves #520