### PR TITLE
feat(_simulators): `simulate` function

### DIFF
--- a/piquasso/__init__.py
+++ b/piquasso/__init__.py
@@ -54,6 +54,8 @@ from piquasso._simulators.connectors import (
     JaxConnector,
 )
 
+from piquasso._simulators._simulate import simulate
+
 from .instructions.preparations import (
     Vacuum,
     Mean,
@@ -129,6 +131,7 @@ __all__ = [
     "SamplingSimulator",
     "FockSimulator",
     "PureFockSimulator",
+    "simulate",
     # Connectors
     "NumpyConnector",
     "TensorflowConnector",

--- a/piquasso/_simulators/_simulate.py
+++ b/piquasso/_simulators/_simulate.py
@@ -1,0 +1,115 @@
+#
+# Copyright 2021-2026 Budapest Quantum Computing Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Optional, Union
+
+from .gaussian import GaussianSimulator
+from .fock import FockSimulator, PureFockSimulator
+from .sampling import SamplingSimulator
+
+from ..api.exceptions import NotImplementedCalculation
+from ..api.connector import BaseConnector
+from ..api.program import Program
+from ..api.config import Config
+from ..api.result import Result
+
+
+def _resolve_simulator_class(program, connector):
+    simulator_classes = (
+        GaussianSimulator,
+        SamplingSimulator,
+        PureFockSimulator,
+        FockSimulator,
+    )  # NOTE: Order matters, as the first compatible simulator is selected.
+
+    possible_simulator_classes = []
+
+    for simulator_class in simulator_classes:
+        supported_instruction_classes = set(simulator_class._instruction_map.keys())
+
+        if all(
+            instruction.__class__ in supported_instruction_classes
+            for instruction in program.instructions
+        ):
+            possible_simulator_classes.append(simulator_class)
+
+    if not possible_simulator_classes:
+        raise NotImplementedCalculation(
+            "The program cannot be simulated by any of the built-in simulators in "
+            "Piquasso. Please verify that the program's instructions are supported by "
+            "at least one built-in simulator. For requests to implement a new "
+            "simulation pathway, please open an issue on the Piquasso GitHub "
+            "repository: "
+            "https://github.com/Budapest-Quantum-Computing-Group/piquasso/issues"
+        )
+
+    if connector is None:
+        return possible_simulator_classes[0]
+
+    for simulator_class in possible_simulator_classes:
+        if isinstance(connector, simulator_class._supported_connector_classes()):
+            return simulator_class
+
+    possible_connectors = {
+        connector_class
+        for simulator_class in possible_simulator_classes
+        for connector_class in simulator_class._supported_connector_classes()
+    }
+
+    possible_connector_names = ", ".join(
+        sorted(connector_class.__name__ for connector_class in possible_connectors)
+    )
+
+    connector_name = type(connector).__name__
+
+    raise NotImplementedCalculation(
+        f"The specified program cannot be simulated by the connector "
+        f"'{connector_name}'. Please consider using another connector from "
+        f"'{possible_connector_names}', or open an issue on the Piquasso GitHub "
+        "repository: "
+        "https://github.com/Budapest-Quantum-Computing-Group/piquasso/issues"
+    )
+
+
+def simulate(
+    program: Program,
+    number_of_modes: Optional[int] = None,
+    *,
+    connector: Optional[BaseConnector] = None,
+    config: Optional[Config] = None,
+    shots: Union[int, None] = 1,
+) -> Result:
+    """Performs a simulation according to the prescribed program.
+
+    Args:
+        program (Program): The quantum program to simulate.
+        number_of_modes (Optional[int]): The number of modes in the simulation.
+            If ``None``, the simulator determines the number of modes from the
+            program where supported.
+        connector (BaseConnector): The connector to use for the simulation.
+        config (Config): The configuration to use for the simulation.
+        shots (Union[int, None]): The number of shots to simulate. If ``None``,
+            the simulation is executed using the exact probability distribution
+            instead of finite-shot sampling.
+
+    Returns:
+        Result: The result of the simulation.
+    """
+
+    simulator_class = _resolve_simulator_class(program, connector)
+
+    simulator = simulator_class(d=number_of_modes, connector=connector, config=config)
+
+    return simulator.execute(program, shots=shots)

--- a/piquasso/_simulators/simulator.py
+++ b/piquasso/_simulators/simulator.py
@@ -38,17 +38,18 @@ class BuiltinSimulator(Simulator):
 
         super().__init__(d=d, config=config, connector=connector)
 
-    def _validate_connector(self, connector):
-        if (
-            isinstance(connector, BuiltinConnector)
-            and not isinstance(connector, self._default_connector_class)
-            and not any(
-                [isinstance(connector, cls) for cls in self._extra_builtin_connectors]
-            )
+    @classmethod
+    def _validate_connector(cls, connector):
+        if isinstance(connector, BuiltinConnector) and not isinstance(
+            connector, cls._supported_connector_classes()
         ):
             raise InvalidSimulation(
                 f"The connector '{connector}' is not supported."
                 f"Supported connectors:"
                 "\n"
-                f"{[self._default_connector_class] + self._extra_builtin_connectors}"
+                f"{cls._supported_connector_classes()}"
             )
+
+    @classmethod
+    def _supported_connector_classes(cls):
+        return tuple([cls._default_connector_class] + cls._extra_builtin_connectors)

--- a/piquasso/api/exceptions.py
+++ b/piquasso/api/exceptions.py
@@ -43,7 +43,7 @@ class InvalidSimulation(PiquassoException):
 
 
 class NotImplementedCalculation(PiquassoException):
-    """Raiesed when a calculation is not implemented."""
+    """Raised when a calculation is not implemented."""
 
 
 class CVQNNException(PiquassoException):

--- a/tests/_simulators/test_simulate.py
+++ b/tests/_simulators/test_simulate.py
@@ -1,0 +1,126 @@
+#
+# Copyright 2021-2026 Budapest Quantum Computing Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+import numpy as np
+import piquasso as pq
+
+
+def test_simulate_Gaussian_instructions():
+    with pq.Program() as program:
+        pq.Q() | pq.Vacuum()
+
+        pq.Q(0) | pq.Displacement(r=0.2, phi=np.pi / 4)
+
+    result = pq.simulate(program)
+
+    assert type(result) is pq.api.result.Result
+
+    assert type(result.state) is pq.GaussianState, (
+        "The state should be a GaussianState, as the program only contains "
+        "instructions compatible with Gaussian states."
+    )
+
+
+def test_simulate_passive_linear_gates():
+    with pq.Program() as program:
+        pq.Q() | pq.StateVector([1, 1, 0])
+
+        pq.Q(0, 1) | pq.Beamsplitter5050()
+        pq.Q(0) | pq.Phaseshifter(np.pi / 3)
+        pq.Q(1, 2) | pq.Beamsplitter5050()
+
+    result = pq.simulate(program, connector=pq.JaxConnector())
+
+    assert type(result.state) is pq.SamplingState, (
+        "The state should be a SamplingState, as it only uses passive linear optical "
+        "gates."
+    )
+
+
+def test_simulate_nonlinear_gates():
+    with pq.Program() as program:
+        pq.Q() | pq.StateVector([1, 1, 0])
+
+        pq.Q(0, 1) | pq.Beamsplitter5050()
+        pq.Q(0) | pq.Kerr(np.pi / 4)
+        pq.Q(1, 2) | pq.Beamsplitter5050()
+
+    result = pq.simulate(program, config=pq.Config(cutoff=9))
+
+    assert (
+        type(result.state) is pq.PureFockState
+    ), "The state should be a PureFockState, as it uses nonlinear gates."
+
+
+def test_simulate_nonlinear_gates_and_channels():
+    with pq.Program() as program:
+        pq.Q() | pq.StateVector([1, 1, 0])
+
+        pq.Q(0, 1) | pq.Beamsplitter5050()
+        pq.Q(0) | pq.Kerr(np.pi / 4)
+        pq.Q(1, 2) | pq.Beamsplitter5050()
+
+        pq.Q(0) | pq.Attenuator(theta=0.1)
+
+    result = pq.simulate(program, number_of_modes=3)
+
+    assert (
+        type(result.state) is pq.FockState
+    ), "The state should be a FockState, as it uses nonlinear gates and channels."
+
+
+def test_simulate_raises_NotImplementedCalculation_when_the_instruction_combination_is_not_supported():  # noqa: E501
+    with pq.Program() as program:
+        pq.Q() | pq.StateVector([1, 1, 0])
+
+        pq.Q(0, 1) | pq.Beamsplitter5050()
+        pq.Q(0) | pq.Kerr(np.pi / 4)
+        pq.Q(1, 2) | pq.Beamsplitter5050()
+
+        pq.Q(0) | pq.DeterministicGaussianChannel(X=np.eye(3), Y=np.eye(3))
+
+    with pytest.raises(pq.api.exceptions.NotImplementedCalculation) as exc:
+        pq.simulate(program)
+
+    assert exc.value.args[0] == (
+        "The program cannot be simulated by any of the built-in simulators in "
+        "Piquasso. Please verify that the program's instructions are supported by at "
+        "least one built-in simulator. For requests to implement a new simulation "
+        "pathway, please open an issue on the Piquasso GitHub repository: "
+        "https://github.com/Budapest-Quantum-Computing-Group/piquasso/issues"
+    )
+
+
+def test_simulate_raises_NotImplementedCalculation_when_connector_is_not_supported():
+    with pq.Program() as program:
+        pq.Q() | pq.StateVector([1, 1, 0])
+
+        pq.Q(0, 1) | pq.Beamsplitter5050()
+        pq.Q(1, 2) | pq.Beamsplitter5050()
+
+    not_even_a_connector = object()
+
+    with pytest.raises(pq.api.exceptions.NotImplementedCalculation) as exc:
+        pq.simulate(program, connector=not_even_a_connector)
+
+    assert exc.value.args[0] == (
+        "The specified program cannot be simulated by the connector "
+        "'object'. Please consider using another connector from "
+        "'JaxConnector, NumpyConnector, TensorflowConnector', or open an issue on the "
+        "Piquasso GitHub repository: "
+        "https://github.com/Budapest-Quantum-Computing-Group/piquasso/issues"
+    )


### PR DESCRIPTION
When users start to use Piquasso, they usually encounter the problem of choosing the correct simulator for their computations, which might be difficult to make.

To lighten this burden on the users, a lightweight `simulate` function is written, which is made available as `pq.simulate`. This function automatically chooses the simulator (`GaussianSimulator`, `SamplingSimulator`, `PureFockSimulator` or `FockSimulator`) and executes the instructions, returning with the simulation result.

Resolves #573