### PR TITLE
ci: Read the Docs check workflow

### DIFF
--- a/.github/workflows/rtd-check.yml
+++ b/.github/workflows/rtd-check.yml
@@ -17,6 +17,9 @@ jobs:
       with:
         fetch-depth: 1
 
+    - name: Install system dependencies
+      run: sudo apt-get install -y pandoc
+
     - name: Set up Python ${{ env.PYTHON_VERSION }}
       uses: actions/setup-python@v4
       with:

--- a/.github/workflows/rtd-check.yml
+++ b/.github/workflows/rtd-check.yml
@@ -1,0 +1,41 @@
+name: "Read the Docs check"
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  rtd_check:
+    runs-on: ubuntu-22.04
+    env:
+      PYTHON_VERSION: "3.12"
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 1
+
+    - name: Set up Python ${{ env.PYTHON_VERSION }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ env.PYTHON_VERSION }}
+
+    - name: Install Piquasso with documentation dependencies
+      run: |
+        pip install --upgrade --no-cache-dir pip setuptools
+        pip install --upgrade --no-cache-dir sphinx
+        pip install --upgrade --upgrade-strategy only-if-needed --no-cache-dir ".[docs]"
+
+    - name: Compile C++ extension
+      run: |
+        pip install cmake pybind11[global]
+        cmake -B build -DCMAKE_INSTALL_PREFIX=$(pwd)
+        cmake --build build
+        cmake --install build
+
+    - name: Build Sphinx HTML
+      run: |
+        cd docs
+        python -m sphinx -T -b html -d _build/doctrees -D language=en . _build --keep-going

--- a/.github/workflows/rtd-check.yml
+++ b/.github/workflows/rtd-check.yml
@@ -13,7 +13,7 @@ jobs:
       PYTHON_VERSION: "3.12"
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         fetch-depth: 1
 
@@ -21,7 +21,7 @@ jobs:
       run: sudo apt-get install -y pandoc
 
     - name: Set up Python ${{ env.PYTHON_VERSION }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ env.PYTHON_VERSION }}
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -131,6 +131,9 @@ html_css_files = ["custom.css"]
 
 # NBSPHINX
 
+# Don't execute notebooks - either output is saved or no output
+nbsphinx_execute = "never"
+
 nbsphinx_prompt_width = "0"
 
 nbsphinx_prolog = r"""

--- a/docs/tutorials/boson-sampling-mc-integral.ipynb
+++ b/docs/tutorials/boson-sampling-mc-integral.ipynb
@@ -88,7 +88,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "0bc7ab2b",
    "metadata": {},
    "outputs": [],
@@ -111,7 +111,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "1ac7d6f1",
    "metadata": {},
    "outputs": [],
@@ -149,7 +149,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "a39e761e",
    "metadata": {},
    "outputs": [],
@@ -208,7 +208,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "cf1bac7d",
    "metadata": {},
    "outputs": [],
@@ -237,7 +237,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "976267d3",
    "metadata": {},
    "outputs": [],
@@ -282,7 +282,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "ef397897-de9d-42a6-b49a-b80984e737a7",
    "metadata": {},
    "outputs": [],
@@ -319,10 +319,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "id": "38cf3bb3",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Piquasso estimated E^(1):       -0.2677\n",
+      "Analytic value for E^(1):       -0.2600\n"
+     ]
+    }
+   ],
    "source": [
     "n_modes = 12\n",
     "xs = np.arange(n_modes)\n",


### PR DESCRIPTION
**Context**

It is challenging to debug documentation build errors and verify fixes.

**Solution**

Two-fold:

1. Turned on pull request runs in Read the Docs (note: unrelated to this PR and performed on the RTD website);

<img width="980" height="55" alt="image" src="https://github.com/user-attachments/assets/c47acfb9-0993-48ec-9429-067a5928e9a4" />


2. Added a GitHub action that mimics the build that Read the Docs performs.

<img width="972" height="45" alt="image" src="https://github.com/user-attachments/assets/f594462e-461f-422a-92c6-f2fb14473571" />


Advantages to having a GH action in addition to turning on pull request runs in Read the Docs - the new `rtd-check.yml` workflow:

* Runs in your GitHub Actions environment, under maintainers' control;
* Faster feedback directly in the PR;
* Python version, dependencies, and build flags may be controlled;
* `--keep-going` gives all errors at once, not just the first one;
* Can be required as a branch protection rule - meaning a PR literally cannot be merged if the docs break, whereas a RTD failure is more of a soft warning.