### PR TITLE
TorchConnector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ logdir/
 # Shared libraries
 *.so
 *.pyd
+uv.lock

--- a/piquasso/__init__.py
+++ b/piquasso/__init__.py
@@ -18,87 +18,99 @@
 One can access all the instructions and states from here as attributes.
 """
 
-from piquasso import cvqnn, dual_rail_encoding, fermionic
-from piquasso._simulators.connectors import (
-    JaxConnector,
-    NumpyConnector,
-    TensorflowConnector,
-    TorchConnector,
-)
-from piquasso._simulators.fock import (
-    BatchPureFockState,
-    FockSimulator,
-    FockState,
-    PureFockSimulator,
-    PureFockState,
-)
-from piquasso._simulators.gaussian import GaussianSimulator, GaussianState
-from piquasso._simulators.sampling import SamplingSimulator, SamplingState
-from piquasso.api.computer import Computer
+from piquasso import cvqnn
+from piquasso import fermionic
+
+from piquasso.api.mode import Q
 from piquasso.api.config import Config
 from piquasso.api.instruction import (
-    Gate,
     Instruction,
-    Measurement,
     Preparation,
+    Gate,
+    Measurement,
 )
-from piquasso.api.mode import Q
 from piquasso.api.program import Program
-from piquasso.api.simulator import Simulator
 from piquasso.api.state import State
+from piquasso.api.computer import Computer
+from piquasso.api.simulator import Simulator
 from piquasso.api.utils import as_code
 
-from .instructions.batch import (
-    BatchApply,
-    BatchPrepare,
+from piquasso import dual_rail_encoding
+
+from piquasso._simulators.sampling import SamplingState, SamplingSimulator
+
+from piquasso._simulators.gaussian import GaussianState, GaussianSimulator
+from piquasso._simulators.fock import (
+    FockState,
+    PureFockState,
+    BatchPureFockState,
+    FockSimulator,
+    PureFockSimulator,
 )
+
+from piquasso._simulators.connectors import (
+    NumpyConnector,
+    TensorflowConnector,
+    JaxConnector,
+    TorchConnector,
+)
+
+from .instructions.preparations import (
+    Vacuum,
+    Mean,
+    Covariance,
+    Thermal,
+    StateVector,
+    DensityMatrix,
+    Create,
+    Annihilate,
+)
+
+from .instructions.gates import (
+    GaussianTransform,
+    Phaseshifter,
+    Beamsplitter,
+    Beamsplitter5050,
+    MachZehnder,
+    Fourier,
+    Displacement,
+    PositionDisplacement,
+    MomentumDisplacement,
+    Squeezing,
+    QuadraticPhase,
+    Squeezing2,
+    Kerr,
+    CrossKerr,
+    SNAP,
+    ControlledX,
+    ControlledZ,
+    Interferometer,
+    Graph,
+    CubicPhase,
+)
+
+from .instructions.measurements import (
+    ParticleNumberMeasurement,
+    ThresholdMeasurement,
+    HomodyneMeasurement,
+    HeterodyneMeasurement,
+    GeneraldyneMeasurement,
+    PostSelectPhotons,
+    ImperfectPostSelectPhotons,
+)
+
 from .instructions.channels import (
-    Attenuator,
     DeterministicGaussianChannel,
+    Attenuator,
     Loss,
     LossyInterferometer,
 )
-from .instructions.gates import (
-    SNAP,
-    Beamsplitter,
-    Beamsplitter5050,
-    ControlledX,
-    ControlledZ,
-    CrossKerr,
-    CubicPhase,
-    Displacement,
-    Fourier,
-    GaussianTransform,
-    Graph,
-    Interferometer,
-    Kerr,
-    MachZehnder,
-    MomentumDisplacement,
-    Phaseshifter,
-    PositionDisplacement,
-    QuadraticPhase,
-    Squeezing,
-    Squeezing2,
+
+from .instructions.batch import (
+    BatchPrepare,
+    BatchApply,
 )
-from .instructions.measurements import (
-    GeneraldyneMeasurement,
-    HeterodyneMeasurement,
-    HomodyneMeasurement,
-    ImperfectPostSelectPhotons,
-    ParticleNumberMeasurement,
-    PostSelectPhotons,
-    ThresholdMeasurement,
-)
-from .instructions.preparations import (
-    Annihilate,
-    Covariance,
-    Create,
-    DensityMatrix,
-    Mean,
-    StateVector,
-    Thermal,
-    Vacuum,
-)
+
 
 __all__ = [
     # API

--- a/piquasso/__init__.py
+++ b/piquasso/__init__.py
@@ -18,98 +18,87 @@
 One can access all the instructions and states from here as attributes.
 """
 
-from piquasso import cvqnn
-from piquasso import fermionic
-
-from piquasso.api.mode import Q
-from piquasso.api.config import Config
-from piquasso.api.instruction import (
-    Instruction,
-    Preparation,
-    Gate,
-    Measurement,
-)
-from piquasso.api.program import Program
-from piquasso.api.state import State
-from piquasso.api.computer import Computer
-from piquasso.api.simulator import Simulator
-from piquasso.api.utils import as_code
-
-from piquasso import dual_rail_encoding
-
-from piquasso._simulators.sampling import SamplingState, SamplingSimulator
-
-from piquasso._simulators.gaussian import GaussianState, GaussianSimulator
-from piquasso._simulators.fock import (
-    FockState,
-    PureFockState,
-    BatchPureFockState,
-    FockSimulator,
-    PureFockSimulator,
-)
-
+from piquasso import cvqnn, dual_rail_encoding, fermionic
 from piquasso._simulators.connectors import (
+    JaxConnector,
     NumpyConnector,
     TensorflowConnector,
-    JaxConnector,
+    TorchConnector,
 )
-
-from .instructions.preparations import (
-    Vacuum,
-    Mean,
-    Covariance,
-    Thermal,
-    StateVector,
-    DensityMatrix,
-    Create,
-    Annihilate,
+from piquasso._simulators.fock import (
+    BatchPureFockState,
+    FockSimulator,
+    FockState,
+    PureFockSimulator,
+    PureFockState,
 )
-
-from .instructions.gates import (
-    GaussianTransform,
-    Phaseshifter,
-    Beamsplitter,
-    Beamsplitter5050,
-    MachZehnder,
-    Fourier,
-    Displacement,
-    PositionDisplacement,
-    MomentumDisplacement,
-    Squeezing,
-    QuadraticPhase,
-    Squeezing2,
-    Kerr,
-    CrossKerr,
-    SNAP,
-    ControlledX,
-    ControlledZ,
-    Interferometer,
-    Graph,
-    CubicPhase,
+from piquasso._simulators.gaussian import GaussianSimulator, GaussianState
+from piquasso._simulators.sampling import SamplingSimulator, SamplingState
+from piquasso.api.computer import Computer
+from piquasso.api.config import Config
+from piquasso.api.instruction import (
+    Gate,
+    Instruction,
+    Measurement,
+    Preparation,
 )
+from piquasso.api.mode import Q
+from piquasso.api.program import Program
+from piquasso.api.simulator import Simulator
+from piquasso.api.state import State
+from piquasso.api.utils import as_code
 
-from .instructions.measurements import (
-    ParticleNumberMeasurement,
-    ThresholdMeasurement,
-    HomodyneMeasurement,
-    HeterodyneMeasurement,
-    GeneraldyneMeasurement,
-    PostSelectPhotons,
-    ImperfectPostSelectPhotons,
+from .instructions.batch import (
+    BatchApply,
+    BatchPrepare,
 )
-
 from .instructions.channels import (
-    DeterministicGaussianChannel,
     Attenuator,
+    DeterministicGaussianChannel,
     Loss,
     LossyInterferometer,
 )
-
-from .instructions.batch import (
-    BatchPrepare,
-    BatchApply,
+from .instructions.gates import (
+    SNAP,
+    Beamsplitter,
+    Beamsplitter5050,
+    ControlledX,
+    ControlledZ,
+    CrossKerr,
+    CubicPhase,
+    Displacement,
+    Fourier,
+    GaussianTransform,
+    Graph,
+    Interferometer,
+    Kerr,
+    MachZehnder,
+    MomentumDisplacement,
+    Phaseshifter,
+    PositionDisplacement,
+    QuadraticPhase,
+    Squeezing,
+    Squeezing2,
 )
-
+from .instructions.measurements import (
+    GeneraldyneMeasurement,
+    HeterodyneMeasurement,
+    HomodyneMeasurement,
+    ImperfectPostSelectPhotons,
+    ParticleNumberMeasurement,
+    PostSelectPhotons,
+    ThresholdMeasurement,
+)
+from .instructions.preparations import (
+    Annihilate,
+    Covariance,
+    Create,
+    DensityMatrix,
+    Mean,
+    StateVector,
+    Thermal,
+    Vacuum,
+)
 
 __all__ = [
     # API
@@ -133,6 +122,7 @@ __all__ = [
     "NumpyConnector",
     "TensorflowConnector",
     "JaxConnector",
+    "TorchConnector",
     # States
     "GaussianState",
     "SamplingState",

--- a/piquasso/_math/decompositions.py
+++ b/piquasso/_math/decompositions.py
@@ -14,14 +14,12 @@
 # limitations under the License.
 
 import numpy as np
-
 from scipy.optimize import root_scalar
 
 from piquasso._math.symplectic import xp_symplectic_form
 from piquasso._math.transformations import xpxp_to_xxpp_indices
-
-from piquasso.api.exceptions import InvalidParameter
 from piquasso.api.connector import BaseConnector
+from piquasso.api.exceptions import InvalidParameter
 
 
 def takagi(matrix, connector, atol=1e-12):
@@ -61,7 +59,7 @@ def takagi(matrix, connector, atol=1e-12):
     diagonal_blocks_for_Q = []
 
     for indices in singular_value_multiplicity_indices:
-        Z = V[:, indices].transpose() @ W[:, indices]
+        Z = V[:, indices].T @ W[:, indices]
 
         D, Q = connector.schur(Z)
         diags = np.diag(D)

--- a/piquasso/_simulators/connectors/__init__.py
+++ b/piquasso/_simulators/connectors/__init__.py
@@ -13,9 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from .jax_ import JaxConnector
 from .numpy_ import NumpyConnector
 from .tensorflow_ import TensorflowConnector
-from .jax_ import JaxConnector
+from .torch_ import TorchConnector
 
-
-__all__ = ["NumpyConnector", "TensorflowConnector", "JaxConnector"]
+__all__ = ["NumpyConnector", "TensorflowConnector", "JaxConnector", "TorchConnector"]

--- a/piquasso/_simulators/connectors/connections.py
+++ b/piquasso/_simulators/connectors/connections.py
@@ -159,7 +159,9 @@ def apply_fermionic_passive_linear_to_state_vector(
 
     for n, indices in enumerate(index_list):
         new_state_vector = connector.assign(
-            new_state_vector, indices, representations[n] @ state_vector[indices]
+            new_state_vector,
+            indices,
+            connector.np.matmul(representations[n], state_vector[indices]),
         )
 
     return new_state_vector

--- a/piquasso/_simulators/connectors/torch_/__init__.py
+++ b/piquasso/_simulators/connectors/torch_/__init__.py
@@ -1,0 +1,19 @@
+#
+# Copyright 2021-2026 Budapest Quantum Computing Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from .connector import TorchConnector
+
+__all__ = ["TorchConnector"]

--- a/piquasso/_simulators/connectors/torch_/connector.py
+++ b/piquasso/_simulators/connectors/torch_/connector.py
@@ -24,7 +24,7 @@ class TorchConnector(BuiltinConnector):
         try:
             import torch
 
-            from .np_mock import MockNumpy
+            from .np_adapter import NumpyAdapter
         except ImportError:
             raise ImportError(
                 "You have invoked a feature which requires 'torch'.\n"
@@ -33,7 +33,7 @@ class TorchConnector(BuiltinConnector):
                 "pip install piquasso[torch]"
             )
 
-        self.np = self.forward_pass_np = MockNumpy()
+        self.np = self.forward_pass_np = NumpyAdapter()
         self.torch = torch
         self.fallback_np = np  # NOTE(TR): I assume this is the "last resort" numpy.
 

--- a/piquasso/_simulators/connectors/torch_/connector.py
+++ b/piquasso/_simulators/connectors/torch_/connector.py
@@ -13,8 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ..connector import BuiltinConnector
 import numpy as np
+
+from ..connector import BuiltinConnector
 
 
 class TorchConnector(BuiltinConnector):
@@ -22,8 +23,8 @@ class TorchConnector(BuiltinConnector):
 
     def __init__(self):
         try:
-            import torch
             import np_mock
+            import torch
         except ImportError:
             raise ImportError(
                 "You have invoked a feature which requires 'torch'.\n"
@@ -31,7 +32,7 @@ class TorchConnector(BuiltinConnector):
                 "\n"
                 "pip install piquasso[torch]"
             )
-        
+
         self.np = np_mock
         self.torch = torch
         self.forward_pass_np = np_mock
@@ -39,14 +40,16 @@ class TorchConnector(BuiltinConnector):
 
     def block_diag(self, input):
         return self.torch.block_diag(input)
-    
+
     def block(self, tensors):
-        rows = [TorchConnector.block(row) for row in tensors]  # Horizontal concatenation
-        return self.torch.cat(rows, dim=0)  # Vertical concatenation
-    
+        # Horizontal concatenation
+        rows = [TorchConnector.block(row) for row in tensors]
+        # Vertical concatenation
+        return self.torch.cat(rows, dim=0)
+
     def _funm(self, matrix, func):
-        """ Helper function for the ``self.logm`` and ``self.expm`` implementation.
-        
+        """Helper function for the ``self.logm`` and ``self.expm`` implementation.
+
         NOTE: This is the same strategy as for the TensorflowConnector."""
         eigenvalues, U = self.torch.linalg.eig(matrix)
 
@@ -59,7 +62,7 @@ class TorchConnector(BuiltinConnector):
 
     def expm(self, matrix):
         return self._funm(matrix, self.torch.exp)
-    
+
     def powm(self, matrix, power):
         return self.torch.linalg.matrix_power(matrix, power)
 
@@ -71,19 +74,20 @@ class TorchConnector(BuiltinConnector):
         return D, Q
 
     def sqrtm(self, A):
-        # TODO(TR): AI-generated! Check if that's correct!     
-        # NOTE: Supposedly mimics TF implementation, and could be slow due to the lack of C++ support.
+        # TODO(TR): AI-generated! Check if that's correct!
+        # NOTE: Supposedly mimics TF implementation, and could be slow due
+        # to the lack of C++ support.
         T, Z = self.schur(A)
-        
+
         n = T.shape[-1]
         R = self.torch.zeros_like(T)
-        
+
         for j in range(n):
             R[j, j] = self.torch.sqrt(T[j, j])
             for i in range(j - 1, -1, -1):
-                s = self.torch.dot(R[i, i+1:j], R[i+1:j, j])
+                s = self.torch.dot(R[i, i + 1 : j], R[i + 1 : j, j])
                 R[i, j] = (T[i, j] - s) / (R[i, i] + R[j, j])
-                
+
         res = Z @ R @ Z.mhr()
         return res
 
@@ -98,10 +102,11 @@ class TorchConnector(BuiltinConnector):
             U = Pinv @ matrix
 
         return U, P
-    
+
     def svd(self, matrix):
-        return self.torch.linalg.svd(matrix)  # NOTE: torch and numpy have matching return order
-    
+        # NOTE: torch and numpy have matching return order
+        return self.torch.linalg.svd(matrix)
+
     def scatter(self, indices, updates, shape):
         # NOTE: Based on the JaxConnector implementation
         embedded_matrix = self.torch.zeros(shape, dtype=updates[0].dtype)
@@ -110,10 +115,11 @@ class TorchConnector(BuiltinConnector):
         embedded_matrix[composite_index] = self.np.array(updates)
         return embedded_matrix
 
-    # NOTE: These two are not implemented in the ``TensorflowConnector``, so I'm also leaving them here.
+    # NOTE: These two are not implemented in the
+    # ``TensorflowConnector``, so I'm also leaving them here.
     # calculate_interferometer_on_fock_space
     # calculate_interferometer_on_fermionic_fock_space
-    
+
     def permanent(self, matrix, rows, cols):
         # NOTE: Same as in TensorflowConnector implementation.
         raise NotImplementedError()
@@ -138,5 +144,3 @@ class TorchConnector(BuiltinConnector):
         array[index] = value
 
         return array
-    
-

--- a/piquasso/_simulators/connectors/torch_/connector.py
+++ b/piquasso/_simulators/connectors/torch_/connector.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 import numpy as np
 
 from ..connector import BuiltinConnector
@@ -38,12 +37,12 @@ class TorchConnector(BuiltinConnector):
         self.forward_pass_np = np_mock
         self.fallback_np = np  # NOTE(TR): I assume this is the "last resort" numpy.
 
-    def block_diag(self, input):
-        return self.torch.block_diag(input)
+    def block_diag(self, arrs):
+        return self.torch.block_diag(arrs)
 
     def block(self, tensors):
         # Horizontal concatenation
-        rows = [TorchConnector.block(row) for row in tensors]
+        rows = [self.block(row) for row in tensors]
         # Vertical concatenation
         return self.torch.cat(rows, dim=0)
 
@@ -70,7 +69,7 @@ class TorchConnector(BuiltinConnector):
         # NOTE: Based on the TensorflowConnector implementation.
         _, vecs = self.torch.linalg.eig(matrix)
         Q, _ = self.torch.linalg.qr(vecs)
-        D = self.torch.linalg.adjoint(Q) @ matrix @ Q
+        D = self.torch.adjoint(Q) @ matrix @ Q
         return D, Q
 
     def sqrtm(self, A):
@@ -114,6 +113,9 @@ class TorchConnector(BuiltinConnector):
         composite_index = tuple([indices_array[:, i] for i in range(len(shape))])
         embedded_matrix[composite_index] = self.np.array(updates)
         return embedded_matrix
+
+    def preprocess_input_for_custom_gradient(self, value):
+        return value
 
     # NOTE: These two are not implemented in the
     # ``TensorflowConnector``, so I'm also leaving them here.

--- a/piquasso/_simulators/connectors/torch_/connector.py
+++ b/piquasso/_simulators/connectors/torch_/connector.py
@@ -22,8 +22,9 @@ class TorchConnector(BuiltinConnector):
 
     def __init__(self):
         try:
-            import np_mock
             import torch
+
+            from .np_mock import MockNumpy
         except ImportError:
             raise ImportError(
                 "You have invoked a feature which requires 'torch'.\n"
@@ -32,9 +33,8 @@ class TorchConnector(BuiltinConnector):
                 "pip install piquasso[torch]"
             )
 
-        self.np = np_mock
+        self.np = self.forward_pass_np = MockNumpy()
         self.torch = torch
-        self.forward_pass_np = np_mock
         self.fallback_np = np  # NOTE(TR): I assume this is the "last resort" numpy.
 
     def block_diag(self, arrs):

--- a/piquasso/_simulators/connectors/torch_/connector.py
+++ b/piquasso/_simulators/connectors/torch_/connector.py
@@ -1,0 +1,142 @@
+#
+# Copyright 2021-2026 Budapest Quantum Computing Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ..connector import BuiltinConnector
+import numpy as np
+
+
+class TorchConnector(BuiltinConnector):
+    """TODO(TR)"""
+
+    def __init__(self):
+        try:
+            import torch
+            import np_mock
+        except ImportError:
+            raise ImportError(
+                "You have invoked a feature which requires 'torch'.\n"
+                "You can install PyTorch via:\n"
+                "\n"
+                "pip install piquasso[torch]"
+            )
+        
+        self.np = np_mock
+        self.torch = torch
+        self.forward_pass_np = np_mock
+        self.fallback_np = np  # NOTE(TR): I assume this is the "last resort" numpy.
+
+    def block_diag(self, input):
+        return self.torch.block_diag(input)
+    
+    def block(self, tensors):
+        rows = [TorchConnector.block(row) for row in tensors]  # Horizontal concatenation
+        return self.torch.cat(rows, dim=0)  # Vertical concatenation
+    
+    def _funm(self, matrix, func):
+        """ Helper function for the ``self.logm`` and ``self.expm`` implementation.
+        
+        NOTE: This is the same strategy as for the TensorflowConnector."""
+        eigenvalues, U = self.torch.linalg.eig(matrix)
+
+        f_eigenvalues = func(eigenvalues)
+
+        return U @ self.torch.diag(f_eigenvalues) @ self.torch.linalg.inv(U)
+
+    def logm(self, matrix):
+        return self._funm(matrix, self.torch.log)
+
+    def expm(self, matrix):
+        return self._funm(matrix, self.torch.exp)
+    
+    def powm(self, matrix, power):
+        return self.torch.linalg.matrix_power(matrix, power)
+
+    def schur(self, matrix):
+        # NOTE: Based on the TensorflowConnector implementation.
+        _, vecs = self.torch.linalg.eig(matrix)
+        Q, _ = self.torch.linalg.qr(vecs)
+        D = self.torch.linalg.adjoint(Q) @ matrix @ Q
+        return D, Q
+
+    def sqrtm(self, A):
+        # TODO(TR): AI-generated! Check if that's correct!     
+        # NOTE: Supposedly mimics TF implementation, and could be slow due to the lack of C++ support.
+        T, Z = self.schur(A)
+        
+        n = T.shape[-1]
+        R = self.torch.zeros_like(T)
+        
+        for j in range(n):
+            R[j, j] = self.torch.sqrt(T[j, j])
+            for i in range(j - 1, -1, -1):
+                s = self.torch.dot(R[i, i+1:j], R[i+1:j, j])
+                R[i, j] = (T[i, j] - s) / (R[i, i] + R[j, j])
+                
+        res = Z @ R @ Z.mhr()
+        return res
+
+    def polar(self, matrix, side="right"):
+        # NOTE: Based on the TensorflowConnector implementation.
+        P = self.sqrtm(self.torch.conj(matrix) @ matrix.t)
+        Pinv = self.torch.linalg.inv(P)
+
+        if side == "right":
+            U = matrix @ Pinv
+        elif side == "left":
+            U = Pinv @ matrix
+
+        return U, P
+    
+    def svd(self, matrix):
+        return self.torch.linalg.svd(matrix)  # NOTE: torch and numpy have matching return order
+    
+    def scatter(self, indices, updates, shape):
+        # NOTE: Based on the JaxConnector implementation
+        embedded_matrix = self.torch.zeros(shape, dtype=updates[0].dtype)
+        indices_array = self.np.array(indices)
+        composite_index = tuple([indices_array[:, i] for i in range(len(shape))])
+        embedded_matrix[composite_index] = self.np.array(updates)
+        return embedded_matrix
+
+    # NOTE: These two are not implemented in the ``TensorflowConnector``, so I'm also leaving them here.
+    # calculate_interferometer_on_fock_space
+    # calculate_interferometer_on_fermionic_fock_space
+    
+    def permanent(self, matrix, rows, cols):
+        # NOTE: Same as in TensorflowConnector implementation.
+        raise NotImplementedError()
+
+    def permanent_laplace(self, matrix, rows, cols):
+        # NOTE: Same as in TensorflowConnector implementation.
+        raise NotImplementedError()
+
+    def hafnian(self, matrix, reduce_on):
+        # NOTE: Same as in TensorflowConnector implementation.
+        raise NotImplementedError()
+
+    def loop_hafnian(self, matrix, diagonal, reduce_on):
+        # NOTE: Same as in TensorflowConnector implementation.
+        raise NotImplementedError()
+
+    def loop_hafnian_batch(self, matrix, diagonal, reduce_on, cutoff):
+        # NOTE: Same as in TensorflowConnector implementation.
+        raise NotImplementedError()
+
+    def assign(self, array, index, value):
+        array[index] = value
+
+        return array
+    
+

--- a/piquasso/_simulators/connectors/torch_/connector.py
+++ b/piquasso/_simulators/connectors/torch_/connector.py
@@ -37,8 +37,8 @@ class TorchConnector(BuiltinConnector):
         self.torch = torch
         self.fallback_np = np  # NOTE(TR): I assume this is the "last resort" numpy.
 
-    def block_diag(self, arrs):
-        return self.torch.block_diag(arrs)
+    def block_diag(self, *arrs):
+        return self.torch.block_diag(*arrs)
 
     def block(self, tensors):
         # Horizontal concatenation
@@ -104,7 +104,7 @@ class TorchConnector(BuiltinConnector):
 
     def svd(self, matrix):
         # NOTE: torch and numpy have matching return order
-        return self.torch.linalg.svd(matrix)
+        return self.torch.linalg.svd(matrix, full_matrices=True)
 
     def scatter(self, indices, updates, shape):
         # NOTE: Based on the JaxConnector implementation

--- a/piquasso/_simulators/connectors/torch_/np_adapter.py
+++ b/piquasso/_simulators/connectors/torch_/np_adapter.py
@@ -21,7 +21,7 @@ import numpy as np
 import torch
 
 
-class MockNumpy:
+class NumpyAdapter:
     """A mock-up class implementing torch versions of the
     functions used by piquasso that can be usually found
     in numpy. This class will be used by TorchConnector."""
@@ -69,7 +69,7 @@ class MockNumpy:
 
     @staticmethod
     def isclose(a, b, rtol=1e-05, atol=1e-08, equal_nan=False):
-        return MockNumpy.array(np.isclose(a, b, rtol, atol, equal_nan))
+        return NumpyAdapter.array(np.isclose(a, b, rtol, atol, equal_nan))
 
     @staticmethod
     def mod(a, b):

--- a/piquasso/_simulators/connectors/torch_/np_adapter.py
+++ b/piquasso/_simulators/connectors/torch_/np_adapter.py
@@ -118,7 +118,34 @@ class NumpyAdapter:
 
     @staticmethod
     def astype(input, dtype):
-        return input.to(dtype)
+        return input.to(translate_dtype(dtype))
+
+    @staticmethod
+    def exp(input):
+        if not isinstance(input, torch.Tensor):
+            input = torch.tensor([input])
+
+            return torch.exp(input)[0]
+
+        return torch.exp(input)
+
+    @staticmethod
+    def sin(input):
+        if not isinstance(input, torch.Tensor):
+            input = torch.tensor([input])
+
+            return torch.sin(input)[0]
+
+        return torch.sin(input)
+
+    @staticmethod
+    def cos(input):
+        if not isinstance(input, torch.Tensor):
+            input = torch.tensor([input])
+
+            return torch.cos(input)[0]
+
+        return torch.cos(input)
 
     @staticmethod
     def zeros(*args, **kwargs):

--- a/piquasso/_simulators/connectors/torch_/np_adapter.py
+++ b/piquasso/_simulators/connectors/torch_/np_adapter.py
@@ -21,6 +21,26 @@ import numpy as np
 import torch
 
 
+def translate_dtype(dtype):
+
+    if dtype == np.float32:
+        return torch.float32
+
+    if dtype == np.float64:
+        return torch.float64
+
+    if dtype == np.complex64:
+        return torch.complex64
+
+    if dtype == np.complex128:
+        return torch.complex128
+
+    if dtype == np.int64:
+        return torch.int64
+
+    return dtype
+
+
 class NumpyAdapter:
     """A mock-up class implementing torch versions of the
     functions used by piquasso that can be usually found
@@ -43,6 +63,11 @@ class NumpyAdapter:
     def copy(input):
         return input.detach().clone()
 
+    @property
+    def int64(self):
+        # Not sure if this is needed. Sometimes `fallback_np` uses `np.int64`, but `torch.int64` is not recognized.
+        return np.int64
+
     @staticmethod
     def array(input, dtype=None):
         # NOTE(TR): Does it make sense? Seems a little misleading,
@@ -60,7 +85,7 @@ class NumpyAdapter:
             return torch.stack([torch.stack(row) for row in input])
         except Exception:
             # Last resort
-            return torch.tensor(input, dtype=dtype)
+            return torch.tensor(input, dtype=translate_dtype(dtype))
             raise
 
     @staticmethod
@@ -78,7 +103,12 @@ class NumpyAdapter:
     @staticmethod
     def matmul(a, b):
         # NOTE: torch.Tensors do not autocast during the multiplication.
-        dtype: torch.dtype = torch.promote_types(a.dtype, b.dtype)
+        dtype: torch.dtype = torch.promote_types(
+            translate_dtype(a.dtype), translate_dtype(b.dtype)
+        )
+
+        if isinstance(a, np.ndarray):
+            a = torch.from_numpy(a)
 
         return a.to(dtype) @ b.to(dtype)
 
@@ -89,3 +119,17 @@ class NumpyAdapter:
     @staticmethod
     def astype(input, dtype):
         return input.to(dtype)
+
+    @staticmethod
+    def zeros(*args, **kwargs):
+        if "dtype" in kwargs:
+            kwargs["dtype"] = translate_dtype(kwargs["dtype"])
+
+        if "shape" in kwargs:
+            shape = kwargs.pop("shape")
+
+            return torch.zeros(shape, **kwargs)
+        else:
+            shape = args[0]
+
+        return torch.zeros(shape, **kwargs)

--- a/piquasso/_simulators/connectors/torch_/np_mock.py
+++ b/piquasso/_simulators/connectors/torch_/np_mock.py
@@ -69,3 +69,7 @@ class MockNumpy:
         dtype: torch.dtype = torch.promote_types(a.dtype, b.dtype)
 
         return a.to(dtype) @ b.to(dtype)
+
+    @staticmethod
+    def identity(n):
+        return torch.eye(n)

--- a/piquasso/_simulators/connectors/torch_/np_mock.py
+++ b/piquasso/_simulators/connectors/torch_/np_mock.py
@@ -15,46 +15,31 @@
 
 # This module contains mock-ups used by the TorchConnector.
 
+from typing import Any
+
 import torch
 
 
-def sum(tensor):
-    return torch.sum(tensor)
+class MockNumpy:
+    """A mock-up class implementing torch versions of the
+    functions used by piquasso that can be usually found
+    in numpy. This class will be used by TorchConnector."""
 
+    def __getattribute__(self, name: str, /) -> Any:
+        """
+        NOTE: Created to reduce boilerplate torch calls.
+        """
+        if hasattr(torch, name):
+            return getattr(torch, name)
 
-def real(tensor):
-    return torch.real(tensor)
+        return super().__getattribute__(name)
 
+    @staticmethod
+    def copy(input):
+        return input.detach().clone()
 
-def array(input):
-    # NOTE(TR): Does it make sense? Seems a little misleading,
-    # but the intuition seems correct.
-    return torch.Tensor(input)
-
-
-def diag(tensor):
-    return torch.diag(tensor)
-
-
-def zeros(size):
-    return torch.zeros(size)
-
-
-def conj(input):
-    return torch.conj(input)
-
-
-def allclose(input, other, rtol=1e-05, atol=1e-08, equal_nan=False):
-    return torch.allclose(input, other, rtol, atol, equal_nan)
-
-
-def copy(input):
-    return input.detach().clone()
-
-
-def abs(input):
-    return torch.abs(input)
-
-
-def outer(v1, v2):
-    return torch.outer(v1, v2)
+    @staticmethod
+    def array(input):
+        # NOTE(TR): Does it make sense? Seems a little misleading,
+        # but the intuition seems correct.
+        return torch.Tensor(input)

--- a/piquasso/_simulators/connectors/torch_/np_mock.py
+++ b/piquasso/_simulators/connectors/torch_/np_mock.py
@@ -17,6 +17,7 @@
 
 from typing import Any
 
+import numpy as np
 import torch
 
 
@@ -29,10 +30,14 @@ class MockNumpy:
         """
         NOTE: Created to reduce boilerplate torch calls.
         """
-        if hasattr(torch, name):
-            return getattr(torch, name)
+        try:
+            # Prioritize self implementations.
+            return super().__getattribute__(name)
+        except AttributeError:
+            if hasattr(torch, name):
+                return getattr(torch, name)
 
-        return super().__getattribute__(name)
+            raise
 
     @staticmethod
     def copy(input):
@@ -42,4 +47,25 @@ class MockNumpy:
     def array(input):
         # NOTE(TR): Does it make sense? Seems a little misleading,
         # but the intuition seems correct.
+        if isinstance(input, np.ndarray):
+            return torch.from_numpy(input)
         return torch.Tensor(input)
+
+    @staticmethod
+    def transpose(input):
+        return input.t()
+
+    @staticmethod
+    def isclose(a, b, rtol=1e-05, atol=1e-08, equal_nan=False):
+        return MockNumpy.array(np.isclose(a, b, rtol, atol, equal_nan))
+
+    @staticmethod
+    def mod(a, b):
+        return torch.remainder(a, b)
+
+    @staticmethod
+    def matmul(a, b):
+        # NOTE: torch.Tensors do not autocast during the multiplication.
+        dtype: torch.dtype = torch.promote_types(a.dtype, b.dtype)
+
+        return a.to(dtype) @ b.to(dtype)

--- a/piquasso/_simulators/connectors/torch_/np_mock.py
+++ b/piquasso/_simulators/connectors/torch_/np_mock.py
@@ -1,0 +1,50 @@
+#
+# Copyright 2021-2026 Budapest Quantum Computing Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This module contains mock-ups used by the TorchConnector.
+
+import torch
+
+
+def sum(tensor):
+    return torch.sum(tensor)
+
+def real(tensor):
+    return torch.real(tensor)
+
+def array(input):
+    # NOTE(TR): Does it make sense? Seems a little misleading, but the intuition seems correct.
+    return torch.Tensor(input)
+
+def diag(tensor):
+    return torch.diag(tensor)
+
+def zeros(size):
+    return torch.zeros(size)
+
+def conj(input):
+    return torch.conj(input)
+
+def allclose(input, other, rtol = 1e-05, atol = 1e-08, equal_nan = False):
+    return torch.allclose(input, other, rtol, atol, equal_nan)
+
+def copy(input):
+    return input.detach().clone()
+
+def abs(input):
+    return torch.abs(input)
+
+def outer(v1, v2):
+    return torch.outer(v1, v2)

--- a/piquasso/_simulators/connectors/torch_/np_mock.py
+++ b/piquasso/_simulators/connectors/torch_/np_mock.py
@@ -71,5 +71,5 @@ class MockNumpy:
         return a.to(dtype) @ b.to(dtype)
 
     @staticmethod
-    def identity(n):
-        return torch.eye(n)
+    def identity(n, dtype=torch.float32):
+        return torch.eye(n, dtype=dtype)

--- a/piquasso/_simulators/connectors/torch_/np_mock.py
+++ b/piquasso/_simulators/connectors/torch_/np_mock.py
@@ -44,12 +44,24 @@ class MockNumpy:
         return input.detach().clone()
 
     @staticmethod
-    def array(input, dtype=torch.float32):
+    def array(input, dtype=None):
         # NOTE(TR): Does it make sense? Seems a little misleading,
         # but the intuition seems correct.
-        if not isinstance(input, np.ndarray):
-            input = np.array(input)
-        return torch.from_numpy(input)
+        #
+        # This method is unreasonably difficult to implement.
+        if isinstance(input, torch.Tensor):
+            return input
+
+        if isinstance(input, np.ndarray):
+            return torch.from_numpy(input)
+
+        try:
+            # 2D list
+            return torch.stack([torch.stack(row) for row in input])
+        except Exception:
+            # Last resort
+            return torch.tensor(input, dtype=dtype)
+            raise
 
     @staticmethod
     def transpose(input):

--- a/piquasso/_simulators/connectors/torch_/np_mock.py
+++ b/piquasso/_simulators/connectors/torch_/np_mock.py
@@ -44,12 +44,12 @@ class MockNumpy:
         return input.detach().clone()
 
     @staticmethod
-    def array(input):
+    def array(input, dtype=torch.float32):
         # NOTE(TR): Does it make sense? Seems a little misleading,
         # but the intuition seems correct.
-        if isinstance(input, np.ndarray):
-            return torch.from_numpy(input)
-        return torch.Tensor(input)
+        if not isinstance(input, np.ndarray):
+            input = np.array(input)
+        return torch.from_numpy(input)
 
     @staticmethod
     def transpose(input):
@@ -73,3 +73,7 @@ class MockNumpy:
     @staticmethod
     def identity(n, dtype=torch.float32):
         return torch.eye(n, dtype=dtype)
+
+    @staticmethod
+    def astype(input, dtype):
+        return input.to(dtype)

--- a/piquasso/_simulators/connectors/torch_/np_mock.py
+++ b/piquasso/_simulators/connectors/torch_/np_mock.py
@@ -21,30 +21,40 @@ import torch
 def sum(tensor):
     return torch.sum(tensor)
 
+
 def real(tensor):
     return torch.real(tensor)
 
+
 def array(input):
-    # NOTE(TR): Does it make sense? Seems a little misleading, but the intuition seems correct.
+    # NOTE(TR): Does it make sense? Seems a little misleading,
+    # but the intuition seems correct.
     return torch.Tensor(input)
+
 
 def diag(tensor):
     return torch.diag(tensor)
 
+
 def zeros(size):
     return torch.zeros(size)
+
 
 def conj(input):
     return torch.conj(input)
 
-def allclose(input, other, rtol = 1e-05, atol = 1e-08, equal_nan = False):
+
+def allclose(input, other, rtol=1e-05, atol=1e-08, equal_nan=False):
     return torch.allclose(input, other, rtol, atol, equal_nan)
+
 
 def copy(input):
     return input.detach().clone()
 
+
 def abs(input):
     return torch.abs(input)
+
 
 def outer(v1, v2):
     return torch.outer(v1, v2)

--- a/piquasso/_simulators/fock/pure/simulator.py
+++ b/piquasso/_simulators/fock/pure/simulator.py
@@ -52,6 +52,7 @@ from piquasso._simulators.connectors import (
     NumpyConnector,
     TensorflowConnector,
     JaxConnector,
+    TorchConnector,
 )
 
 
@@ -148,7 +149,7 @@ class PureFockSimulator(BuiltinSimulator):
 
     _default_connector_class = NumpyConnector
 
-    _extra_builtin_connectors = [TensorflowConnector, JaxConnector]
+    _extra_builtin_connectors = [TensorflowConnector, JaxConnector, TorchConnector]
 
     _measurement_classes_allowed_mid_circuit = (
         measurements.ParticleNumberMeasurement,

--- a/piquasso/_simulators/gaussian/simulator.py
+++ b/piquasso/_simulators/gaussian/simulator.py
@@ -16,7 +16,7 @@
 from ..simulator import BuiltinSimulator
 from piquasso.instructions import preparations, gates, measurements, channels
 
-from piquasso._simulators.connectors import NumpyConnector, JaxConnector
+from piquasso._simulators.connectors import NumpyConnector, JaxConnector, TorchConnector
 
 from .state import GaussianState
 from .simulation_steps import (
@@ -134,7 +134,7 @@ class GaussianSimulator(BuiltinSimulator):
 
     _default_connector_class = NumpyConnector
 
-    _extra_builtin_connectors = [JaxConnector]
+    _extra_builtin_connectors = [JaxConnector, TorchConnector]
 
     _measurement_classes_allowed_mid_circuit = (
         measurements.HomodyneMeasurement,

--- a/piquasso/_simulators/sampling/simulator.py
+++ b/piquasso/_simulators/sampling/simulator.py
@@ -16,7 +16,7 @@
 from ..simulator import BuiltinSimulator
 from piquasso.instructions import preparations, gates, measurements, channels
 
-from piquasso._simulators.connectors import NumpyConnector, JaxConnector
+from piquasso._simulators.connectors import NumpyConnector, JaxConnector, TorchConnector
 
 from .state import SamplingState
 from .simulation_steps import (
@@ -102,6 +102,6 @@ class SamplingSimulator(BuiltinSimulator):
 
     _default_connector_class = NumpyConnector
 
-    _extra_builtin_connectors = [JaxConnector]
+    _extra_builtin_connectors = [JaxConnector, TorchConnector]
 
     _measurement_classes_allowed_mid_circuit = (measurements.PostSelectPhotons,)

--- a/piquasso/decompositions/clements.py
+++ b/piquasso/decompositions/clements.py
@@ -142,7 +142,7 @@ def inverse_clements(decomposition: Decomposition, connector: BaseConnector, dty
     for beamsplitter in decomposition.beamsplitters:
         beamsplitter_matrix = _get_embedded_beamsplitter_matrix(beamsplitter, d, connector, dtype=dtype)
 
-        interferometer = beamsplitter_matrix @ interferometer
+        interferometer = np.matmul(beamsplitter_matrix, interferometer)
 
     phis = np.empty(d, dtype=interferometer.dtype)
 

--- a/piquasso/decompositions/clements.py
+++ b/piquasso/decompositions/clements.py
@@ -15,17 +15,13 @@
 
 """An implementation for the Clements decomposition."""
 
-from typing import List, Tuple, TYPE_CHECKING
-
 from dataclasses import dataclass
-
-from piquasso.api.connector import BaseConnector
-
-from piquasso.instructions.gates import Phaseshifter, Beamsplitter
+from typing import TYPE_CHECKING, List, Tuple
 
 from piquasso._math.indices import get_operator_index
-
 from piquasso._simulators.connectors import NumpyConnector
+from piquasso.api.connector import BaseConnector
+from piquasso.instructions.gates import Beamsplitter, Phaseshifter
 
 if TYPE_CHECKING:
     import numpy as np
@@ -131,9 +127,7 @@ def instructions_from_decomposition(decomposition):
     return instructions
 
 
-def inverse_clements(
-    decomposition: Decomposition, connector: BaseConnector, dtype: "np.dtype"
-) -> "np.ndarray":
+def inverse_clements(decomposition: Decomposition, connector: BaseConnector, dtype: "np.dtype") -> "np.ndarray":
     """Inverse of the Clements decomposition.
 
     Returns:
@@ -146,9 +140,7 @@ def inverse_clements(
     interferometer = np.identity(d, dtype=dtype)
 
     for beamsplitter in decomposition.beamsplitters:
-        beamsplitter_matrix = _get_embedded_beamsplitter_matrix(
-            beamsplitter, d, connector, dtype=dtype
-        )
+        beamsplitter_matrix = _get_embedded_beamsplitter_matrix(beamsplitter, d, connector, dtype=dtype)
 
         interferometer = beamsplitter_matrix @ interferometer
 
@@ -189,16 +181,11 @@ def clements(U: "np.ndarray", connector: BaseConnector) -> Decomposition:
             operations, U = _apply_inverse_beamsplitters(column, U, connector)
             first_beamsplitters.extend(operations)
 
-    middle_phasshifters = [
-        PS(mode=mode, phi=np.angle(diagonal))
-        for mode, diagonal in enumerate(np.diag(U))
-    ]
+    middle_phasshifters = [PS(mode=mode, phi=np.angle(diagonal)) for mode, diagonal in enumerate(np.diag(U))]
 
     last_beamsplitters = list(reversed(last_beamsplitters))
 
-    commuted_beamsplitters, phasehifters = _commute(
-        middle_phasshifters, last_beamsplitters, connector
-    )
+    commuted_beamsplitters, phasehifters = _commute(middle_phasshifters, last_beamsplitters, connector)
 
     return Decomposition(
         beamsplitters=first_beamsplitters + commuted_beamsplitters,
@@ -271,9 +258,7 @@ def _get_commute_angles(bs_theta, bs_phi, phi1, phi2, connector):
     return bs_theta_p, bs_phi_p, phi1_p, phi2_p
 
 
-def _apply_direct_beamsplitters(
-    column: int, U: "np.ndarray", connector: BaseConnector
-) -> tuple:
+def _apply_direct_beamsplitters(column: int, U: "np.ndarray", connector: BaseConnector) -> tuple:
     """
     Calculates the direct beamsplitters for a given column `column`, and
     applies it to `U`.
@@ -294,9 +279,7 @@ def _apply_direct_beamsplitters(
         matrix_element_to_eliminate = U[modes[0], j]
         matrix_element_above = -U[modes[1], j]
 
-        angles = _get_angles(
-            matrix_element_to_eliminate, matrix_element_above, connector
-        )
+        angles = _get_angles(matrix_element_to_eliminate, matrix_element_above, connector)
 
         operation = BS(modes=modes, params=angles)
 
@@ -309,9 +292,7 @@ def _apply_direct_beamsplitters(
     return operations, U
 
 
-def _apply_inverse_beamsplitters(
-    column: int, U: "np.ndarray", connector: BaseConnector
-) -> tuple:
+def _apply_inverse_beamsplitters(column: int, U: "np.ndarray", connector: BaseConnector) -> tuple:
     """
     Calculates the inverse beamsplitters for a given column `column`, and
     applies it to `U`.
@@ -334,15 +315,11 @@ def _apply_inverse_beamsplitters(
         matrix_element_to_eliminate = U[i, modes[1]]
         matrix_element_to_left = U[i, modes[0]]
 
-        angles = _get_angles(
-            matrix_element_to_eliminate, matrix_element_to_left, connector
-        )
+        angles = _get_angles(matrix_element_to_eliminate, matrix_element_to_left, connector)
 
         operation = BS(modes=modes, params=angles)
 
-        beamsplitter = connector.np.conj(
-            _get_embedded_beamsplitter_matrix(operation, d, connector, dtype)
-        ).T
+        beamsplitter = connector.np.conj(_get_embedded_beamsplitter_matrix(operation, d, connector, dtype)).T
 
         U = U @ beamsplitter
 
@@ -357,7 +334,7 @@ def _get_angles(matrix_element_to_eliminate, other_matrix_element, connector):
     if np.isclose(matrix_element_to_eliminate, 0.0):
         return np.pi / 2, 0.0
 
-    r = other_matrix_element / matrix_element_to_eliminate
+    r = np.array(other_matrix_element / matrix_element_to_eliminate)
     theta = np.arctan(np.abs(r))
     phi = np.angle(r)
 
@@ -372,8 +349,8 @@ def _get_embedded_beamsplitter_matrix(
     theta, phi = operation.params
     i, j = operation.modes
 
-    c = np.cos(theta).astype(dtype)
-    s = np.sin(theta).astype(dtype)
+    c = np.astype(np.cos(theta), dtype)
+    s = np.astype(np.sin(theta), dtype)
 
     matrix = np.array(
         [
@@ -386,9 +363,7 @@ def _get_embedded_beamsplitter_matrix(
     return connector.embed_in_identity(matrix, get_operator_index((i, j)), d)
 
 
-def get_weights_from_decomposition(
-    decomposition: Decomposition, d: int, connector: BaseConnector
-) -> "np.ndarray":
+def get_weights_from_decomposition(decomposition: Decomposition, d: int, connector: BaseConnector) -> "np.ndarray":
     """Concatenates the weight vector from the angles in the Clements decomposition.
 
     Returns:
@@ -413,9 +388,7 @@ def get_weights_from_decomposition(
     return weights
 
 
-def get_decomposition_from_weights(
-    weights: "np.ndarray", d: int, connector: BaseConnector
-) -> Decomposition:
+def get_decomposition_from_weights(weights: "np.ndarray", d: int, connector: BaseConnector) -> Decomposition:
     """Puts the data in the weight vector into a Clements decompositon.
 
     Returns:
@@ -443,9 +416,7 @@ def get_decomposition_from_weights(
     return decomposition
 
 
-def get_weights_from_interferometer(
-    U: "np.ndarray", connector: BaseConnector
-) -> "np.ndarray":
+def get_weights_from_interferometer(U: "np.ndarray", connector: BaseConnector) -> "np.ndarray":
     """Creates a vector of weights from the Clements angles."""
     decomposition = clements(U, connector)
 

--- a/piquasso/decompositions/clements.py
+++ b/piquasso/decompositions/clements.py
@@ -127,7 +127,9 @@ def instructions_from_decomposition(decomposition):
     return instructions
 
 
-def inverse_clements(decomposition: Decomposition, connector: BaseConnector, dtype: "np.dtype") -> "np.ndarray":
+def inverse_clements(
+    decomposition: Decomposition, connector: BaseConnector, dtype: "np.dtype"
+) -> "np.ndarray":
     """Inverse of the Clements decomposition.
 
     Returns:
@@ -140,7 +142,9 @@ def inverse_clements(decomposition: Decomposition, connector: BaseConnector, dty
     interferometer = np.identity(d, dtype=dtype)
 
     for beamsplitter in decomposition.beamsplitters:
-        beamsplitter_matrix = _get_embedded_beamsplitter_matrix(beamsplitter, d, connector, dtype=dtype)
+        beamsplitter_matrix = _get_embedded_beamsplitter_matrix(
+            beamsplitter, d, connector, dtype=dtype
+        )
 
         interferometer = np.matmul(beamsplitter_matrix, interferometer)
 
@@ -181,11 +185,16 @@ def clements(U: "np.ndarray", connector: BaseConnector) -> Decomposition:
             operations, U = _apply_inverse_beamsplitters(column, U, connector)
             first_beamsplitters.extend(operations)
 
-    middle_phasshifters = [PS(mode=mode, phi=np.angle(diagonal)) for mode, diagonal in enumerate(np.diag(U))]
+    middle_phasshifters = [
+        PS(mode=mode, phi=np.angle(diagonal))
+        for mode, diagonal in enumerate(np.diag(U))
+    ]
 
     last_beamsplitters = list(reversed(last_beamsplitters))
 
-    commuted_beamsplitters, phasehifters = _commute(middle_phasshifters, last_beamsplitters, connector)
+    commuted_beamsplitters, phasehifters = _commute(
+        middle_phasshifters, last_beamsplitters, connector
+    )
 
     return Decomposition(
         beamsplitters=first_beamsplitters + commuted_beamsplitters,
@@ -258,7 +267,9 @@ def _get_commute_angles(bs_theta, bs_phi, phi1, phi2, connector):
     return bs_theta_p, bs_phi_p, phi1_p, phi2_p
 
 
-def _apply_direct_beamsplitters(column: int, U: "np.ndarray", connector: BaseConnector) -> tuple:
+def _apply_direct_beamsplitters(
+    column: int, U: "np.ndarray", connector: BaseConnector
+) -> tuple:
     """
     Calculates the direct beamsplitters for a given column `column`, and
     applies it to `U`.
@@ -279,7 +290,9 @@ def _apply_direct_beamsplitters(column: int, U: "np.ndarray", connector: BaseCon
         matrix_element_to_eliminate = U[modes[0], j]
         matrix_element_above = -U[modes[1], j]
 
-        angles = _get_angles(matrix_element_to_eliminate, matrix_element_above, connector)
+        angles = _get_angles(
+            matrix_element_to_eliminate, matrix_element_above, connector
+        )
 
         operation = BS(modes=modes, params=angles)
 
@@ -292,7 +305,9 @@ def _apply_direct_beamsplitters(column: int, U: "np.ndarray", connector: BaseCon
     return operations, U
 
 
-def _apply_inverse_beamsplitters(column: int, U: "np.ndarray", connector: BaseConnector) -> tuple:
+def _apply_inverse_beamsplitters(
+    column: int, U: "np.ndarray", connector: BaseConnector
+) -> tuple:
     """
     Calculates the inverse beamsplitters for a given column `column`, and
     applies it to `U`.
@@ -315,11 +330,15 @@ def _apply_inverse_beamsplitters(column: int, U: "np.ndarray", connector: BaseCo
         matrix_element_to_eliminate = U[i, modes[1]]
         matrix_element_to_left = U[i, modes[0]]
 
-        angles = _get_angles(matrix_element_to_eliminate, matrix_element_to_left, connector)
+        angles = _get_angles(
+            matrix_element_to_eliminate, matrix_element_to_left, connector
+        )
 
         operation = BS(modes=modes, params=angles)
 
-        beamsplitter = connector.np.conj(_get_embedded_beamsplitter_matrix(operation, d, connector, dtype)).T
+        beamsplitter = connector.np.conj(
+            _get_embedded_beamsplitter_matrix(operation, d, connector, dtype)
+        ).T
 
         U = U @ beamsplitter
 
@@ -363,7 +382,9 @@ def _get_embedded_beamsplitter_matrix(
     return connector.embed_in_identity(matrix, get_operator_index((i, j)), d)
 
 
-def get_weights_from_decomposition(decomposition: Decomposition, d: int, connector: BaseConnector) -> "np.ndarray":
+def get_weights_from_decomposition(
+    decomposition: Decomposition, d: int, connector: BaseConnector
+) -> "np.ndarray":
     """Concatenates the weight vector from the angles in the Clements decomposition.
 
     Returns:
@@ -388,7 +409,9 @@ def get_weights_from_decomposition(decomposition: Decomposition, d: int, connect
     return weights
 
 
-def get_decomposition_from_weights(weights: "np.ndarray", d: int, connector: BaseConnector) -> Decomposition:
+def get_decomposition_from_weights(
+    weights: "np.ndarray", d: int, connector: BaseConnector
+) -> Decomposition:
     """Puts the data in the weight vector into a Clements decompositon.
 
     Returns:
@@ -416,7 +439,9 @@ def get_decomposition_from_weights(weights: "np.ndarray", d: int, connector: Bas
     return decomposition
 
 
-def get_weights_from_interferometer(U: "np.ndarray", connector: BaseConnector) -> "np.ndarray":
+def get_weights_from_interferometer(
+    U: "np.ndarray", connector: BaseConnector
+) -> "np.ndarray":
     """Creates a vector of weights from the Clements angles."""
     decomposition = clements(U, connector)
 

--- a/piquasso/decompositions/clements.py
+++ b/piquasso/decompositions/clements.py
@@ -340,7 +340,7 @@ def _apply_inverse_beamsplitters(
             _get_embedded_beamsplitter_matrix(operation, d, connector, dtype)
         ).T
 
-        U = U @ beamsplitter
+        U = connector.np.matmul(U, beamsplitter)
 
         operations.append(operation)
 

--- a/piquasso/fermionic/fock/simulator.py
+++ b/piquasso/fermionic/fock/simulator.py
@@ -25,7 +25,7 @@ from .simulation_steps import (
 )
 
 from piquasso._simulators.simulator import BuiltinSimulator
-from piquasso._simulators.connectors import NumpyConnector, JaxConnector
+from piquasso._simulators.connectors import NumpyConnector, JaxConnector, TorchConnector
 from piquasso.fermionic.instructions import ControlledPhase, IsingXX
 
 
@@ -73,4 +73,4 @@ class PureFockSimulator(BuiltinSimulator):
 
     _default_connector_class = NumpyConnector
 
-    _extra_builtin_connectors = [JaxConnector]
+    _extra_builtin_connectors = [JaxConnector, TorchConnector]

--- a/piquasso/fermionic/gaussian/simulator.py
+++ b/piquasso/fermionic/gaussian/simulator.py
@@ -29,7 +29,7 @@ from .simulation_steps import (
 from .state import GaussianState
 
 from piquasso._simulators.simulator import BuiltinSimulator
-from piquasso._simulators.connectors import NumpyConnector, JaxConnector
+from piquasso._simulators.connectors import NumpyConnector, JaxConnector, TorchConnector
 
 
 class GaussianSimulator(BuiltinSimulator):
@@ -80,4 +80,4 @@ class GaussianSimulator(BuiltinSimulator):
 
     _default_connector_class = NumpyConnector
 
-    _extra_builtin_connectors = [JaxConnector]
+    _extra_builtin_connectors = [JaxConnector, TorchConnector]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ Changelog = "https://github.com/Budapest-Quantum-Computing-Group/piquasso/blob/m
 [project.optional-dependencies]
 qiskit = ["qiskit"]
 tensorflow = ["tensorflow"]
+torch = ["torch"]
 jax = ["jax[cpu]"]
 matplotlib = ["matplotlib"]
 dask = ["dask"]

--- a/tests/_math/test_decompositions.py
+++ b/tests/_math/test_decompositions.py
@@ -13,32 +13,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import networkx as nx
+import numpy as np
 import pytest
-
 from pytest_lazy_fixtures import lf
 
-import numpy as np
-
-import networkx as nx
-
 import piquasso as pq
-
-from piquasso._math.linalg import is_unitary, is_diagonal
-from piquasso._math.symplectic import is_symplectic, xp_symplectic_form
 from piquasso._math.decompositions import (
     takagi,
     williamson,
 )
+from piquasso._math.linalg import is_diagonal, is_unitary
+from piquasso._math.symplectic import is_symplectic, xp_symplectic_form
+from piquasso._simulators.connectors import JaxConnector, NumpyConnector, TorchConnector
 
-from piquasso._simulators.connectors import (
-    NumpyConnector,
-    JaxConnector,
+for_all_connectors = pytest.mark.parametrize(
+    "connector", [NumpyConnector(), JaxConnector(), TorchConnector(), lf("tensorflow_connector")]
 )
 
 
-@pytest.mark.parametrize(
-    "connector", [NumpyConnector(), JaxConnector(), lf("tensorflow_connector")]
-)
+# TODO(TR): This had no "lf" in ("tensorflow_connector"). Is that a problem?
+@for_all_connectors
 def test_takagi_on_real_symmetric_2_by_2_matrix(connector):
     matrix = np.array(
         [
@@ -55,9 +50,7 @@ def test_takagi_on_real_symmetric_2_by_2_matrix(connector):
     assert np.allclose(matrix, unitary @ np.diag(singular_values) @ unitary.transpose())
 
 
-@pytest.mark.parametrize(
-    "connector", [NumpyConnector(), JaxConnector(), lf("tensorflow_connector")]
-)
+@for_all_connectors
 def test_takagi_on_complex_symmetric_2_by_2_matrix_with_multiplicities(connector):
     matrix = np.array(
         [
@@ -74,9 +67,8 @@ def test_takagi_on_complex_symmetric_2_by_2_matrix_with_multiplicities(connector
     assert np.allclose(matrix, unitary @ np.diag(singular_values) @ unitary.transpose())
 
 
-@pytest.mark.parametrize(
-    "connector", [NumpyConnector(), JaxConnector(), lf("tensorflow_connector")]
-)
+# TODO(TR): This had no "lf" in ("tensorflow_connector"). Is that a problem?
+@for_all_connectors
 def test_takagi_on_real_symmetric_3_by_3_matrix(connector):
     matrix = np.array(
         [
@@ -94,9 +86,8 @@ def test_takagi_on_real_symmetric_3_by_3_matrix(connector):
     assert np.allclose(matrix, unitary @ np.diag(singular_values) @ unitary.transpose())
 
 
-@pytest.mark.parametrize(
-    "connector", [NumpyConnector(), JaxConnector(), lf("tensorflow_connector")]
-)
+# TODO(TR): This had no "lf" in ("tensorflow_connector"). Is that a problem?
+@for_all_connectors
 def test_takagi_on_complex_symmetric_3_by_3_matrix(connector):
     matrix = np.array(
         [
@@ -114,9 +105,8 @@ def test_takagi_on_complex_symmetric_3_by_3_matrix(connector):
 
 
 @pytest.mark.monkey
-@pytest.mark.parametrize(
-    "connector", [NumpyConnector(), JaxConnector(), lf("tensorflow_connector")]
-)
+# TODO(TR): This had no "lf" in ("tensorflow_connector"). Is that a problem?
+@for_all_connectors
 def test_takagi_on_complex_symmetric_6_by_6_matrix_with_multiplicities(
     connector,
     generate_unitary_matrix,
@@ -133,20 +123,14 @@ def test_takagi_on_complex_symmetric_6_by_6_matrix_with_multiplicities(
     assert np.allclose(np.abs(calculated_singular_values), calculated_singular_values)
     assert np.allclose(
         matrix,
-        calculated_unitary
-        @ np.diag(calculated_singular_values)
-        @ calculated_unitary.transpose(),
+        calculated_unitary @ np.diag(calculated_singular_values) @ calculated_unitary.transpose(),
     )
 
 
 @pytest.mark.monkey
 @pytest.mark.parametrize("N", [2, 3, 4, 5, 6])
-@pytest.mark.parametrize(
-    "connector", [NumpyConnector(), JaxConnector(), lf("tensorflow_connector")]
-)
-def test_takagi_on_complex_symmetric_N_by_N_matrix(
-    N, connector, generate_complex_symmetric_matrix
-):
+@for_all_connectors
+def test_takagi_on_complex_symmetric_N_by_N_matrix(N, connector, generate_complex_symmetric_matrix):
     matrix = generate_complex_symmetric_matrix(N)
     singular_values, unitary = takagi(matrix, connector)
 
@@ -155,9 +139,7 @@ def test_takagi_on_complex_symmetric_N_by_N_matrix(
     assert np.allclose(matrix, unitary @ np.diag(singular_values) @ unitary.transpose())
 
 
-@pytest.mark.parametrize(
-    "connector", [NumpyConnector(), JaxConnector(), lf("tensorflow_connector")]
-)
+@for_all_connectors
 def test_takagi_on_adjacency_matrix_with_multiplicity(connector):
     adjacency_matrix = np.array(
         [
@@ -176,14 +158,10 @@ def test_takagi_on_adjacency_matrix_with_multiplicity(connector):
     singular_values, unitary = takagi(adjacency_matrix, connector)
     assert is_unitary(unitary)
     assert np.allclose(np.abs(singular_values), singular_values)
-    assert np.allclose(
-        adjacency_matrix, unitary @ np.diag(singular_values) @ unitary.transpose()
-    )
+    assert np.allclose(adjacency_matrix, unitary @ np.diag(singular_values) @ unitary.transpose())
 
 
-@pytest.mark.parametrize(
-    "connector", [NumpyConnector(), JaxConnector(), lf("tensorflow_connector")]
-)
+@for_all_connectors
 def test_takagi_on_random_adjacency_matrix_with_multiplicity(connector):
     graph = nx.erdos_renyi_graph(10, p=0.5)
 
@@ -192,9 +170,7 @@ def test_takagi_on_random_adjacency_matrix_with_multiplicity(connector):
     singular_values, unitary = takagi(adjacency_matrix, connector)
     assert is_unitary(unitary)
     assert np.allclose(np.abs(singular_values), singular_values)
-    assert np.allclose(
-        adjacency_matrix, unitary @ np.diag(singular_values) @ unitary.transpose()
-    )
+    assert np.allclose(adjacency_matrix, unitary @ np.diag(singular_values) @ unitary.transpose())
 
 
 @pytest.mark.parametrize("connector", [NumpyConnector(), JaxConnector()])
@@ -241,9 +217,7 @@ def test_williamson_with_squeezed_covariance_matrix(connector):
 
 @pytest.mark.monkey
 @pytest.mark.parametrize("connector", [NumpyConnector(), JaxConnector()])
-def test_williamson_with_random_positive_definite_matrix(
-    generate_random_positive_definite_matrix, connector
-):
+def test_williamson_with_random_positive_definite_matrix(generate_random_positive_definite_matrix, connector):
     dim = 4
     matrix = generate_random_positive_definite_matrix(dim)
 

--- a/tests/_math/test_decompositions.py
+++ b/tests/_math/test_decompositions.py
@@ -28,11 +28,12 @@ from piquasso._math.symplectic import is_symplectic, xp_symplectic_form
 from piquasso._simulators.connectors import JaxConnector, NumpyConnector, TorchConnector
 
 for_all_connectors = pytest.mark.parametrize(
-    "connector", [NumpyConnector(), JaxConnector(), TorchConnector(), lf("tensorflow_connector")]
+    "connector",
+    [NumpyConnector(), JaxConnector(), TorchConnector(), lf("tensorflow_connector")],
 )
 
 
-# TODO(TR): This had no "lf" in ("tensorflow_connector"). Is that a problem?
+# NOTE(TR): This had no "lf" in ("tensorflow_connector"). Is that a problem?
 @for_all_connectors
 def test_takagi_on_real_symmetric_2_by_2_matrix(connector):
     matrix = np.array(
@@ -42,12 +43,18 @@ def test_takagi_on_real_symmetric_2_by_2_matrix(connector):
         ],
         dtype=complex,
     )
+    # TorchConnector operates on `torch.Tensor`, so we need to parse.
+    matrix = connector.np.array(matrix)
 
     singular_values, unitary = takagi(matrix, connector)
 
     assert is_unitary(unitary)
-    assert np.allclose(np.abs(singular_values), singular_values)
-    assert np.allclose(matrix, unitary @ np.diag(singular_values) @ unitary.transpose())
+    assert np.allclose(connector.np.abs(singular_values), singular_values)
+    # NOTE: We need matmul instead of @, because torch.Tensors do not automatically promote types.
+    assert np.allclose(
+        matrix,
+        connector.np.matmul(unitary, connector.np.diag(singular_values)) @ unitary.T,
+    )
 
 
 @for_all_connectors
@@ -59,12 +66,18 @@ def test_takagi_on_complex_symmetric_2_by_2_matrix_with_multiplicities(connector
         ],
         dtype=complex,
     )
+    # TorchConnector operates on `torch.Tensor`, so we need to parse.
+    matrix = connector.np.array(matrix)
 
     singular_values, unitary = takagi(matrix, connector)
 
     assert is_unitary(unitary)
-    assert np.allclose(np.abs(singular_values), singular_values)
-    assert np.allclose(matrix, unitary @ np.diag(singular_values) @ unitary.transpose())
+    assert connector.np.allclose(connector.np.abs(singular_values), singular_values)
+    # NOTE: We need matmul instead of @, because torch.Tensors do not automatically promote types.
+    assert connector.np.allclose(
+        matrix,
+        connector.np.matmul(unitary, connector.np.diag(singular_values)) @ unitary.T,
+    )
 
 
 # TODO(TR): This had no "lf" in ("tensorflow_connector"). Is that a problem?
@@ -78,12 +91,16 @@ def test_takagi_on_real_symmetric_3_by_3_matrix(connector):
         ],
         dtype=complex,
     )
+    # TorchConnector operates on `torch.Tensor`, so we need to parse.
+    matrix = connector.np.array(matrix)
 
     singular_values, unitary = takagi(matrix, connector)
 
     assert is_unitary(unitary)
-    assert np.allclose(np.abs(singular_values), singular_values)
-    assert np.allclose(matrix, unitary @ np.diag(singular_values) @ unitary.transpose())
+    assert connector.np.allclose(connector.np.abs(singular_values), singular_values)
+    assert connector.np.allclose(
+        matrix, np.matmul(unitary, connector.np.diag(singular_values)) @ unitary.T
+    )
 
 
 # TODO(TR): This had no "lf" in ("tensorflow_connector"). Is that a problem?
@@ -96,12 +113,18 @@ def test_takagi_on_complex_symmetric_3_by_3_matrix(connector):
             [3j, 5j, 9],
         ],
     )
+    # TorchConnector operates on `torch.Tensor`, so we need to parse.
+    matrix = connector.np.array(matrix)
 
     singular_values, unitary = takagi(matrix, connector)
 
     assert is_unitary(unitary)
-    assert np.allclose(np.abs(singular_values), singular_values)
-    assert np.allclose(matrix, unitary @ np.diag(singular_values) @ unitary.transpose())
+    assert connector.np.allclose(connector.np.abs(singular_values), singular_values)
+    # NOTE: We need matmul instead of @, because torch.Tensors do not automatically promote types.
+    assert connector.np.allclose(
+        matrix,
+        connector.np.matmul(unitary, connector.np.diag(singular_values)) @ unitary.T,
+    )
 
 
 @pytest.mark.monkey
@@ -115,28 +138,46 @@ def test_takagi_on_complex_symmetric_6_by_6_matrix_with_multiplicities(
 
     unitary = generate_unitary_matrix(6)
 
-    matrix = unitary @ np.diag(singular_values) @ unitary.transpose()
+    # TorchConnector operates on `torch.Tensor`, so we need to parse.
+    unitary = connector.np.array(unitary)
+    singular_values = connector.np.array(singular_values)
+
+    matrix = (
+        connector.np.matmul(unitary, connector.np.diag(singular_values)) @ unitary.T
+    )
 
     calculated_singular_values, calculated_unitary = takagi(matrix, connector)
 
     assert is_unitary(calculated_unitary)
-    assert np.allclose(np.abs(calculated_singular_values), calculated_singular_values)
-    assert np.allclose(
+    assert connector.np.allclose(
+        connector.np.abs(calculated_singular_values), calculated_singular_values
+    )
+    assert connector.np.allclose(
         matrix,
-        calculated_unitary @ np.diag(calculated_singular_values) @ calculated_unitary.transpose(),
+        connector.np.matmul(
+            calculated_unitary, connector.np.diag(calculated_singular_values)
+        )
+        @ calculated_unitary.T,
     )
 
 
 @pytest.mark.monkey
 @pytest.mark.parametrize("N", [2, 3, 4, 5, 6])
 @for_all_connectors
-def test_takagi_on_complex_symmetric_N_by_N_matrix(N, connector, generate_complex_symmetric_matrix):
+def test_takagi_on_complex_symmetric_N_by_N_matrix(
+    N, connector, generate_complex_symmetric_matrix
+):
     matrix = generate_complex_symmetric_matrix(N)
+    # TorchConnector operates on `torch.Tensor`, so we need to parse.
+    matrix = connector.np.array(matrix)
     singular_values, unitary = takagi(matrix, connector)
 
     assert is_unitary(unitary)
-    assert np.allclose(np.abs(singular_values), singular_values)
-    assert np.allclose(matrix, unitary @ np.diag(singular_values) @ unitary.transpose())
+    assert connector.np.allclose(connector.np.abs(singular_values), singular_values)
+    assert connector.np.allclose(
+        matrix,
+        connector.np.matmul(unitary, connector.np.diag(singular_values)) @ unitary.T,
+    )
 
 
 @for_all_connectors
@@ -154,11 +195,16 @@ def test_takagi_on_adjacency_matrix_with_multiplicity(connector):
         ],
         dtype=complex,
     )
+    # TorchConnector operates on `torch.Tensor`, so we need to parse.
+    adjacency_matrix = connector.np.array(adjacency_matrix)
 
     singular_values, unitary = takagi(adjacency_matrix, connector)
     assert is_unitary(unitary)
-    assert np.allclose(np.abs(singular_values), singular_values)
-    assert np.allclose(adjacency_matrix, unitary @ np.diag(singular_values) @ unitary.transpose())
+    assert connector.np.allclose(np.abs(singular_values), singular_values)
+    assert connector.np.allclose(
+        adjacency_matrix,
+        connector.np.matmul(unitary, connector.np.diag(singular_values)) @ unitary.T,
+    )
 
 
 @for_all_connectors
@@ -166,11 +212,16 @@ def test_takagi_on_random_adjacency_matrix_with_multiplicity(connector):
     graph = nx.erdos_renyi_graph(10, p=0.5)
 
     adjacency_matrix = nx.adjacency_matrix(graph).todense().astype(complex)
+    # TorchConnector operates on `torch.Tensor`, so we need to parse.
+    adjacency_matrix = connector.np.array(adjacency_matrix)
 
     singular_values, unitary = takagi(adjacency_matrix, connector)
     assert is_unitary(unitary)
-    assert np.allclose(np.abs(singular_values), singular_values)
-    assert np.allclose(adjacency_matrix, unitary @ np.diag(singular_values) @ unitary.transpose())
+    assert connector.np.allclose(connector.np.abs(singular_values), singular_values)
+    assert connector.np.allclose(
+        adjacency_matrix,
+        connector.np.matmul(unitary, connector.np.diag(singular_values)) @ unitary.T,
+    )
 
 
 @pytest.mark.parametrize("connector", [NumpyConnector(), JaxConnector()])
@@ -217,7 +268,9 @@ def test_williamson_with_squeezed_covariance_matrix(connector):
 
 @pytest.mark.monkey
 @pytest.mark.parametrize("connector", [NumpyConnector(), JaxConnector()])
-def test_williamson_with_random_positive_definite_matrix(generate_random_positive_definite_matrix, connector):
+def test_williamson_with_random_positive_definite_matrix(
+    generate_random_positive_definite_matrix, connector
+):
     dim = 4
     matrix = generate_random_positive_definite_matrix(dim)
 

--- a/tests/_math/test_decompositions.py
+++ b/tests/_math/test_decompositions.py
@@ -33,7 +33,6 @@ for_all_connectors = pytest.mark.parametrize(
 )
 
 
-# NOTE(TR): This had no "lf" in ("tensorflow_connector"). Is that a problem?
 @for_all_connectors
 def test_takagi_on_real_symmetric_2_by_2_matrix(connector):
     matrix = np.array(
@@ -82,7 +81,6 @@ def test_takagi_on_complex_symmetric_2_by_2_matrix_with_multiplicities(connector
     )
 
 
-# TODO(TR): This had no "lf" in ("tensorflow_connector"). Is that a problem?
 @for_all_connectors
 def test_takagi_on_real_symmetric_3_by_3_matrix(connector):
     matrix = np.array(
@@ -105,7 +103,6 @@ def test_takagi_on_real_symmetric_3_by_3_matrix(connector):
     )
 
 
-# TODO(TR): This had no "lf" in ("tensorflow_connector"). Is that a problem?
 @for_all_connectors
 def test_takagi_on_complex_symmetric_3_by_3_matrix(connector):
     matrix = np.array(
@@ -131,7 +128,6 @@ def test_takagi_on_complex_symmetric_3_by_3_matrix(connector):
 
 
 @pytest.mark.monkey
-# TODO(TR): This had no "lf" in ("tensorflow_connector"). Is that a problem?
 @for_all_connectors
 def test_takagi_on_complex_symmetric_6_by_6_matrix_with_multiplicities(
     connector,

--- a/tests/_math/test_decompositions.py
+++ b/tests/_math/test_decompositions.py
@@ -50,7 +50,8 @@ def test_takagi_on_real_symmetric_2_by_2_matrix(connector):
 
     assert is_unitary(unitary)
     assert np.allclose(connector.np.abs(singular_values), singular_values)
-    # NOTE: We need matmul instead of @, because torch.Tensors do not automatically promote types.
+    # NOTE: We need matmul instead of @,
+    # because torch.Tensors do not automatically promote types.
     assert np.allclose(
         matrix,
         connector.np.matmul(unitary, connector.np.diag(singular_values)) @ unitary.T,
@@ -73,7 +74,8 @@ def test_takagi_on_complex_symmetric_2_by_2_matrix_with_multiplicities(connector
 
     assert is_unitary(unitary)
     assert connector.np.allclose(connector.np.abs(singular_values), singular_values)
-    # NOTE: We need matmul instead of @, because torch.Tensors do not automatically promote types.
+    # NOTE: We need matmul instead of @,
+    # because torch.Tensors do not automatically promote types.
     assert connector.np.allclose(
         matrix,
         connector.np.matmul(unitary, connector.np.diag(singular_values)) @ unitary.T,
@@ -120,7 +122,8 @@ def test_takagi_on_complex_symmetric_3_by_3_matrix(connector):
 
     assert is_unitary(unitary)
     assert connector.np.allclose(connector.np.abs(singular_values), singular_values)
-    # NOTE: We need matmul instead of @, because torch.Tensors do not automatically promote types.
+    # NOTE: We need matmul instead of @,
+    # because torch.Tensors do not automatically promote types.
     assert connector.np.allclose(
         matrix,
         connector.np.matmul(unitary, connector.np.diag(singular_values)) @ unitary.T,

--- a/tests/decompositions/test_clements.py
+++ b/tests/decompositions/test_clements.py
@@ -93,7 +93,9 @@ def test_clements_decomposition_using_piquasso_PureFockSimulator(dummy_unitary):
         for operation in decomposition.phaseshifters:
             pq.Q(operation.mode) | pq.Phaseshifter(operation.phi)
 
-    simulator = pq.PureFockSimulator(d=d, config=pq.Config(cutoff=sum(occupation_numbers) + 1))
+    simulator = pq.PureFockSimulator(
+        d=d, config=pq.Config(cutoff=sum(occupation_numbers) + 1)
+    )
 
     state_with_interferometer = simulator.execute(program_with_interferometer).state
     state_with_decomposition = simulator.execute(program_with_decomposition).state
@@ -180,7 +182,9 @@ def test_instructions_from_decomposition_using_piquasso_GaussianSimulator(
         pq.Q() | pq.Interferometer(matrix=U)
 
     program_with_decomposition = pq.Program(
-        instructions=[pq.Squeezing(r).on_modes(mode) for mode, r in enumerate(squeezings)]
+        instructions=[
+            pq.Squeezing(r).on_modes(mode) for mode, r in enumerate(squeezings)
+        ]
         + instructions_from_decomposition(decomposition)
     )
 
@@ -212,7 +216,9 @@ def test_instructions_from_decomposition_using_piquasso_GaussianSimulator_with_c
         for mode, r in enumerate(squeezings):
             pq.Q(mode) | pq.Squeezing(r)
 
-        program_with_decomposition.instructions.extend(instructions_from_decomposition(decomposition))
+        program_with_decomposition.instructions.extend(
+            instructions_from_decomposition(decomposition)
+        )
 
     simulator = pq.GaussianSimulator(d=d)
 
@@ -239,7 +245,9 @@ def test_instructions_from_decomposition_using_piquasso_GaussianSimulator_random
 
     with pq.Program() as program_with_decomposition:
         pq.Q() | gaussian_transform
-        program_with_decomposition.instructions.extend(instructions_from_decomposition(decomposition))
+        program_with_decomposition.instructions.extend(
+            instructions_from_decomposition(decomposition)
+        )
 
     simulator = pq.GaussianSimulator(d=d)
 
@@ -250,7 +258,13 @@ def test_instructions_from_decomposition_using_piquasso_GaussianSimulator_random
 
 
 @pytest.mark.parametrize(
-    "connector", (pq.NumpyConnector(), lf("tensorflow_connector"), pq.JaxConnector(), pq.TorchConnector())
+    "connector",
+    (
+        pq.NumpyConnector(),
+        lf("tensorflow_connector"),
+        pq.JaxConnector(),
+        pq.TorchConnector(),
+    ),
 )
 def test_clements_decomposition_roundtrip(connector, dummy_unitary):
     d = 5
@@ -264,7 +278,13 @@ def test_clements_decomposition_roundtrip(connector, dummy_unitary):
 
 
 @pytest.mark.parametrize(
-    "connector", (pq.NumpyConnector(), lf("tensorflow_connector"), pq.JaxConnector(), pq.TorchConnector())
+    "connector",
+    (
+        pq.NumpyConnector(),
+        lf("tensorflow_connector"),
+        pq.JaxConnector(),
+        pq.TorchConnector(),
+    ),
 )
 def test_clements_decomposition_roundtrip_with_weights(connector, dummy_unitary):
     d = 6
@@ -284,7 +304,13 @@ def test_clements_decomposition_roundtrip_with_weights(connector, dummy_unitary)
 
 
 @pytest.mark.parametrize(
-    "connector", (pq.NumpyConnector(), lf("tensorflow_connector"), pq.JaxConnector(), pq.TorchConnector())
+    "connector",
+    (
+        pq.NumpyConnector(),
+        lf("tensorflow_connector"),
+        pq.JaxConnector(),
+        pq.TorchConnector(),
+    ),
 )
 def test_weigths_to_interferometer_roundtrip(connector, dummy_unitary):
     d = 6
@@ -360,14 +386,18 @@ def test_clements_decomposition_with_JaxConnector(dummy_unitary):
     )
 
 
-def test_clements_decomposition_with_TensorflowConnector_from_weights(dummy_unitary, tf):
+def test_clements_decomposition_with_TensorflowConnector_from_weights(
+    dummy_unitary, tf
+):
     d = 2
     U = dummy_unitary(d)
 
     weights = tf.Variable(get_weights_from_interferometer(U, pq.NumpyConnector()))
 
     with tf.GradientTape() as tape:
-        decomposition = get_decomposition_from_weights(weights, d=d, connector=pq.TensorflowConnector())
+        decomposition = get_decomposition_from_weights(
+            weights, d=d, connector=pq.TensorflowConnector()
+        )
 
     assert len(decomposition.beamsplitters) == 1
     assert len(decomposition.phaseshifters) == 2
@@ -390,7 +420,9 @@ def test_clements_decomposition_with_JaxConnector_from_weights(dummy_unitary):
     connector = pq.JaxConnector()
 
     def get_first_beamsplitter_theta(weights):
-        decomposition = get_decomposition_from_weights(weights, d=d, connector=connector)
+        decomposition = get_decomposition_from_weights(
+            weights, d=d, connector=connector
+        )
 
         first_beamsplitter_theta = decomposition.beamsplitters[0].params[0]
 

--- a/tests/decompositions/test_clements.py
+++ b/tests/decompositions/test_clements.py
@@ -13,27 +13,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
-
-from pytest_lazy_fixtures import lf
-
 import numpy as np
+import pytest
+from jax import grad
+from pytest_lazy_fixtures import lf
 from scipy.stats import unitary_group
 
 import piquasso as pq
-
-from jax import grad
-
+from piquasso._simulators.connectors.torch_ import TorchConnector
 from piquasso.decompositions.clements import (
     clements,
-    inverse_clements,
-    get_weights_from_decomposition,
     get_decomposition_from_weights,
-    get_weights_from_interferometer,
     get_interferometer_from_weights,
+    get_weights_from_decomposition,
+    get_weights_from_interferometer,
     instructions_from_decomposition,
+    inverse_clements,
 )
-
 
 pytestmark = pytest.mark.monkey
 
@@ -98,9 +94,7 @@ def test_clements_decomposition_using_piquasso_PureFockSimulator(dummy_unitary):
         for operation in decomposition.phaseshifters:
             pq.Q(operation.mode) | pq.Phaseshifter(operation.phi)
 
-    simulator = pq.PureFockSimulator(
-        d=d, config=pq.Config(cutoff=sum(occupation_numbers) + 1)
-    )
+    simulator = pq.PureFockSimulator(d=d, config=pq.Config(cutoff=sum(occupation_numbers) + 1))
 
     state_with_interferometer = simulator.execute(program_with_interferometer).state
     state_with_decomposition = simulator.execute(program_with_decomposition).state
@@ -187,9 +181,7 @@ def test_instructions_from_decomposition_using_piquasso_GaussianSimulator(
         pq.Q() | pq.Interferometer(matrix=U)
 
     program_with_decomposition = pq.Program(
-        instructions=[
-            pq.Squeezing(r).on_modes(mode) for mode, r in enumerate(squeezings)
-        ]
+        instructions=[pq.Squeezing(r).on_modes(mode) for mode, r in enumerate(squeezings)]
         + instructions_from_decomposition(decomposition)
     )
 
@@ -221,9 +213,7 @@ def test_instructions_from_decomposition_using_piquasso_GaussianSimulator_with_c
         for mode, r in enumerate(squeezings):
             pq.Q(mode) | pq.Squeezing(r)
 
-        program_with_decomposition.instructions.extend(
-            instructions_from_decomposition(decomposition)
-        )
+        program_with_decomposition.instructions.extend(instructions_from_decomposition(decomposition))
 
     simulator = pq.GaussianSimulator(d=d)
 
@@ -250,9 +240,7 @@ def test_instructions_from_decomposition_using_piquasso_GaussianSimulator_random
 
     with pq.Program() as program_with_decomposition:
         pq.Q() | gaussian_transform
-        program_with_decomposition.instructions.extend(
-            instructions_from_decomposition(decomposition)
-        )
+        program_with_decomposition.instructions.extend(instructions_from_decomposition(decomposition))
 
     simulator = pq.GaussianSimulator(d=d)
 
@@ -263,11 +251,11 @@ def test_instructions_from_decomposition_using_piquasso_GaussianSimulator_random
 
 
 @pytest.mark.parametrize(
-    "connector", (pq.NumpyConnector(), lf("tensorflow_connector"), pq.JaxConnector())
+    "connector", (pq.NumpyConnector(), lf("tensorflow_connector"), pq.JaxConnector(), pq.TorchConnector())
 )
 def test_clements_decomposition_roundtrip(connector, dummy_unitary):
     d = 5
-    U = dummy_unitary(d)
+    U = connector.np.array(dummy_unitary(d))
 
     decomposition = clements(U, connector)
 
@@ -277,11 +265,11 @@ def test_clements_decomposition_roundtrip(connector, dummy_unitary):
 
 
 @pytest.mark.parametrize(
-    "connector", (pq.NumpyConnector(), lf("tensorflow_connector"), pq.JaxConnector())
+    "connector", (pq.NumpyConnector(), lf("tensorflow_connector"), pq.JaxConnector(), pq.TorchConnector())
 )
 def test_clements_decomposition_roundtrip_with_weights(connector, dummy_unitary):
     d = 6
-    U = dummy_unitary(d)
+    U = connector.np.array(dummy_unitary(d))
 
     decomposition = clements(U, connector)
 
@@ -297,7 +285,7 @@ def test_clements_decomposition_roundtrip_with_weights(connector, dummy_unitary)
 
 
 @pytest.mark.parametrize(
-    "connector", (pq.NumpyConnector(), lf("tensorflow_connector"), pq.JaxConnector())
+    "connector", (pq.NumpyConnector(), lf("tensorflow_connector"), pq.JaxConnector(), pq.TorchConnector())
 )
 def test_weigths_to_interferometer_roundtrip(connector, dummy_unitary):
     d = 6
@@ -373,18 +361,14 @@ def test_clements_decomposition_with_JaxConnector(dummy_unitary):
     )
 
 
-def test_clements_decomposition_with_TensorflowConnector_from_weights(
-    dummy_unitary, tf
-):
+def test_clements_decomposition_with_TensorflowConnector_from_weights(dummy_unitary, tf):
     d = 2
     U = dummy_unitary(d)
 
     weights = tf.Variable(get_weights_from_interferometer(U, pq.NumpyConnector()))
 
     with tf.GradientTape() as tape:
-        decomposition = get_decomposition_from_weights(
-            weights, d=d, connector=pq.TensorflowConnector()
-        )
+        decomposition = get_decomposition_from_weights(weights, d=d, connector=pq.TensorflowConnector())
 
     assert len(decomposition.beamsplitters) == 1
     assert len(decomposition.phaseshifters) == 2
@@ -407,9 +391,7 @@ def test_clements_decomposition_with_JaxConnector_from_weights(dummy_unitary):
     connector = pq.JaxConnector()
 
     def get_first_beamsplitter_theta(weights):
-        decomposition = get_decomposition_from_weights(
-            weights, d=d, connector=connector
-        )
+        decomposition = get_decomposition_from_weights(weights, d=d, connector=connector)
 
         first_beamsplitter_theta = decomposition.beamsplitters[0].params[0]
 

--- a/tests/decompositions/test_clements.py
+++ b/tests/decompositions/test_clements.py
@@ -20,7 +20,6 @@ from pytest_lazy_fixtures import lf
 from scipy.stats import unitary_group
 
 import piquasso as pq
-from piquasso._simulators.connectors.torch_ import TorchConnector
 from piquasso.decompositions.clements import (
     clements,
     get_decomposition_from_weights,

--- a/tests/fermionic/fock/test_gates.py
+++ b/tests/fermionic/fock/test_gates.py
@@ -22,7 +22,7 @@ import numpy as np
 import pytest
 
 for_all_connectors = pytest.mark.parametrize(
-    "connector", [pq.NumpyConnector(), pq.JaxConnector()]
+    "connector", [pq.NumpyConnector(), pq.JaxConnector(), pq.TorchConnector()]
 )
 
 

--- a/tests/fermionic/fock/test_gates.py
+++ b/tests/fermionic/fock/test_gates.py
@@ -149,7 +149,7 @@ def test_Interferometer_subsystem_equivalence(connector, generate_unitary_matrix
 def test_Interferometer_nonconsecutive_ordering_raises_InvalidParameter(connector):
     d = 3
 
-    self_adjoint = np.array(
+    self_adjoint = connector.np.array(
         [
             [1, 2j, 3 + 4j],
             [-2j, 2, 5],

--- a/tests/fermionic/fock/test_preparations.py
+++ b/tests/fermionic/fock/test_preparations.py
@@ -19,7 +19,7 @@ import numpy as np
 import piquasso as pq
 
 for_all_connectors = pytest.mark.parametrize(
-    "connector", [pq.NumpyConnector(), pq.JaxConnector()]
+    "connector", [pq.NumpyConnector(), pq.JaxConnector(), pq.TorchConnector()]
 )
 
 

--- a/tests/fermionic/fock/test_state.py
+++ b/tests/fermionic/fock/test_state.py
@@ -20,7 +20,7 @@ import numpy as np
 import piquasso as pq
 
 for_all_connectors = pytest.mark.parametrize(
-    "connector", [pq.NumpyConnector(), pq.JaxConnector()]
+    "connector", [pq.NumpyConnector(), pq.JaxConnector(), pq.TorchConnector()]
 )
 
 

--- a/tests/fermionic/gaussian/test_gates.py
+++ b/tests/fermionic/gaussian/test_gates.py
@@ -25,7 +25,7 @@ from piquasso.decompositions.clements import clements, instructions_from_decompo
 
 
 for_all_connectors = pytest.mark.parametrize(
-    "connector", [pq.NumpyConnector(), pq.JaxConnector()]
+    "connector", [pq.NumpyConnector(), pq.JaxConnector(), pq.TorchConnector()]
 )
 
 

--- a/tests/fermionic/gaussian/test_preparations.py
+++ b/tests/fermionic/gaussian/test_preparations.py
@@ -21,7 +21,7 @@ from piquasso.api.exceptions import InvalidParameter
 
 
 for_all_connectors = pytest.mark.parametrize(
-    "connector", [pq.NumpyConnector(), pq.JaxConnector()]
+    "connector", [pq.NumpyConnector(), pq.JaxConnector(), pq.TorchConnector()]
 )
 
 

--- a/tests/fermionic/gaussian/test_state.py
+++ b/tests/fermionic/gaussian/test_state.py
@@ -36,7 +36,7 @@ from piquasso.fermionic._utils import (
 
 
 for_all_connectors = pytest.mark.parametrize(
-    "connector", [pq.NumpyConnector(), pq.JaxConnector()]
+    "connector", [pq.NumpyConnector(), pq.JaxConnector(), pq.TorchConnector()]
 )
 
 

--- a/tests/fermionic/test_simulator_equivalence.py
+++ b/tests/fermionic/test_simulator_equivalence.py
@@ -22,7 +22,7 @@ import piquasso as pq
 from piquasso.fermionic._utils import binary_to_fock_indices
 
 for_all_connectors = pytest.mark.parametrize(
-    "connector", [pq.NumpyConnector(), pq.JaxConnector()]
+    "connector", [pq.NumpyConnector(), pq.JaxConnector(), pq.TorchConnector()]
 )
 
 


### PR DESCRIPTION
The implementation of basic TorchConnector. Passes all the tests that the `TensorflowConnector` passes.

Some of the tests and Takagi decomposition was adjusted, so that it uses more `connector.np` functions instead of e.g. in-place matrix multiplication. This allows us to avoid some of the `torch.Tensor` induced issues.