### PR TITLE
fix(docs): Update nbsphinx rule to never run notebooks

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -131,6 +131,9 @@ html_css_files = ["custom.css"]
 
 # NBSPHINX
 
+# Don't execute notebooks - either output is saved or no output
+nbsphinx_execute = "never"
+
 nbsphinx_prompt_width = "0"
 
 nbsphinx_prolog = r"""

--- a/docs/tutorials/boson-sampling-mc-integral.ipynb
+++ b/docs/tutorials/boson-sampling-mc-integral.ipynb
@@ -88,7 +88,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "0bc7ab2b",
    "metadata": {},
    "outputs": [],
@@ -111,7 +111,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "1ac7d6f1",
    "metadata": {},
    "outputs": [],
@@ -149,7 +149,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "a39e761e",
    "metadata": {},
    "outputs": [],
@@ -208,7 +208,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "cf1bac7d",
    "metadata": {},
    "outputs": [],
@@ -237,7 +237,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "976267d3",
    "metadata": {},
    "outputs": [],
@@ -282,7 +282,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "ef397897-de9d-42a6-b49a-b80984e737a7",
    "metadata": {},
    "outputs": [],
@@ -319,10 +319,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "id": "38cf3bb3",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Piquasso estimated E^(1):       -0.2677\n",
+      "Analytic value for E^(1):       -0.2600\n"
+     ]
+    }
+   ],
    "source": [
     "n_modes = 12\n",
     "xs = np.arange(n_modes)\n",


### PR DESCRIPTION
**Context**

Fixes the documentation build issues from the latest release of Piquasso.

The main issue was that a new tutorial was added to Piquasso (boson sampling Monte Carlo), and no outputs were saved in the Jupyter notebook. In such a case, the `nbsphinx` dependency attempts to run the notebook cells to generate outputs on the fly, but no kernel was available on Read the Docs, so the build failed.

**Solution**

Two solutions for extra care:
1. Disabled running any notebooks by `nbsphinx` - either they already have their outputs saved, or no outputs will be generated;
2. Added outputs for the boson sampling Monte Carlo tutorial (`docs/tutorials/boson-sampling-mc-integral.ipynb`).

Note: the first solution already would have sufficed, but also performed 2. for the sake of convention (i.e., Piquasso tutorials have saved outputs).