### PR TITLE
Respect modes in SamplingSimulator particle measurements

### DIFF
--- a/piquasso/_simulators/sampling/simulation_steps.py
+++ b/piquasso/_simulators/sampling/simulation_steps.py
@@ -249,6 +249,7 @@ def particle_number_measurement(
         rng=rng,
         postselect_data=postselect_data,
     )
+    samples = [tuple(sample[mode] for mode in instruction.modes) for sample in samples]
 
     binned_samples = get_counts(samples)
 

--- a/tests/_simulators/sampling/test_measurements.py
+++ b/tests/_simulators/sampling/test_measurements.py
@@ -86,6 +86,28 @@ def test_sampling_mode_permutation(interferometer_matrix):
     ), f"Expected [1, 0, 0, 1, 1], got: {sample}"
 
 
+@pytest.mark.parametrize(
+    ("measurement_modes", "expected_sample"),
+    [
+        ((0, 1), (1, 2)),
+        ((1, 0), (2, 1)),
+    ],
+)
+def test_sampling_particle_number_measurement_respects_modes(
+    measurement_modes, expected_sample
+):
+    shots = 3
+
+    with pq.Program() as program:
+        pq.Q() | pq.StateVector([1, 2, 0, 0, 0])
+        pq.Q(*measurement_modes) | pq.ParticleNumberMeasurement()
+
+    simulator = pq.SamplingSimulator(d=5)
+    result = simulator.execute(program, shots)
+
+    assert result.samples == [expected_sample] * shots
+
+
 def test_sampling_multiple_samples_for_permutation_interferometer(
     interferometer_matrix,
 ):


### PR DESCRIPTION
## Summary
- trim `SamplingSimulator` particle-number samples to the requested measurement modes before building result branches
- add a regression test covering `pq.Q(0, 1)` and reversed `pq.Q(1, 0)` mode order

Fixes #499.

## Validation
- repro script for issue #499 now returns `[(1, 1), (1, 1), (1, 1)]`
- `tests/_simulators/sampling/test_measurements.py -q`: `35 passed, 1 warning`
- non-JAX sampling subset (`test_measurements.py`, `test_channels.py`, `test_preparations.py`, `test_state.py`): `60 passed, 1 warning`
- `python -m py_compile piquasso\_simulators\sampling\simulation_steps.py tests\_simulators\sampling\test_measurements.py`
- `black --check` on changed files
- `flake8` on changed files
- `git diff --check`

Note: collecting the broader sampling `test_gates.py` file in my local Windows environment requires the optional `jax` extra and failed before running tests because `jax` is not installed.

AI disclosure: I used OpenAI Codex to help trace the simulator path, implement the small patch, and run validation.