### PR TITLE
Add fermionic Gaussian particle number measurement

### DIFF
--- a/piquasso/fermionic/gaussian/simulation_steps.py
+++ b/piquasso/fermionic/gaussian/simulation_steps.py
@@ -18,6 +18,9 @@ from piquasso.api.branch import Branch
 from piquasso.api.exceptions import InvalidParameter
 from piquasso.api.instruction import Instruction
 
+from collections import Counter
+from fractions import Fraction
+
 from piquasso.instructions.gates import _PassiveLinearGate, Squeezing2
 from piquasso.fermionic.instructions import IsingXX
 
@@ -273,3 +276,88 @@ def ising_XX(state: GaussianState, instruction: IsingXX, shots: int) -> "List[Br
     evolved_state = _do_apply_gaussian_hamiltonian(state, h, modes)
 
     return [Branch(state=evolved_state)]
+
+
+def particle_number_measurement(
+    state: GaussianState, instruction: Instruction, shots: int
+) -> "List[Branch]":
+    samples = _get_particle_number_measurement_samples(state, instruction, shots)
+    sample_counts = Counter(samples)
+
+    return [
+        Branch(state=None, outcome=sample, frequency=Fraction(count, shots))
+        for sample, count in sample_counts.items()
+    ]
+
+
+def _get_particle_number_measurement_samples(
+    state: GaussianState, instruction: Instruction, shots: int
+) -> "List[Tuple[int, ...]]":
+    return [
+        _generate_particle_number_measurement_sample(
+            state,
+            modes=instruction.modes,
+            seed=state._config.seed_sequence + index,
+        )
+        for index in range(shots)
+    ]
+
+
+def _generate_particle_number_measurement_sample(
+    state: GaussianState, modes: "Tuple[int, ...]", seed: int
+) -> "Tuple[int, ...]":
+    fallback_np = state._connector.fallback_np
+    rng = fallback_np.random.default_rng(seed)
+
+    sample = tuple()
+
+    for index in range(len(modes)):
+        partial_modes = modes[: index + 1]
+
+        zero_probability = _get_partial_detection_probability(
+            state, partial_modes, sample + (0,)
+        )
+        one_probability = _get_partial_detection_probability(
+            state, partial_modes, sample + (1,)
+        )
+
+        normalizer = zero_probability + one_probability
+        one_conditional_probability = (
+            0.0 if normalizer == 0.0 else one_probability / normalizer
+        )
+        one_conditional_probability = max(0.0, min(1.0, one_conditional_probability))
+
+        value = rng.choice(
+            (0, 1),
+            p=(1 - one_conditional_probability, one_conditional_probability),
+        )
+
+        sample = sample + (int(value),)
+
+    return sample
+
+
+def _get_partial_detection_probability(
+    state: GaussianState,
+    modes: "Tuple[int, ...]",
+    occupation_numbers: "Tuple[int, ...]",
+) -> float:
+    fallback_np = state._connector.fallback_np
+    reduced_state = state.reduced(modes)
+
+    basis_state = GaussianState(
+        d=reduced_state.d,
+        connector=reduced_state._connector,
+        config=reduced_state._config,
+    )
+    basis_state._set_occupation_numbers(fallback_np.array(occupation_numbers))
+
+    np = state._connector.np
+    identity = np.identity(2 * reduced_state.d)
+    determinant = np.linalg.det(
+        (identity - reduced_state.covariance_matrix @ basis_state.covariance_matrix) / 2
+    )
+
+    probability_squared = max(0.0, float(fallback_np.real(determinant)))
+
+    return float(fallback_np.sqrt(probability_squared))

--- a/piquasso/fermionic/gaussian/simulator.py
+++ b/piquasso/fermionic/gaussian/simulator.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from piquasso.instructions import gates, preparations
+from piquasso.instructions import gates, measurements, preparations
 
 from ..instructions import GaussianHamiltonian, ParentHamiltonian, IsingXX
 
@@ -23,6 +23,7 @@ from .simulation_steps import (
     parent_hamiltonian,
     gaussian_hamiltonian,
     passive_linear_gate,
+    particle_number_measurement,
     squeezing2,
     ising_XX,
 )
@@ -62,6 +63,9 @@ class GaussianSimulator(BuiltinSimulator):
         :class:`~piquasso.instructions.gates.Beamsplitter`,
         :class:`~piquasso.instructions.gates.Phaseshifter`,
         :class:`~piquasso.fermionic.instructions.GaussianHamiltonian`.
+
+    Supported measurements:
+        :class:`~piquasso.instructions.measurements.ParticleNumberMeasurement`.
     """
 
     _state_class = GaussianState
@@ -76,6 +80,7 @@ class GaussianSimulator(BuiltinSimulator):
         gates.Phaseshifter: passive_linear_gate,
         gates.Squeezing2: squeezing2,
         IsingXX: ising_XX,
+        measurements.ParticleNumberMeasurement: particle_number_measurement,
     }
 
     _default_connector_class = NumpyConnector

--- a/tests/fermionic/gaussian/test_measurements.py
+++ b/tests/fermionic/gaussian/test_measurements.py
@@ -1,0 +1,99 @@
+#
+# Copyright 2021-2026 Budapest Quantum Computing Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections import Counter
+
+import numpy as np
+import pytest
+
+import piquasso as pq
+
+
+for_all_connectors = pytest.mark.parametrize(
+    "connector", [pq.NumpyConnector(), pq.JaxConnector()]
+)
+
+
+def test_GaussianSimulator_ParticleNumberMeasurement_issue_reproduction(
+    generate_unitary_matrix,
+):
+    d = 5
+
+    with pq.Program() as program:
+        pq.Q() | pq.StateVector([1, 1, 1, 0, 0])
+        pq.Q() | pq.Interferometer(generate_unitary_matrix(d))
+        pq.Q() | pq.ParticleNumberMeasurement()
+
+    simulator = pq.fermionic.GaussianSimulator(d=d, config=pq.Config(seed_sequence=321))
+
+    result = simulator.execute(program, shots=50)
+
+    assert len(result.samples) == 50
+    assert all(len(sample) == d for sample in result.samples)
+    assert all(set(sample) <= {0, 1} for sample in result.samples)
+    assert all(sum(sample) == 3 for sample in result.samples)
+
+
+@for_all_connectors
+def test_GaussianSimulator_ParticleNumberMeasurement_respects_measured_modes(
+    connector,
+):
+    with pq.Program() as program:
+        pq.Q() | pq.StateVector([1, 0, 1])
+        pq.Q(2, 0) | pq.ParticleNumberMeasurement()
+
+    simulator = pq.fermionic.GaussianSimulator(
+        d=3, connector=connector, config=pq.Config(seed_sequence=123)
+    )
+
+    result = simulator.execute(program, shots=10)
+
+    assert result.samples == [(1, 1)] * 10
+
+
+@for_all_connectors
+def test_GaussianSimulator_ParticleNumberMeasurement_matches_probabilities(
+    connector,
+):
+    theta = np.pi / 5
+    interferometer = np.array(
+        [
+            [np.cos(theta), -np.sin(theta)],
+            [np.sin(theta), np.cos(theta)],
+        ]
+    )
+
+    with pq.Program() as state_program:
+        pq.Q() | pq.StateVector([1, 0])
+        pq.Q() | pq.Interferometer(interferometer)
+
+    with pq.Program() as measurement_program:
+        pq.Q() | pq.StateVector([1, 0])
+        pq.Q() | pq.Interferometer(interferometer)
+        pq.Q() | pq.ParticleNumberMeasurement()
+
+    simulator = pq.fermionic.GaussianSimulator(
+        d=2, connector=connector, config=pq.Config(seed_sequence=123)
+    )
+
+    expected_state = simulator.execute(state_program).state
+    expected_probability = expected_state.get_particle_detection_probability([1, 0])
+
+    shots = 2000
+    result = simulator.execute(measurement_program, shots=shots)
+    counts = Counter(result.samples)
+
+    assert set(counts) <= {(1, 0), (0, 1)}
+    assert np.isclose(counts[(1, 0)] / shots, expected_probability, atol=0.05)


### PR DESCRIPTION
## Summary
- add `ParticleNumberMeasurement` support to `fermionic.GaussianSimulator`
- sample fermionic occupation patterns mode by mode using conditional detection probabilities
- add regression coverage for the issue example, measured-mode ordering, and sampled probabilities

Closes #521

## Validation
- `python -m pytest -q tests\fermionic\gaussian\test_measurements.py` (`5 passed`)
- `python -m pytest -q tests\fermionic\gaussian tests\fermionic\test_simulator_equivalence.py` (`163 passed`)
- `python -m pytest -q tests\fermionic` (`218 passed, 1 warning`)
- issue-style smoke script for the documented 5-mode fermionic Gaussian sampling example
- `python -m py_compile piquasso\fermionic\gaussian\simulator.py piquasso\fermionic\gaussian\simulation_steps.py tests\fermionic\gaussian\test_measurements.py`
- `python -m black --check piquasso\fermionic\gaussian\simulator.py piquasso\fermionic\gaussian\simulation_steps.py tests\fermionic\gaussian\test_measurements.py`
- `python -m flake8 piquasso\fermionic\gaussian\simulator.py piquasso\fermionic\gaussian\simulation_steps.py tests\fermionic\gaussian\test_measurements.py`
- `git diff --check`
- `python -m pip check`

## AI disclosure
I used OpenAI Codex to inspect the simulator paths, implement the sampling helper, and run the validation commands above.