### PR TITLE
Fix: `loop_hafnian` test occupation number precision (Windows)

### DIFF
--- a/tests/_math/test_hafnian.py
+++ b/tests/_math/test_hafnian.py
@@ -660,7 +660,7 @@ def test_loop_hafnian_with_reduction_batch_random():
         A = A + A.T
         diagonal = np.random.rand(d) + 1j * np.random.rand(d)
 
-        occupation_numbers = np.random.randint(0, max_photons, d)
+        occupation_numbers = np.random.randint(0, max_photons, d, dtype=np.int64)
         occupation_numbers[-1] = 0
 
         cutoff = np.random.randint(1, 12)


### PR DESCRIPTION
**Context**

On Windows, NumPy may default to a 32-bit int which is incompatible with the int64 signature of loop_hafnian_with_reduction_batch, making the test `tests/_math/test_hafnian.py::test_loop_hafnian_with_reduction_batch_random` raise:

````py

self = CPUDispatcher(<function loop_hafnian_with_reduction_batch at 0x000001DE553E8040>)
args = [Array(complex128, 2, 'C', False, aligned=True), Array(complex128, 1, 'C', False, aligned=True), Array(int32, 1, 'C', False, aligned=True), int64], kws = {}
msg = 'No matching definition for argument type(s) array(complex128, 2d, C), array(complex128, 1d, C), array(int32, 1d, C), int64'

    def _explain_matching_error(self, *args, **kws):
        """
        Callback for the C _Dispatcher object.
        """
        assert not kws, "kwargs not handled"
        args = [self.typeof_pyval(a) for a in args]
        msg = ("No matching definition for argument type(s) %s"
               % ', '.join(map(str, args)))
>       raise TypeError(msg)
E       TypeError: No matching definition for argument type(s) array(complex128, 2d, C), array(complex128, 1d, C), array(int32, 1d, C), int64

..\..\Anaconda3\envs\py12\Lib\site-packages\numba\core\dispatcher.py:659: TypeError
=========================================================================================== short test summary info ============================================================================================
FAILED tests/_math/test_hafnian.py::test_loop_hafnian_with_reduction_batch_random - TypeError: No matching definition for argument type(s) array(complex128, 2d, C), array(complex128, 1d, C), array(int32, 1d, C), int64
````

**Solution**

Cast the occupation number (3rd argument) to a double-precision integer.