### PR TITLE
Add Gaussian ladder string moments

### DIFF
--- a/piquasso/_simulators/gaussian/state.py
+++ b/piquasso/_simulators/gaussian/state.py
@@ -1153,6 +1153,28 @@ class GaussianState(State):
         corresponds to
         :math:`\langle \hat{a}_0^\dagger \hat{a}_0 \rangle`.
 
+        The ordered first and second ladder-operator moments are obtained from their
+        quadrature counterparts using
+
+        .. math::
+            \boldsymbol{\xi} = \frac{1}{\sqrt{\hbar}} W \boldsymbol{Y},
+            \qquad
+            \left\langle \boldsymbol{\xi} \boldsymbol{\xi}^T \right\rangle
+            = \frac{1}{\hbar} W
+                \left\langle \boldsymbol{Y} \boldsymbol{Y}^T \right\rangle W^T,
+
+        where :math:`\boldsymbol{\xi} = (a_0, \dots, a_{d-1},
+        a_0^\dagger, \dots, a_{d-1}^\dagger)^T`,
+        :math:`\boldsymbol{Y}` is in xxpp-ordering, and
+
+        .. math::
+            W = \frac{1}{\sqrt{2}}
+                \begin{bmatrix} I & iI \\ I & -iI \end{bmatrix}.
+
+        Since the ordered quadrature second moments include the canonical commutation
+        relations, this transformation preserves the specified operator ordering.
+        Higher-order moments then follow from Isserlis' theorem.
+
         Args:
             string: The indices of the ladder operators.
 

--- a/piquasso/_simulators/gaussian/state.py
+++ b/piquasso/_simulators/gaussian/state.py
@@ -27,7 +27,11 @@ from piquasso._math.linalg import (
     is_symmetric,
     is_positive_semidefinite,
 )
-from piquasso._math.symplectic import symplectic_form, xp_symplectic_form
+from piquasso._math.symplectic import (
+    symplectic_form,
+    xp_symplectic_form,
+    complex_symplectic_form,
+)
 from piquasso._math.fock import get_fock_space_basis
 from piquasso._math.transformations import xxpp_to_xpxp_indices, xpxp_to_xxpp_indices
 
@@ -1153,26 +1157,21 @@ class GaussianState(State):
         corresponds to
         :math:`\langle \hat{a}_0^\dagger \hat{a}_0 \rangle`.
 
-        The ordered first and second ladder-operator moments are obtained from their
-        quadrature counterparts using
+        The ordered first and second ladder-operator moments are obtained from the
+        complex covariance matrix using
 
         .. math::
-            \boldsymbol{\xi} = \frac{1}{\sqrt{\hbar}} W \boldsymbol{Y},
-            \qquad
-            \left\langle \boldsymbol{\xi} \boldsymbol{\xi}^T \right\rangle
-            = \frac{1}{\hbar} W
-                \left\langle \boldsymbol{Y} \boldsymbol{Y}^T \right\rangle W^T,
+            \left\langle
+                \Delta\boldsymbol{\xi} \Delta\boldsymbol{\xi}^T
+            \right\rangle
+            =
+            \frac{1}{2} \left( \sigma_c + J_c \right) X,
 
         where :math:`\boldsymbol{\xi} = (a_0, \dots, a_{d-1},
-        a_0^\dagger, \dots, a_{d-1}^\dagger)^T`,
-        :math:`\boldsymbol{Y}` is in xxpp-ordering, and
-
-        .. math::
-            W = \frac{1}{\sqrt{2}}
-                \begin{bmatrix} I & iI \\ I & -iI \end{bmatrix}.
-
-        Since the ordered quadrature second moments include the canonical commutation
-        relations, this transformation preserves the specified operator ordering.
+        a_0^\dagger, \dots, a_{d-1}^\dagger)^T`, :math:`J_c` is the
+        complex symplectic form, and :math:`X` swaps annihilation and creation
+        columns to convert the second covariance index from
+        :math:`\boldsymbol{\xi}^\dagger` to :math:`\boldsymbol{\xi}`.
         Higher-order moments then follow from Isserlis' theorem.
 
         Args:
@@ -1185,20 +1184,19 @@ class GaussianState(State):
         np = self._connector.np
 
         d = self.d
-        hbar = self._config.hbar
-
         identity = np.identity(d)
-        transformation = np.block(
-            [[identity, 1j * identity], [identity, -1j * identity]]
-        ) / np.sqrt(2)
-
-        ordered_xp_covariance = (
-            self.xxpp_covariance_matrix / 2 + 0.5j * hbar * xp_symplectic_form(d)
+        ladder_operator_swap = np.block(
+            [
+                [np.zeros((d, d)), identity],
+                [identity, np.zeros((d, d))],
+            ]
         )
 
         first_order_moments = self.complex_displacement
         second_order_moments = (
-            transformation @ ordered_xp_covariance @ transformation.T / hbar
+            (self.complex_covariance + complex_symplectic_form(d))
+            @ ladder_operator_swap
+            / 2
         )
 
         def recursive(op_list: List[int]) -> complex:

--- a/piquasso/_simulators/gaussian/state.py
+++ b/piquasso/_simulators/gaussian/state.py
@@ -1020,6 +1020,34 @@ class GaussianState(State):
 
         return self.reduced(modes).fock_probabilities
 
+    def _get_operator_string_moment(
+        self,
+        string: List[int],
+        first_order_moments: np.ndarray,
+        second_order_moments: np.ndarray,
+    ) -> complex:
+        # TODO: Reimplement this using the loop hafnian!
+        def recursive(op_list: List[int]) -> complex:
+            if not op_list:
+                return 1.0
+
+            if len(op_list) == 1:
+                return first_order_moments[op_list[0]]
+
+            first = op_list[0]
+            rest = op_list[1:]
+
+            total = first_order_moments[first] * recursive(rest)
+
+            for j, second in enumerate(rest):
+                remaining = rest[:j] + rest[j + 1 :]
+
+                total += second_order_moments[first, second] * recursive(remaining)
+
+            return total
+
+        return recursive(list(string))
+
     def get_xp_string_moment(self, string: List[int]) -> complex:
         r"""Moment corresponding to a product of quadrature operators (XP-string).
 
@@ -1118,29 +1146,9 @@ class GaussianState(State):
 
         second_order_moments = cov_xxpp / 2 + 0.5j * hbar * xp_symplectic_form(d)
 
-        # TODO: Reimplement this using the loop hafnian!
-        def recursive(op_list: List[int]) -> complex:
-            if not op_list:
-                return 1.0
-
-            if len(op_list) == 1:
-                return first_order_moments[op_list[0]]
-
-            first = op_list[0]
-            rest = op_list[1:]
-
-            total = first_order_moments[first] * recursive(rest)
-
-            for j, second in enumerate(rest):
-                remaining = rest[:j] + rest[j + 1 :]
-
-                pair_val = second_order_moments[first, second]
-
-                total += pair_val * recursive(remaining)
-
-            return total
-
-        return recursive(list(string))
+        return self._get_operator_string_moment(
+            string, first_order_moments, second_order_moments
+        )
 
     def get_ladder_string_moment(self, string: List[int]) -> complex:
         r"""Moment corresponding to a product of ladder operators.
@@ -1199,26 +1207,9 @@ class GaussianState(State):
             / 2
         )
 
-        def recursive(op_list: List[int]) -> complex:
-            if not op_list:
-                return 1.0
-
-            if len(op_list) == 1:
-                return first_order_moments[op_list[0]]
-
-            first = op_list[0]
-            rest = op_list[1:]
-
-            total = first_order_moments[first] * recursive(rest)
-
-            for j, second in enumerate(rest):
-                remaining = rest[:j] + rest[j + 1 :]
-
-                total += second_order_moments[first, second] * recursive(remaining)
-
-            return total
-
-        return recursive(list(string))
+        return self._get_operator_string_moment(
+            string, first_order_moments, second_order_moments
+        )
 
     def is_pure(self) -> bool:
         return bool(np.isclose(self.get_purity(), 1.0))

--- a/piquasso/_simulators/gaussian/state.py
+++ b/piquasso/_simulators/gaussian/state.py
@@ -1138,6 +1138,68 @@ class GaussianState(State):
 
         return recursive(list(string))
 
+    def get_ladder_string_moment(self, string: List[int]) -> complex:
+        r"""Moment corresponding to a product of ladder operators.
+
+        The indices of `string` follow the ordering of :attr:`complex_displacement`,
+        i.e., :math:`0, \dots, d-1` denotes
+        :math:`\hat{a}_0, \dots, \hat{a}_{d-1}` and
+        :math:`d, \dots, 2d-1` denotes
+        :math:`\hat{a}_0^\dagger, \dots, \hat{a}_{d-1}^\dagger`.
+
+        The order of the indices determines the operator ordering. For example,
+        ``[0, d]`` corresponds to
+        :math:`\langle \hat{a}_0 \hat{a}_0^\dagger \rangle`, while ``[d, 0]``
+        corresponds to
+        :math:`\langle \hat{a}_0^\dagger \hat{a}_0 \rangle`.
+
+        Args:
+            string: The indices of the ladder operators.
+
+        Returns:
+            The moment corresponding to the specified operator product.
+        """
+
+        np = self._connector.np
+
+        d = self.d
+        hbar = self._config.hbar
+
+        identity = np.identity(d)
+        transformation = np.block(
+            [[identity, 1j * identity], [identity, -1j * identity]]
+        ) / np.sqrt(2)
+
+        ordered_xp_covariance = (
+            self.xxpp_covariance_matrix / 2 + 0.5j * hbar * xp_symplectic_form(d)
+        )
+
+        first_order_moments = self.complex_displacement
+        second_order_moments = (
+            transformation @ ordered_xp_covariance @ transformation.T / hbar
+        )
+
+        def recursive(op_list: List[int]) -> complex:
+            if not op_list:
+                return 1.0
+
+            if len(op_list) == 1:
+                return first_order_moments[op_list[0]]
+
+            first = op_list[0]
+            rest = op_list[1:]
+
+            total = first_order_moments[first] * recursive(rest)
+
+            for j, second in enumerate(rest):
+                remaining = rest[:j] + rest[j + 1 :]
+
+                total += second_order_moments[first, second] * recursive(remaining)
+
+            return total
+
+        return recursive(list(string))
+
     def is_pure(self) -> bool:
         return bool(np.isclose(self.get_purity(), 1.0))
 

--- a/tests/_simulators/gaussian/test_state.py
+++ b/tests/_simulators/gaussian/test_state.py
@@ -1437,6 +1437,81 @@ def test_get_xp_string_moment_hbar_dependence():
     assert np.isclose(value1 * np.sqrt(hbar_2 / hbar_1) ** len(indices), value2)
 
 
+def test_get_ladder_string_moment_vacuum_state():
+    with pq.Program() as program:
+        pq.Q() | pq.Vacuum()
+
+    state = pq.GaussianSimulator(d=1).execute(program).state
+
+    assert np.isclose(state.get_ladder_string_moment([]), 1.0)
+    assert np.isclose(state.get_ladder_string_moment([0]), 0.0)
+    assert np.isclose(state.get_ladder_string_moment([1]), 0.0)
+
+    assert np.isclose(state.get_ladder_string_moment([0, 1]), 1.0)
+    assert np.isclose(state.get_ladder_string_moment([1, 0]), 0.0)
+    assert np.isclose(state.get_ladder_string_moment([0, 0]), 0.0)
+    assert np.isclose(state.get_ladder_string_moment([1, 1]), 0.0)
+
+
+def test_get_ladder_string_moment_coherent_state():
+    r = 0.2
+    phi = np.pi / 7
+    alpha = r * np.exp(1j * phi)
+
+    with pq.Program() as program:
+        pq.Q() | pq.Vacuum()
+        pq.Q(0) | pq.Displacement(r=r, phi=phi)
+
+    state = pq.GaussianSimulator(d=1).execute(program).state
+
+    assert np.isclose(state.get_ladder_string_moment([0]), alpha)
+    assert np.isclose(state.get_ladder_string_moment([1]), alpha.conj())
+    assert np.isclose(state.get_ladder_string_moment([0, 1]), abs(alpha) ** 2 + 1)
+    assert np.isclose(state.get_ladder_string_moment([1, 0]), abs(alpha) ** 2)
+    assert np.isclose(state.get_ladder_string_moment([1, 1, 0, 0]), abs(alpha) ** 4)
+
+
+def test_get_ladder_string_moment_admits_ccr():
+    with pq.Program() as program:
+        pq.Q() | pq.Vacuum()
+        pq.Q(1) | pq.Displacement(r=0.4)
+        pq.Q(0) | pq.Squeezing(r=0.2, phi=0.3)
+        pq.Q(0, 1) | pq.Beamsplitter(theta=np.pi / 5)
+
+    state = pq.GaussianSimulator(d=2).execute(program).state
+
+    assert np.isclose(
+        state.get_ladder_string_moment([0, 2]) - state.get_ladder_string_moment([2, 0]),
+        1.0,
+    )
+    assert np.isclose(
+        state.get_ladder_string_moment([0, 3]) - state.get_ladder_string_moment([3, 0]),
+        0.0,
+    )
+
+
+def test_get_ladder_string_moment_does_not_depend_on_hbar():
+    with pq.Program() as program:
+        pq.Q() | pq.Vacuum()
+        pq.Q(1) | pq.Displacement(r=0.4)
+        pq.Q(0) | pq.Squeezing(r=0.2, phi=0.3)
+        pq.Q(0, 1) | pq.Beamsplitter(theta=np.pi / 5)
+
+    state1 = (
+        pq.GaussianSimulator(d=2, config=pq.Config(hbar=1.0)).execute(program).state
+    )
+    state2 = (
+        pq.GaussianSimulator(d=2, config=pq.Config(hbar=3.0)).execute(program).state
+    )
+
+    indices = [0, 2, 1, 3, 0, 2]
+
+    assert np.isclose(
+        state1.get_ladder_string_moment(indices),
+        state2.get_ladder_string_moment(indices),
+    )
+
+
 def test_GaussianState_get_parity_operator_expectation_value_on_vacuum():
     with pq.Program() as program:
         pq.Q() | pq.Vacuum()

--- a/tests/_simulators/gaussian/test_state.py
+++ b/tests/_simulators/gaussian/test_state.py
@@ -1512,6 +1512,25 @@ def test_get_ladder_string_moment_does_not_depend_on_hbar():
     )
 
 
+def test_get_ladder_string_moment_jax_gradient_and_jit():
+    connector = pq.JaxConnector()
+
+    @jax.jit
+    def get_mean_photon_number(r):
+        with pq.Program() as program:
+            pq.Q() | pq.Vacuum()
+            pq.Q(0) | pq.Displacement(r=r)
+
+        state = pq.GaussianSimulator(connector=connector).execute(program).state
+
+        return state.get_ladder_string_moment([1, 0]).real
+
+    r = 0.2
+
+    assert np.isclose(get_mean_photon_number(r), r**2)
+    assert np.isclose(jax.grad(get_mean_photon_number)(r), 2 * r)
+
+
 def test_GaussianState_get_parity_operator_expectation_value_on_vacuum():
     with pq.Program() as program:
         pq.Q() | pq.Vacuum()


### PR DESCRIPTION
Closes #524.

## Summary

- add `GaussianState.get_ladder_string_moment`
- preserve the requested annihilation/creation index convention and operator order
- evaluate arbitrary-order Gaussian moments using ordered second moments and Isserlis' theorem
- add coverage for vacuum, coherent, multimode, CCR, `hbar` independence, and JAX/JIT

## Validation

- `python -m black --check piquasso/_simulators/gaussian/state.py tests/_simulators/gaussian/test_state.py`
- `python -m flake8 piquasso/_simulators/gaussian/state.py tests/_simulators/gaussian/test_state.py`
- `git diff --check`
- `pytest tests/_simulators/gaussian/test_state.py -k "get_xp_string_moment or get_ladder_string_moment" -q` (`18 passed`)
- explicit comparison against the XP expansion for every ladder-operator string through degree 6 on a nontrivial two-mode Gaussian state

## AI disclosure

I used OpenAI Codex to help inspect the codebase, brainstorm the ordered-moment transformation, and draft tests. I independently verified and refined the implementation using the checks listed above.