### PR TITLE
Validate cutoff for fock preparations

### DIFF
--- a/piquasso/_simulators/fock/general/simulation_steps.py
+++ b/piquasso/_simulators/fock/general/simulation_steps.py
@@ -27,6 +27,8 @@ from piquasso.api.instruction import Instruction
 from piquasso.api.branch import Branch
 from piquasso.api.exceptions import InvalidParameter
 
+from piquasso._math.validations import validate_occupation_numbers
+
 from piquasso._utils import sample_from_probability_map
 
 from piquasso._math.indices import get_index_in_fock_space
@@ -453,6 +455,20 @@ def _add_occupation_number_basis(
     bra: Tuple[int, ...],
     coefficient: complex,
 ) -> None:
+    if state._config.validate:
+        validate_occupation_numbers(
+            ket,
+            state.d,
+            state._config.cutoff,
+            context=": DensityMatrix ket",
+        )
+        validate_occupation_numbers(
+            bra,
+            state.d,
+            state._config.cutoff,
+            context=": DensityMatrix bra",
+        )
+
     index = get_index_in_fock_space(ket)
     dual_index = get_index_in_fock_space(bra)
 

--- a/piquasso/_simulators/sampling/simulation_steps.py
+++ b/piquasso/_simulators/sampling/simulation_steps.py
@@ -28,6 +28,8 @@ from piquasso.api.exceptions import InvalidState, NotImplementedCalculation
 from piquasso.api.branch import Branch
 from piquasso.api.instruction import Instruction
 
+from piquasso._math.validations import validate_occupation_numbers
+
 from piquasso._simulators.fock.pure.simulation_steps import (
     imperfect_post_select_photons as pure_fock_imperfect_post_select_photons,
 )
@@ -64,10 +66,12 @@ def state_vector(
         occupation_numbers = instruction._get_all_params(state._connector)[
             "occupation_numbers"
         ]
-        if state._config.validate and len(occupation_numbers) != state.d:
-            raise InvalidState(
-                f"The occupation numbers '{occupation_numbers}' are not well-defined "
-                f"on '{state.d}' modes: instruction={instruction}"
+        if state._config.validate:
+            validate_occupation_numbers(
+                occupation_numbers,
+                state.d,
+                state._config.cutoff,
+                context=f": instruction={instruction}",
             )
 
         state._occupation_numbers.append(np.rint(occupation_numbers).astype(int))
@@ -78,11 +82,12 @@ def state_vector(
             state._connector
         )["fock_amplitude_map"].items():
 
-            if state._config.validate and len(occupation_numbers) != state.d:
-                raise InvalidState(
-                    f"The occupation numbers '{occupation_numbers}' "
-                    f"are not well-defined "
-                    f"on '{state.d}' modes: instruction={instruction}"
+            if state._config.validate:
+                validate_occupation_numbers(
+                    occupation_numbers,
+                    state.d,
+                    state._config.cutoff,
+                    context=f": instruction={instruction}",
                 )
 
             state._occupation_numbers.append(np.rint(occupation_numbers).astype(int))

--- a/tests/_simulators/fock/general/test_preparations.py
+++ b/tests/_simulators/fock/general/test_preparations.py
@@ -94,6 +94,42 @@ def test_overflow_with_zero_norm_raises_InvalidState_when_normalized():
     assert error.value.args[0] == "The norm of the state is 0."
 
 
+def test_density_matrix_raises_InvalidState_when_ket_cutoff_too_small():
+    occupation_numbers = [0, 1, 0, 1, 1, 1]
+
+    with pq.Program() as program:
+        pq.Q() | pq.DensityMatrix(ket=occupation_numbers, bra=[0, 0, 0, 0, 0, 0])
+
+    simulator = pq.FockSimulator(d=6, config=pq.Config(cutoff=4, validate=True))
+
+    with pytest.raises(pq.api.exceptions.InvalidState) as error:
+        simulator.execute(program)
+
+    assert error.value.args[0] == (
+        "The occupation numbers '(0, 1, 0, 1, 1, 1)' require "
+        "a cutoff of at least '5', but the provided cutoff is '4'.: "
+        "DensityMatrix ket"
+    )
+
+
+def test_density_matrix_raises_InvalidState_when_bra_cutoff_too_small():
+    occupation_numbers = [0, 1, 0, 1, 1, 1]
+
+    with pq.Program() as program:
+        pq.Q() | pq.DensityMatrix(ket=[0, 0, 0, 0, 0, 0], bra=occupation_numbers)
+
+    simulator = pq.FockSimulator(d=6, config=pq.Config(cutoff=4, validate=True))
+
+    with pytest.raises(pq.api.exceptions.InvalidState) as error:
+        simulator.execute(program)
+
+    assert error.value.args[0] == (
+        "The occupation numbers '(0, 1, 0, 1, 1, 1)' require "
+        "a cutoff of at least '5', but the provided cutoff is '4'.: "
+        "DensityMatrix bra"
+    )
+
+
 def test_creation_on_multiple_modes():
     with pq.Program() as program:
         pq.Q() | pq.DensityMatrix(ket=[0, 0, 1], bra=[0, 0, 1]) * 2 / 5

--- a/tests/_simulators/sampling/test_preparations.py
+++ b/tests/_simulators/sampling/test_preparations.py
@@ -44,9 +44,47 @@ def test_initial_state_raises_InvalidState_for_occupation_numbers_of_differing_l
         simulator.execute(program).state
 
     assert error.value.args[0] == (
-        "The occupation numbers '(1, 1, 1)' are not well-defined on '5' modes: "
+        "The occupation numbers '(1, 1, 1)' are not well-defined on '5' modes.: "
         "instruction=StateVector(occupation_numbers=(1, 1, 1), "
         "coefficient=0.7071067811865475, modes=(0, 1, 2, 3, 4))"
+    )
+
+
+def test_initial_state_raises_InvalidState_when_cutoff_too_small():
+    occupation_numbers = [0, 1, 0, 1, 1, 1]
+
+    with pq.Program() as program:
+        pq.Q() | pq.StateVector(occupation_numbers)
+
+    simulator = pq.SamplingSimulator(d=6, config=pq.Config(cutoff=4, validate=True))
+
+    with pytest.raises(pq.api.exceptions.InvalidState) as error:
+        simulator.execute(program)
+
+    assert error.value.args[0] == (
+        "The occupation numbers '(0, 1, 0, 1, 1, 1)' require "
+        "a cutoff of at least '5', but the provided cutoff is '4'.: "
+        "instruction=StateVector(occupation_numbers=(0, 1, 0, 1, 1, 1), "
+        "coefficient=1.0, modes=(0, 1, 2, 3, 4, 5))"
+    )
+
+
+def test_initial_state_with_fock_amplitude_map_raises_InvalidState_when_cutoff_too_small():
+    occupation_numbers = (0, 1, 0, 1, 1, 1)
+
+    with pq.Program() as program:
+        pq.Q() | pq.StateVector(fock_amplitude_map={occupation_numbers: 1.0})
+
+    simulator = pq.SamplingSimulator(d=6, config=pq.Config(cutoff=4, validate=True))
+
+    with pytest.raises(pq.api.exceptions.InvalidState) as error:
+        simulator.execute(program)
+
+    assert error.value.args[0] == (
+        "The occupation numbers '(0, 1, 0, 1, 1, 1)' require "
+        "a cutoff of at least '5', but the provided cutoff is '4'.: "
+        "instruction=StateVector(fock_amplitude_map={(0, 1, 0, 1, 1, 1): 1.0}, "
+        "coefficient=1.0, modes=(0, 1, 2, 3, 4, 5))"
     )
 
 


### PR DESCRIPTION
## Summary

- Validate `SamplingSimulator` `StateVector` occupation numbers against the simulator cutoff before they are stored.
- Reuse the existing `validate_occupation_numbers` helper for sampling `fock_amplitude_map` entries as well.
- Add cutoff validation for `FockSimulator` `DensityMatrix` ket/bra preparation paths.
- Add regression coverage for too-small cutoff errors in sampling and general fock preparations.

This turns the low-cutoff SamplingSimulator reproduction from an internal `IndexError` into a descriptive `InvalidState` explaining the required cutoff.

Closes #472

## Validation

- `.\.venv\Scripts\python.exe -m pytest tests\_simulators\sampling\test_preparations.py tests\_simulators\fock\general\test_preparations.py -q` (`28 passed`)
- `.\.venv\Scripts\python.exe -m py_compile piquasso\_simulators\sampling\simulation_steps.py piquasso\_simulators\fock\general\simulation_steps.py tests\_simulators\sampling\test_preparations.py tests\_simulators\fock\general\test_preparations.py`
- `git diff --check`
- Manual reproduction: the `SamplingSimulator` program from #472 now raises `InvalidState` with `requires a cutoff of at least '5'` instead of reaching the previous `IndexError`.

## Disclosure

I used AI assistance to help inspect the code paths and prepare this patch, then validated the resulting changes locally with the commands above.