### PR TITLE
Add fermionic PureFock particle number measurement

### DIFF
--- a/piquasso/fermionic/fock/simulation_steps.py
+++ b/piquasso/fermionic/fock/simulation_steps.py
@@ -17,6 +17,8 @@ from piquasso.api.branch import Branch
 
 from piquasso.api.exceptions import InvalidParameter
 
+from piquasso._utils import sample_from_probability_map
+
 from piquasso._math.validations import (
     all_zero_or_one,
     are_modes_consecutive,
@@ -30,6 +32,7 @@ from ._utils import (
 
 from .._utils import (
     get_fock_space_index,
+    get_fock_space_basis,
     get_cutoff_fock_space_dimension,
     next_second_quantized,
 )
@@ -38,7 +41,8 @@ from .state import PureFockState
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import List
+    from typing import List, Tuple
+    from piquasso.api.instruction import Instruction
     from piquasso.instructions.preparations import StateVector
     from piquasso.instructions.gates import _PassiveLinearGate, Squeezing2
     from piquasso.fermionic.instructions import ControlledPhase, IsingXX
@@ -231,3 +235,97 @@ def ising_XX(
         state._state_vector = connector.assign(state._state_vector, index, final)
 
     return [Branch(state=state)]
+
+
+def particle_number_measurement(
+    state: PureFockState, instruction: "Instruction", shots: int
+) -> "List[Branch]":
+    probability_map = _get_probability_map(state, instruction.modes)
+
+    frequency_map = sample_from_probability_map(probability_map, shots)
+
+    branches = []
+
+    for sample, frequency in frequency_map.items():
+        new_state = _get_post_measurement_state(
+            state=state,
+            sample=sample,
+            modes=instruction.modes,
+            probability=probability_map[sample],
+        )
+
+        branches.append(Branch(new_state, sample, frequency=frequency))
+
+    return branches
+
+
+def _get_probability_map(
+    state: PureFockState, modes: "Tuple[int, ...]"
+) -> "dict[Tuple[int, ...], float]":
+    fallback_np = state._connector.fallback_np
+
+    basis = get_fock_space_basis(state.d, state._config.cutoff)
+    probabilities = fallback_np.asarray(state.fock_probabilities)
+
+    probability_map = {}
+
+    for occupation_numbers, probability in zip(basis, probabilities):
+        sample = tuple(int(occupation_numbers[mode]) for mode in modes)
+
+        probability_map[sample] = probability_map.get(sample, 0.0) + float(
+            fallback_np.real(probability)
+        )
+
+    return probability_map
+
+
+def _get_post_measurement_state(
+    *,
+    state: PureFockState,
+    sample: "Tuple[int, ...]",
+    modes: "Tuple[int, ...]",
+    probability: float,
+) -> PureFockState:
+    connector = state._connector
+    np = connector.np
+    fallback_np = connector.fallback_np
+
+    remaining_modes = tuple(mode for mode in range(state.d) if mode not in modes)
+
+    config = state._config.copy()
+    config.cutoff -= sum(sample)
+
+    new_state = PureFockState(
+        d=len(remaining_modes), connector=connector, config=config
+    )
+
+    basis = get_fock_space_basis(state.d, state._config.cutoff)
+    normalization = fallback_np.sqrt(1 / probability)
+
+    new_state_vector = np.zeros(
+        shape=new_state.state_vector.shape,
+        dtype=state._config.complex_dtype,
+    )
+
+    for source_index, occupation_numbers in enumerate(basis):
+        current_sample = tuple(int(occupation_numbers[mode]) for mode in modes)
+
+        if current_sample != sample:
+            continue
+
+        remaining_occupation_numbers = occupation_numbers[
+            fallback_np.array(remaining_modes, dtype=int)
+        ]
+
+        target_index = get_fock_space_index(remaining_occupation_numbers)
+
+        new_state_vector = connector.assign(
+            new_state_vector,
+            target_index,
+            new_state_vector[target_index]
+            + normalization * state.state_vector[source_index],
+        )
+
+    new_state._state_vector = new_state_vector
+
+    return new_state

--- a/piquasso/fermionic/fock/simulator.py
+++ b/piquasso/fermionic/fock/simulator.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from piquasso.instructions import gates, preparations
+from piquasso.instructions import gates, measurements, preparations
 from .state import PureFockState
 
 from .simulation_steps import (
@@ -22,6 +22,7 @@ from .simulation_steps import (
     squeezing2,
     controlled_phase,
     ising_XX,
+    particle_number_measurement,
 )
 
 from piquasso._simulators.simulator import BuiltinSimulator
@@ -54,6 +55,9 @@ class PureFockSimulator(BuiltinSimulator):
 
     Supported gates:
         :class:`~piquasso.instructions.gates.Interferometer`.
+
+    Supported measurements:
+        :class:`~piquasso.instructions.measurements.ParticleNumberMeasurement`.
     """
 
     _state_class = PureFockState
@@ -69,7 +73,14 @@ class PureFockSimulator(BuiltinSimulator):
         gates.Squeezing2: squeezing2,
         ControlledPhase: controlled_phase,
         IsingXX: ising_XX,
+        measurements.ParticleNumberMeasurement: particle_number_measurement,
     }
+
+    _measurement_classes_allowed_mid_circuit = (measurements.ParticleNumberMeasurement,)
+
+    _measurement_classes_allowed_with_shots_none = (
+        measurements.ParticleNumberMeasurement,
+    )
 
     _default_connector_class = NumpyConnector
 

--- a/tests/fermionic/fock/test_measurements.py
+++ b/tests/fermionic/fock/test_measurements.py
@@ -1,0 +1,148 @@
+#
+# Copyright 2021-2026 Budapest Quantum Computing Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from fractions import Fraction
+
+import numpy as np
+import pytest
+
+import piquasso as pq
+
+
+for_all_connectors = pytest.mark.parametrize(
+    "connector", [pq.NumpyConnector(), pq.JaxConnector()]
+)
+
+
+@for_all_connectors
+def test_ParticleNumberMeasurement_on_all_modes(connector):
+    with pq.Program() as program:
+        pq.Q() | pq.StateVector([1, 0, 1])
+        pq.Q() | pq.ParticleNumberMeasurement()
+
+    simulator = pq.fermionic.PureFockSimulator(
+        d=3, config=pq.Config(cutoff=4), connector=connector
+    )
+
+    result = simulator.execute(program, shots=3)
+
+    assert result.samples == [(1, 0, 1)] * 3
+    assert result.state is None
+
+
+@for_all_connectors
+def test_ParticleNumberMeasurement_on_one_mode_projects_state(connector):
+    with pq.Program() as program:
+        pq.Q() | pq.StateVector([1, 0, 1]) / np.sqrt(2)
+        pq.Q() | pq.StateVector([0, 1, 0]) / np.sqrt(2)
+        pq.Q(0) | pq.ParticleNumberMeasurement()
+
+    simulator = pq.fermionic.PureFockSimulator(
+        d=3, config=pq.Config(cutoff=4, seed_sequence=0), connector=connector
+    )
+
+    result = simulator.execute(program, shots=None)
+
+    assert set(result.outcome_map) == {(0,), (1,)}
+    assert result.outcome_map[(0,)]["frequency"] == pytest.approx(0.5)
+    assert result.outcome_map[(1,)]["frequency"] == pytest.approx(0.5)
+
+    assert np.allclose(
+        result.outcome_map[(0,)]["state"].fock_probabilities_map[(1, 0)],
+        1.0,
+    )
+    assert np.allclose(
+        result.outcome_map[(1,)]["state"].fock_probabilities_map[(0, 1)],
+        1.0,
+    )
+
+
+@for_all_connectors
+def test_ParticleNumberMeasurement_shots_none_returns_exact_frequencies(connector):
+    with pq.Program() as program:
+        pq.Q() | np.sqrt(0.25) * pq.StateVector([0, 0])
+        pq.Q() | np.sqrt(0.75) * pq.StateVector([1, 1])
+        pq.Q() | pq.ParticleNumberMeasurement()
+
+    simulator = pq.fermionic.PureFockSimulator(
+        d=2, config=pq.Config(cutoff=3), connector=connector
+    )
+
+    result = simulator.execute(program, shots=None)
+
+    assert result.outcome_map[(0, 0)]["frequency"] == pytest.approx(0.25)
+    assert result.outcome_map[(1, 1)]["frequency"] == pytest.approx(0.75)
+
+
+@for_all_connectors
+def test_ParticleNumberMeasurement_with_multiple_shots(connector):
+    shots = 5
+
+    with pq.Program() as program:
+        pq.Q() | pq.StateVector([0, 1, 0])
+        pq.Q() | pq.ParticleNumberMeasurement()
+
+    simulator = pq.fermionic.PureFockSimulator(
+        d=3, config=pq.Config(cutoff=4), connector=connector
+    )
+
+    result = simulator.execute(program, shots=shots)
+
+    assert result.samples == [(0, 1, 0)] * shots
+
+
+@for_all_connectors
+def test_ParticleNumberMeasurement_after_interferometer(connector):
+    shots = 10
+
+    interferometer = np.array(
+        [
+            [1 / np.sqrt(2), -1 / np.sqrt(2), 0],
+            [1 / np.sqrt(2), 1 / np.sqrt(2), 0],
+            [0, 0, 1],
+        ]
+    )
+
+    with pq.Program() as program:
+        pq.Q() | pq.StateVector([1, 1, 0])
+        pq.Q() | pq.Interferometer(interferometer)
+        pq.Q() | pq.ParticleNumberMeasurement()
+
+    simulator = pq.fermionic.PureFockSimulator(
+        d=3, config=pq.Config(cutoff=4), connector=connector
+    )
+
+    result = simulator.execute(program, shots=shots)
+
+    assert len(result.samples) == shots
+    assert all(sum(sample) == 2 for sample in result.samples)
+
+
+@for_all_connectors
+def test_ParticleNumberMeasurement_mid_circuit_reindexes_remaining_modes(connector):
+    with pq.Program() as program:
+        pq.Q() | pq.StateVector([1, 0, 1])
+        pq.Q(0) | pq.ParticleNumberMeasurement()
+        pq.Q(2) | pq.Phaseshifter(phi=np.pi)
+        pq.Q() | pq.ParticleNumberMeasurement()
+
+    simulator = pq.fermionic.PureFockSimulator(
+        d=3, config=pq.Config(cutoff=4), connector=connector
+    )
+
+    result = simulator.execute(program, shots=1)
+
+    assert result.samples == [(1, 0, 1)]
+    assert result.branches[0].frequency == Fraction(1)


### PR DESCRIPTION
## Summary
- add `ParticleNumberMeasurement` support to `fermionic.PureFockSimulator`
- sample from fermionic Fock-basis probabilities and build post-measurement branches
- allow exact `shots=None` distributions and mid-circuit measurements on remaining active modes

## Tests
- `python -m pytest -q tests\fermionic`
- `python -m black --check piquasso\fermionic\fock\simulator.py piquasso\fermionic\fock\simulation_steps.py tests\fermionic\fock\test_measurements.py`
- `python -m flake8 piquasso\fermionic\fock\simulator.py piquasso\fermionic\fock\simulation_steps.py tests\fermionic\fock\test_measurements.py`
- `git diff --check`
- `python -m pip check`

Closes #522