### PR TITLE
Measure only the specified modes for ParticleNumberMeasurement on SamplingSimulator

### DIFF
--- a/piquasso/_simulators/sampling/marginal.py
+++ b/piquasso/_simulators/sampling/marginal.py
@@ -47,6 +47,13 @@ are the coefficients of the low-rank permanent polynomial
     G(c) =
         1 / r! * Per((I + V diag(c) V^dagger)_{r,r}).
 
+Equivalently, the coefficients ``b_alpha`` are the binomial moments of the output
+distribution on the selected modes, i.e.,
+
+    b_alpha = E[prod_j binom(X_j, alpha_j)],
+
+where ``X_j`` is the random variable for the output photon number in mode ``T[j]``.
+
 The probability of observing a pattern ``y`` on the selected modes is obtained
 from the binomial transform
 
@@ -124,7 +131,7 @@ def get_marginal_probabilities(
 
     compositions = get_fock_space_basis(k_total, n + 1)
 
-    diagonal_coefficients = _get_diagonal_coefficients(
+    binomial_moments = _get_binomial_moments(
         input_photons=input_photons,
         interferometer=interferometer,
         all_modes=all_modes,
@@ -142,8 +149,8 @@ def get_marginal_probabilities(
         )
     outcomes_with_postselection[:, num_postselected_modes:] = outcomes
     indices = cutoff_fock_space_dim_array(np.arange(n + 2), k_total)
-    probabilities = _probabilities_from_diagonal_coefficients(
-        diagonal_coefficients, compositions, outcomes_with_postselection, indices
+    probabilities = _probabilities_from_binomial_moments(
+        binomial_moments, compositions, outcomes_with_postselection, indices
     )
 
     ret = {tuple(outcome): probabilities[i].real for i, outcome in enumerate(outcomes)}
@@ -151,7 +158,7 @@ def get_marginal_probabilities(
     return ret
 
 
-def _get_diagonal_coefficients(
+def _get_binomial_moments(
     input_photons: np.ndarray,
     interferometer: np.ndarray,
     all_modes: np.ndarray,
@@ -210,13 +217,13 @@ def _get_diagonal_coefficients(
         bihomogeneous_blocks = new_blocks
         processed_degree = processed_degree + occupation
 
-    return _extract_diagonal_coefficients_from_bihomogeneous_blocks(
+    return _extract_binomial_moments_from_bihomogeneous_blocks(
         bihomogeneous_blocks, compositions, indices, factorials
     )
 
 
 @nb.njit(cache=True)
-def _extract_diagonal_coefficients_from_bihomogeneous_blocks(
+def _extract_binomial_moments_from_bihomogeneous_blocks(
     bihomogeneous_blocks: Sequence[np.ndarray],
     compositions: np.ndarray,
     indices: np.ndarray,
@@ -224,7 +231,7 @@ def _extract_diagonal_coefficients_from_bihomogeneous_blocks(
 ) -> np.ndarray:
     n = len(factorials) - 1
 
-    diagonal_coefficients = np.zeros(len(compositions), dtype=np.float64)
+    binomial_moments = np.zeros(len(compositions), dtype=np.float64)
 
     offsets = np.zeros(n + 2, dtype=np.int64)
     for i in range(n + 1):
@@ -240,9 +247,9 @@ def _extract_diagonal_coefficients_from_bihomogeneous_blocks(
             alpha_fact = 1.0
             for value in comps_i[j]:
                 alpha_fact *= factorials[int(value)]
-            diagonal_coefficients[start + j] = (alpha_fact * diag[j]).real
+            binomial_moments[start + j] = (alpha_fact * diag[j]).real
 
-    return diagonal_coefficients
+    return binomial_moments
 
 
 @nb.njit(cache=True)
@@ -298,7 +305,7 @@ def _add_bihomogeneous_product_term(
 
 
 @nb.njit(cache=True)
-def _probabilities_from_diagonal_coefficients(
+def _probabilities_from_binomial_moments(
     diagonals: np.ndarray,
     compositions: np.ndarray,
     outcomes: np.ndarray,

--- a/piquasso/_simulators/sampling/marginal.py
+++ b/piquasso/_simulators/sampling/marginal.py
@@ -337,3 +337,25 @@ def _probabilities_from_diagonal_coefficients(
         probs[y_index] = total
 
     return probs
+
+def generate_marginal_samples(state, selected_modes, shots, rng):
+    '''
+        Implements mode-by-mode sampling.
+    '''
+    if sum(state._occupation_numbers[0]) == 0:
+        return [(0,) * len(selected_modes)] * shots
+    samples = []
+    while len(samples) < shots:
+        sample = np.zeros(len(selected_modes), dtype=int)
+        state._postselections = {}
+        for i_mode, mode in enumerate(selected_modes):
+            probs = state.get_marginal_probabilities((mode,))
+            n_photons_list = np.array(list(probs.keys()))
+            n_photons_probs = np.array(list(probs.values()))
+            positive_probs = np.where(n_photons_probs>0)
+            n_photons = rng.choice(n_photons_list[positive_probs], p=n_photons_probs[positive_probs])[0]
+            if n_photons > 0:
+                sample[i_mode] += n_photons
+                state._postselections[mode] = n_photons
+        samples.append(tuple(sample.tolist()))
+    return samples

--- a/piquasso/_simulators/sampling/marginal.py
+++ b/piquasso/_simulators/sampling/marginal.py
@@ -354,8 +354,7 @@ def generate_marginal_samples(state, selected_modes, shots, rng):
             n_photons_probs = np.array(list(probs.values()))
             positive_probs = np.where(n_photons_probs>0)
             n_photons = rng.choice(n_photons_list[positive_probs], p=n_photons_probs[positive_probs])[0]
-            if n_photons > 0:
-                sample[i_mode] += n_photons
-                state._postselections[mode] = n_photons
+            sample[i_mode] += n_photons
+            state._postselections[mode] = n_photons
         samples.append(tuple(sample.tolist()))
     return samples

--- a/piquasso/_simulators/sampling/marginal.py
+++ b/piquasso/_simulators/sampling/marginal.py
@@ -99,8 +99,12 @@ import numba as nb
 from scipy.special import factorial
 
 from piquasso._math.combinatorics import comb
-from piquasso._math.fock import get_fock_space_basis, cutoff_fock_space_dim_array
-from piquasso._math.indices import get_index_in_fock_subspace
+from piquasso._math.fock import (
+    get_fock_space_basis,
+    cutoff_fock_space_dim_array,
+    nb_get_fock_space_basis,
+)
+from piquasso._math.indices import get_index_in_fock_space, get_index_in_fock_subspace
 
 
 def get_marginal_probabilities(
@@ -131,7 +135,7 @@ def get_marginal_probabilities(
 
     compositions = get_fock_space_basis(k_total, n + 1)
 
-    binomial_moments = _get_binomial_moments(
+    binomial_moments = get_binomial_moments(
         input_photons=input_photons,
         interferometer=interferometer,
         all_modes=all_modes,
@@ -158,7 +162,7 @@ def get_marginal_probabilities(
     return ret
 
 
-def _get_binomial_moments(
+def get_binomial_moments(
     input_photons: np.ndarray,
     interferometer: np.ndarray,
     all_modes: np.ndarray,
@@ -406,3 +410,29 @@ def _shift_minus_one_inplace(line: np.ndarray, length: int) -> None:
     for i in range(length - 1):
         for j in range(length - 1, i, -1):
             line[j - 1] -= line[j]
+
+
+@nb.njit(cache=True)
+def get_single_marginal_probability_from_binomial_moments(
+    n: int,
+    d: int,
+    binomial_moments: np.ndarray,
+    particles: np.ndarray,
+) -> float:
+    k = len(particles)
+
+    full_occupation = np.zeros(d, dtype=nb.int64)
+
+    probability = 0.0
+
+    for beta in nb_get_fock_space_basis(k, n + 1 - sum(particles)):
+        prod = 1.0
+
+        for i in range(k):
+            full_occupation[i] = beta[i] + particles[i]
+            prod *= comb(full_occupation[i], particles[i]) * (-1) ** beta[i]
+
+        index = get_index_in_fock_space(full_occupation)
+        probability += prod * binomial_moments[index]
+
+    return probability

--- a/piquasso/_simulators/sampling/marginal.py
+++ b/piquasso/_simulators/sampling/marginal.py
@@ -337,24 +337,3 @@ def _probabilities_from_diagonal_coefficients(
         probs[y_index] = total
 
     return probs
-
-def generate_marginal_samples(state, selected_modes, shots, rng):
-    '''
-        Implements mode-by-mode sampling.
-    '''
-    if sum(state._occupation_numbers[0]) == 0:
-        return [(0,) * len(selected_modes)] * shots
-    samples = []
-    while len(samples) < shots:
-        sample = np.zeros(len(selected_modes), dtype=int)
-        state._postselections = {}
-        for i_mode, mode in enumerate(selected_modes):
-            probs = state.get_marginal_probabilities((mode,))
-            n_photons_list = np.array(list(probs.keys()))
-            n_photons_probs = np.array(list(probs.values()))
-            positive_probs = np.where(n_photons_probs>0)
-            n_photons = rng.choice(n_photons_list[positive_probs], p=n_photons_probs[positive_probs])[0]
-            sample[i_mode] += n_photons
-            state._postselections[mode] = n_photons
-        samples.append(tuple(sample.tolist()))
-    return samples

--- a/piquasso/_simulators/sampling/simulation_steps.py
+++ b/piquasso/_simulators/sampling/simulation_steps.py
@@ -274,6 +274,7 @@ def particle_number_measurement(
         calculate_permanent_laplace=state._connector.permanent_laplace,
         rng=rng,
         postselect_data=postselect_data,
+        selected_modes=instruction.modes,
     )
 
     binned_samples = get_counts(samples)

--- a/piquasso/_simulators/sampling/simulation_steps.py
+++ b/piquasso/_simulators/sampling/simulation_steps.py
@@ -37,6 +37,7 @@ from .utils import (
     generate_samples,
     generate_lossy_samples,
 )
+from .marginal import generate_marginal_samples
 from piquasso._utils import get_counts
 
 
@@ -248,34 +249,38 @@ def particle_number_measurement(
         state._config.max_sample_generation_trials,
     )
 
-    if not state.is_lossy:
-        partial_generate_samples = partial(
-            generate_samples,
-            interferometer=state.interferometer,
-            reject_condition=lambda: False,
-        )
-    elif np.all(np.isclose(singular_values, singular_values[0])):
-        uniform_transmission_probability = singular_values[0] ** 2
+    if len(instruction.modes) > 0 and len(instruction.modes) < len(initial_state):
+        samples = generate_marginal_samples(state, instruction.modes, shots, rng)
 
-        partial_generate_samples = partial(
-            generate_samples,
-            interferometer=state.interferometer,
-            reject_condition=lambda: rng.uniform() > uniform_transmission_probability,
-        )
     else:
-        partial_generate_samples = partial(
-            generate_lossy_samples,
-            interferometer_svd=interferometer_svd,
-        )
 
-    samples = partial_generate_samples(
-        initial_state,
-        shots,
-        calculate_permanent_laplace=state._connector.permanent_laplace,
-        rng=rng,
-        postselect_data=postselect_data,
-        selected_modes=instruction.modes,
-    )
+        if not state.is_lossy:
+            partial_generate_samples = partial(
+                generate_samples,
+                interferometer=state.interferometer,
+                reject_condition=lambda: False,
+            )
+        elif np.all(np.isclose(singular_values, singular_values[0])):
+            uniform_transmission_probability = singular_values[0] ** 2
+
+            partial_generate_samples = partial(
+                generate_samples,
+                interferometer=state.interferometer,
+                reject_condition=lambda: rng.uniform() > uniform_transmission_probability,
+            )
+        else:
+            partial_generate_samples = partial(
+                generate_lossy_samples,
+                interferometer_svd=interferometer_svd,
+            )
+
+        samples = partial_generate_samples(
+            initial_state,
+            shots,
+            calculate_permanent_laplace=state._connector.permanent_laplace,
+            rng=rng,
+            postselect_data=postselect_data,
+        )
 
     binned_samples = get_counts(samples)
 

--- a/piquasso/_simulators/sampling/simulation_steps.py
+++ b/piquasso/_simulators/sampling/simulation_steps.py
@@ -37,6 +37,7 @@ from .utils import (
     generate_samples,
     generate_lossy_samples,
     generate_marginal_samples,
+    is_direct_marginal_sampling_cheaper,
     map_to_original_modes,
 )
 from piquasso._utils import get_counts
@@ -252,15 +253,15 @@ def particle_number_measurement(
 
     marginal_sampling = set(modes) != set(range(state.d))
 
-    if marginal_sampling:
-        if state.is_lossy:
-            raise NotImplementedCalculation(
-                f"The instruction {instruction} is not supported for lossy states with "
-                "postselection on a subset of modes.\n"
-                "If you need this feature to be implemented, please create an issue at "
-                "https://github.com/Budapest-Quantum-Computing-Group/piquasso/issues"
-            )
-
+    if (
+        marginal_sampling
+        and not state.is_lossy
+        and is_direct_marginal_sampling_cheaper(
+            k=len(modes) + len(postselected_modes),
+            d=state.total_number_of_modes,
+            n=int(np.sum(initial_state)),
+        )
+    ):
         original_modes = map_to_original_modes(modes, postselected_modes)
 
         samples = generate_marginal_samples(
@@ -325,6 +326,12 @@ def particle_number_measurement(
     )
 
     binned_samples = get_counts(samples)
+
+    if marginal_sampling:
+        binned_samples = {
+            tuple(outcome[mode] for mode in modes): multiplicity
+            for outcome, multiplicity in binned_samples.items()
+        }
 
     branches = [
         Branch(state=None, outcome=outcome, frequency=Fraction(multiplicity, shots))

--- a/piquasso/_simulators/sampling/simulation_steps.py
+++ b/piquasso/_simulators/sampling/simulation_steps.py
@@ -250,7 +250,7 @@ def particle_number_measurement(
 
     modes = instruction.modes
 
-    marginal_sampling = set(postselected_modes + modes) != set(range(state.d))
+    marginal_sampling = set(modes) != set(range(state.d))
 
     if marginal_sampling:
         if state.is_lossy:

--- a/piquasso/_simulators/sampling/simulation_steps.py
+++ b/piquasso/_simulators/sampling/simulation_steps.py
@@ -37,7 +37,6 @@ from .utils import (
     generate_samples,
     generate_lossy_samples,
 )
-from .marginal import generate_marginal_samples
 from piquasso._utils import get_counts
 
 
@@ -249,38 +248,34 @@ def particle_number_measurement(
         state._config.max_sample_generation_trials,
     )
 
-    if len(instruction.modes) > 0 and len(instruction.modes) < len(initial_state):
-        samples = generate_marginal_samples(state, instruction.modes, shots, rng)
-
-    else:
-
-        if not state.is_lossy:
-            partial_generate_samples = partial(
-                generate_samples,
-                interferometer=state.interferometer,
-                reject_condition=lambda: False,
-            )
-        elif np.all(np.isclose(singular_values, singular_values[0])):
-            uniform_transmission_probability = singular_values[0] ** 2
-
-            partial_generate_samples = partial(
-                generate_samples,
-                interferometer=state.interferometer,
-                reject_condition=lambda: rng.uniform() > uniform_transmission_probability,
-            )
-        else:
-            partial_generate_samples = partial(
-                generate_lossy_samples,
-                interferometer_svd=interferometer_svd,
-            )
-
-        samples = partial_generate_samples(
-            initial_state,
-            shots,
-            calculate_permanent_laplace=state._connector.permanent_laplace,
-            rng=rng,
-            postselect_data=postselect_data,
+    if not state.is_lossy:
+        partial_generate_samples = partial(
+            generate_samples,
+            interferometer=state.interferometer,
+            reject_condition=lambda: False,
         )
+    elif np.all(np.isclose(singular_values, singular_values[0])):
+        uniform_transmission_probability = singular_values[0] ** 2
+
+        partial_generate_samples = partial(
+            generate_samples,
+            interferometer=state.interferometer,
+            reject_condition=lambda: rng.uniform() > uniform_transmission_probability,
+        )
+    else:
+        partial_generate_samples = partial(
+            generate_lossy_samples,
+            interferometer_svd=interferometer_svd,
+        )
+
+    samples = partial_generate_samples(
+        initial_state,
+        shots,
+        calculate_permanent_laplace=state._connector.permanent_laplace,
+        rng=rng,
+        postselect_data=postselect_data,
+        selected_modes=instruction.modes,
+    )
 
     binned_samples = get_counts(samples)
 

--- a/piquasso/_simulators/sampling/simulation_steps.py
+++ b/piquasso/_simulators/sampling/simulation_steps.py
@@ -36,6 +36,8 @@ from piquasso._simulators.fock.pure.simulation_steps import (
 from .utils import (
     generate_samples,
     generate_lossy_samples,
+    generate_marginal_samples,
+    map_to_original_modes,
 )
 from piquasso._utils import get_counts
 
@@ -236,17 +238,63 @@ def particle_number_measurement(
 
     initial_state = state._occupation_numbers[0]
 
-    interferometer_svd = np.linalg.svd(state.interferometer)
-
     rng = state._config.rng
 
-    singular_values = interferometer_svd[1]
+    postselected_modes = state._get_postselected_modes()
 
     postselect_data = (
-        state._get_postselected_modes(),
+        postselected_modes,
         state._get_postselected_photons(),
         state._config.max_sample_generation_trials,
     )
+
+    modes = instruction.modes
+
+    marginal_sampling = set(postselected_modes + modes) != set(range(state.d))
+
+    if marginal_sampling:
+        if state.is_lossy:
+            raise NotImplementedCalculation(
+                f"The instruction {instruction} is not supported for lossy states with "
+                "postselection on a subset of modes.\n"
+                "If you need this feature to be implemented, please create an issue at "
+                "https://github.com/Budapest-Quantum-Computing-Group/piquasso/issues"
+            )
+
+        original_modes = map_to_original_modes(modes, postselected_modes)
+
+        samples = generate_marginal_samples(
+            initial_state=initial_state,
+            interferometer=state.interferometer,
+            modes=original_modes,
+            shots=shots,
+            rng=rng,
+            postselect_data=postselect_data,
+        )
+
+        binned_samples = get_counts(samples)
+
+        branches = []
+
+        for outcome, multiplicity in binned_samples.items():
+            new_state = state.copy()
+            new_state._postselections = {
+                **new_state._postselections,
+                **{mode: x for mode, x in zip(modes, outcome)},
+            }
+
+            branches.append(
+                Branch(
+                    state=new_state,
+                    outcome=outcome,
+                    frequency=Fraction(multiplicity, shots),
+                )
+            )
+
+        return branches
+
+    interferometer_svd = np.linalg.svd(state.interferometer)
+    singular_values = interferometer_svd[1]
 
     if not state.is_lossy:
         partial_generate_samples = partial(

--- a/piquasso/_simulators/sampling/simulation_steps.py
+++ b/piquasso/_simulators/sampling/simulation_steps.py
@@ -274,7 +274,6 @@ def particle_number_measurement(
         calculate_permanent_laplace=state._connector.permanent_laplace,
         rng=rng,
         postselect_data=postselect_data,
-        selected_modes=instruction.modes,
     )
 
     binned_samples = get_counts(samples)

--- a/piquasso/_simulators/sampling/utils.py
+++ b/piquasso/_simulators/sampling/utils.py
@@ -183,7 +183,7 @@ def generate_samples(
     k = len(selected_modes)
 
     if k == 1 and n>=3 and n<10:
-        return _generate_marginal_samples(
+        return _generate_k_modes_samples(
             input, 
             shots, 
             interferometer, 
@@ -487,7 +487,7 @@ def _calculate_singular_values_matrix_expansion(singular_values_vector):
     return np.diag(expansion_values)
 
 
-def _generate_marginal_samples(
+def _generate_k_modes_samples(
         input, shots, interferometer, rng, selected_modes, n
 ):
     '''
@@ -496,12 +496,12 @@ def _generate_marginal_samples(
     samples = []
 
     while len(samples) < shots:
-        sample = _generate_marginal_sample(selected_modes, n, input, interferometer, rng)
+        sample = _generate_k_modes_sample(selected_modes, n, input, interferometer, rng)
         samples.append(tuple(sample))
 
     return samples
 
-def multiply_polynomials(poly_arr_shape, arr):
+def _multiply_polynomials(poly_arr_shape, arr):
     '''
         Multiplies arrays of polynomial coefficients with fft.
     '''
@@ -510,7 +510,7 @@ def multiply_polynomials(poly_arr_shape, arr):
     ifft_arr = np.fft.ifftn(prod_arr, axes=range(1, len(prod_arr.shape)))
     return ifft_arr
 
-def compute_laguerre(k, x, ra):
+def _compute_laguerre(k, x, ra):
     '''
         Computes the Laguerre series at degree ra and returns an array of its polynomials.
     '''
@@ -535,7 +535,7 @@ def compute_laguerre(k, x, ra):
         coeffs[:, i, relevant_indices] = poly_coeffs
     return coeffs
 
-def _generate_marginal_sample(modes, n, inputs, interferometer, rng):
+def _generate_k_modes_sample(modes, n, inputs, interferometer, rng):
     '''
         Implements sampling when k-modes have been selected for measurement.
     '''
@@ -556,8 +556,8 @@ def _generate_marginal_sample(modes, n, inputs, interferometer, rng):
     faw = np.conj(V).T[:, None, :]*np.power(omegas, -1)[None,...]
     xa = np.einsum('nmi,nmj->mnij', faz, faw)
     xa = np.sum(-xa, axis=2)
-    l_ra = compute_laguerre(k, xa, occupied_inputs)
-    P_omega = multiply_polynomials(poly_arr_shape, l_ra)
+    l_ra = _compute_laguerre(k, xa, occupied_inputs)
+    P_omega = _multiply_polynomials(poly_arr_shape, l_ra)
     D_t = np.sum(P_omega, axis=0)
     D_t /= N**k
 

--- a/piquasso/_simulators/sampling/utils.py
+++ b/piquasso/_simulators/sampling/utils.py
@@ -25,6 +25,7 @@ from piquasso._math.combinatorics import partitions, partitions_bounded_k
 from piquasso._math.fock import get_fock_space_basis
 from .marginal import (
     _get_diagonal_coefficients,
+    cutoff_fock_space_dim_array,
     _probabilities_from_diagonal_coefficients,
 )
 
@@ -601,10 +602,14 @@ def _generate_marginal_samples(
                     ]
                     intermediate_diagonal = diagonal_coefficients[relevant_indices]
 
+                indices = cutoff_fock_space_dim_array(
+                    np.arange(n + 2), num_postselected_modes + 1
+                )
                 probabilities = _probabilities_from_diagonal_coefficients(
                     intermediate_diagonal,
                     intermediate_compositions,
                     outcomes_with_postselection,
+                    indices,
                 )
                 if np.all(probabilities == 0):
                     break

--- a/piquasso/_simulators/sampling/utils.py
+++ b/piquasso/_simulators/sampling/utils.py
@@ -22,13 +22,6 @@ from piquasso.api.exceptions import InvalidSimulation
 
 from piquasso._math.combinatorics import partitions, partitions_bounded_k
 
-from piquasso._math.fock import get_fock_space_basis
-from .marginal import (
-    _get_diagonal_coefficients,
-    cutoff_fock_space_dim_array,
-    _probabilities_from_diagonal_coefficients,
-)
-
 """
 This is a contribution from `theboss`, see https://github.com/Tomev-CTP/theboss.
 
@@ -158,8 +151,6 @@ def generate_samples(
     rng,
     reject_condition,
     postselect_data,
-    selected_modes,
-    lossy=False,
 ):
     """
     Generates samples corresponding to the Clifford & Clifford algorithm B from
@@ -185,11 +176,8 @@ def generate_samples(
     Returns:
         The generated samples.
     """
-    if 0 < len(selected_modes) < len(input) and not lossy:
-        return _generate_marginal_samples(
-            input, interferometer, selected_modes, shots, rng, postselect_data
-        )
-    elif len(postselect_data[0]) > 0:
+
+    if len(postselect_data[0]) > 0:
         sample_generator = partial(
             _generate_sample_with_postselect,
             reject_condition=reject_condition,
@@ -205,7 +193,6 @@ def generate_samples(
         sample_generator=sample_generator,
         interferometer=interferometer,
         rng=rng,
-        selected_modes=selected_modes,
     )
 
 
@@ -216,7 +203,6 @@ def generate_lossy_samples(
     interferometer_svd,
     rng,
     postselect_data,
-    selected_modes,
 ):
     """
     Basically the same algorithm as in `generate_samples`, but doubles the system size
@@ -239,8 +225,6 @@ def generate_lossy_samples(
         rng,
         reject_condition=lambda: False,
         postselect_data=postselect_data,
-        selected_modes=selected_modes,
-        lossy=True,
     )
 
     # Trim output state
@@ -262,13 +246,7 @@ def _get_first_quantized(occupation_numbers):
 
 
 def _generate_samples(
-    input,
-    shots,
-    calculate_permanent_laplace,
-    interferometer,
-    sample_generator,
-    rng,
-    selected_modes,
+    input, shots, calculate_permanent_laplace, interferometer, sample_generator, rng
 ):
     d = len(input)
     n = np.sum(input)
@@ -287,7 +265,7 @@ def _generate_samples(
             rng=rng,
         )
         samples.append(tuple(sample))
-    samples = [tuple(sample[mode] for mode in selected_modes) for sample in samples]
+
     return samples
 
 
@@ -491,143 +469,3 @@ def _calculate_singular_values_matrix_expansion(singular_values_vector):
     expansion_values = np.sqrt(vector_of_squared_expansions)
 
     return np.diag(expansion_values)
-
-
-def _generate_marginal_samples(
-    initial_state, interferometer, selected_modes, shots, rng, postselect_data
-):
-    """
-    Implements mode-by-mode sampling with postselection.
-    """
-    n = sum(initial_state)
-    k = len(selected_modes)
-
-    if n == 0:
-        return [(0,) * k] * shots
-
-    postselect_modes, postselect_photons, max_sample_generation_trials = postselect_data
-    selected_modes = np.array(selected_modes)
-    for postselected in postselect_modes:
-        selected_modes[selected_modes >= postselected] += 1
-    all_selected_modes = np.array(sorted(tuple(selected_modes) + postselect_modes))
-
-    compositions = get_fock_space_basis(len(all_selected_modes), n + 1)
-    diagonal_coefficients = _get_diagonal_coefficients(
-        input_photons=initial_state,
-        interferometer=interferometer,
-        all_modes=all_selected_modes,
-        compositions=compositions,
-    )
-
-    samples = []
-    while len(samples) < shots:
-        sample = []
-
-        postselections = {
-            postselect_modes[i]: postselect_photons[i]
-            for i in range(len(postselect_data[0]))
-        }
-
-        retry = True
-        trial_count = 0
-
-        while retry:
-            trial_count += 1
-
-            if trial_count > max_sample_generation_trials:
-                raise InvalidSimulation(
-                    "Too many trials during sample generation. "
-                    "The specified postselection criteria may be very highly unlikely. "
-                    "Aborting. "
-                    "To increase the limit, set Config.max_sample_generation_trials "
-                    f"to a higher value. Current value: {max_sample_generation_trials}."
-                )
-
-            for mode in selected_modes:
-
-                if mode in postselections:
-                    continue
-
-                cutoff = int(n - np.sum(list(postselections.values())) + 1)
-                outcomes = get_fock_space_basis(1, cutoff)
-                num_postselected_modes = len(postselections.keys())
-                ordered_modes = sorted(list(postselections.keys()) + [mode])
-                current_index = ordered_modes.index(mode)
-
-                outcomes_with_postselection = np.zeros(
-                    (len(outcomes), num_postselected_modes + 1), dtype=np.int64
-                )
-                if num_postselected_modes:
-                    postselected_array = np.array(
-                        [list(postselections.keys()), list(postselections.values())],
-                        dtype=int,
-                    )
-                    postselected_array[0, postselected_array[0, :] < mode] = range(
-                        current_index
-                    )
-                    postselected_array[0, postselected_array[0, :] > mode] = range(
-                        current_index + 1, num_postselected_modes + 1
-                    )
-                    outcomes_with_postselection[:, postselected_array[0]] = np.asarray(
-                        postselected_array[1], dtype=np.int64
-                    )
-                outcomes_with_postselection[:, current_index : current_index + 1] = (
-                    outcomes
-                )
-
-                intermediate_compositions = get_fock_space_basis(
-                    num_postselected_modes + 1, n + 1
-                )
-                intermediate_diagonal = diagonal_coefficients
-                if intermediate_compositions.shape[1] < len(all_selected_modes):
-                    intermediate_compositions_full = np.zeros(
-                        (intermediate_compositions.shape[0], len(all_selected_modes)),
-                        dtype=int,
-                    )
-                    columns_ordering = [
-                        i
-                        for i in range(len(all_selected_modes))
-                        if all_selected_modes[i] in ordered_modes
-                    ]
-                    intermediate_compositions_full[:, columns_ordering] = (
-                        intermediate_compositions
-                    )
-                    intermediate_compositions_dict = {
-                        tuple(row) for row in intermediate_compositions_full
-                    }
-                    relevant_indices = [
-                        i
-                        for i, row in enumerate(compositions)
-                        if tuple(row) in intermediate_compositions_dict
-                    ]
-                    intermediate_diagonal = diagonal_coefficients[relevant_indices]
-
-                indices = cutoff_fock_space_dim_array(
-                    np.arange(n + 2), num_postselected_modes + 1
-                )
-                probabilities = _probabilities_from_diagonal_coefficients(
-                    intermediate_diagonal,
-                    intermediate_compositions,
-                    outcomes_with_postselection,
-                    indices,
-                )
-                if np.all(probabilities == 0):
-                    break
-                probabilities /= np.sum(probabilities)
-
-                n_photons_list = outcomes.flatten()
-                n_photons_probs = probabilities.real
-                positive_probs = np.where(n_photons_probs > 0)
-
-                n_photons = rng.choice(
-                    n_photons_list[positive_probs], p=n_photons_probs[positive_probs]
-                )
-
-                sample.append(n_photons)
-                postselections[mode] = n_photons
-
-            if len(sample) > 0:
-                retry = False
-
-        samples.append(tuple(sample))
-    return samples

--- a/piquasso/_simulators/sampling/utils.py
+++ b/piquasso/_simulators/sampling/utils.py
@@ -13,12 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from collections import defaultdict
 from itertools import product
 import math
 import numpy as np
-from scipy.special import factorial
-from numpy.polynomial.laguerre import lag2poly
+from scipy.special import factorial, comb
 
 from functools import partial
 
@@ -475,88 +473,32 @@ def _calculate_singular_values_matrix_expansion(singular_values_vector):
     return np.diag(expansion_values)
 
 
-def multiply_polynomials(dict_1, dict_2):
+def multiply_polynomials(poly_arr_shape, arr_1, arr_2):
     '''
-        Multiplies two dictionaries of polynomial coefficients.
+        Multiplies two arrays of polynomial coefficients with fft.
     '''
-    if not dict_1:
-        return dict_2
-        
-    new_dict = defaultdict(complex)
+    if arr_1 is None:
+        return arr_2
+    fft_1 = np.fft.fftn(arr_1, poly_arr_shape)
+    fft_2 = np.fft.fftn(arr_2, poly_arr_shape)
+    fft_i = np.fft.ifftn(fft_1 * fft_2)
+    return fft_i
 
-    for exp_1, coeff_1 in dict_1.items():
-        exp_1 = np.asarray(exp_1)
-
-        for exp_2, coeff_2 in dict_2.items():
-            new_dict[tuple(exp_1 + exp_2)] += coeff_1 * coeff_2
-
-    return { exp:coeff for exp, coeff in new_dict.items() if coeff != 0 }
-
-def add_polynomials(dict_1, dict_2):
+def compute_laguerre(k, x, ra):
     '''
-        Adds two dictionaries of polynomial coefficients.
+        Computes the Laguerre series at degree ra and returns an array of its polynomials.
     '''
-    new_dict = defaultdict(complex)
+    coeffs = np.zeros([ra+1]*k, dtype=complex)
 
-    for exp, coeff in dict_1.items():
-        new_dict[exp] += coeff
+    poly_indices = np.indices(coeffs.shape).sum(axis=0)
+    relevant_indices = (poly_indices <= ra)
 
-    for exp, coeff in dict_2.items():
-        new_dict[exp] += coeff
+    coeffs[relevant_indices] = ((-1) ** poly_indices[relevant_indices]) * comb(ra, poly_indices[relevant_indices])
+    alphas = np.where(relevant_indices)
+    for i in range(k):
+        coeffs[relevant_indices] *= x[i]**alphas[i] / factorial(alphas[i])
 
-    return { exp:coeff for exp, coeff in new_dict.items() if coeff != 0 }
-
-def decompositions(d, k):
-    '''
-        Yields all decompositions whose sum is d.
-        For example: decompositions(2, 2) yields
-            [2, 0]
-            [1, 1]
-            [0, 2]
-    '''
-    if k == 1:
-        yield (d,)
-        return
-
-    decomp = np.zeros(k, dtype=int)
-    decomp[0] = d
-
-    while True:
-        yield decomp
-
-        for i in range(k-2, -1, -1):
-            if decomp[i] > 0:
-                break
-            else:
-                return
-
-        decomp[i] -= 1
-        right_sum = decomp[i + 1:].sum() + 1
-        decomp[i + 1:] = 0
-        decomp[i + 1] = right_sum
-
-def compute_laguerre(coeffs, ra, k):
-    '''
-        Computes the Laguerre series at degree ra and returns a dict of its polynomials.
-    '''
-    poly_dict = defaultdict(complex)
-
-    l_coeffs = lag2poly([0] * ra + [1])
-    factorials = np.array([factorial(i) for i in range(ra + 1)])
-
-    for d, ld in enumerate(l_coeffs):
-        if ld == 0:
-            continue
-
-        for alpha in decompositions(d, k):
-            polynomial = factorials[d]
-            for i in alpha:
-                polynomial /= factorials[i]
-
-            coeff = ld * polynomial * np.prod(coeffs**alpha)
-            poly_dict[tuple(alpha)] += coeff
-
-    return { exp:coeff for exp, coeff in poly_dict.items() if coeff != 0 }
+    return coeffs
 
 def generate_k_modes_marginal_sample(modes, n, inputs, interferometer, rng):
     '''
@@ -569,17 +511,21 @@ def generate_k_modes_marginal_sample(modes, n, inputs, interferometer, rng):
 
     V = np.conj(interferometer)[modes, :][:, np.where(inputs!=0)[0]]
     possible_ys = list(product(range(N), repeat=k))
-    D_t = {}
+    poly_arr_shape = [N]*k
+    D_t = np.zeros(poly_arr_shape, dtype=complex)
+
     for y in possible_ys:
-        omegas = np.array([np.exp(2j*np.pi/N)**i for i in y])
+        omegas = [np.exp(2j*np.pi/N)**i for i in y]
         xa = np.array([-np.outer(V[:, a]*omegas, np.conj(V[:, a])*np.power(omegas, -1)) for a in range(s)])
         xa = np.sum(xa, 1)
-        P_omega = {}
-        for a, ra in enumerate(occupied_inputs):
-            res = compute_laguerre(xa[a], ra, k)
-            P_omega = multiply_polynomials(P_omega, res)
-        D_t = add_polynomials(D_t, P_omega)
-    p_zw_diag = { alpha:coeff/N**k for (alpha, coeff) in D_t.items() }
+        P_omega = None
+        for a in range(s):
+            l_ra = compute_laguerre(k, xa[a], occupied_inputs[a])
+            P_omega = multiply_polynomials(poly_arr_shape, P_omega, l_ra)
+        D_t += P_omega
+    D_t /= N**k
+
+    p_zw_diag = { tuple(alpha):D_t[*alpha] for alpha in possible_ys if sum(alpha)<=n }
             
     p_ys = {}
     for y in p_zw_diag.keys():
@@ -589,6 +535,6 @@ def generate_k_modes_marginal_sample(modes, n, inputs, interferometer, rng):
             p_y += np.prod(factorial(alpha)) * p_zw_diag[alpha] * np.prod([math.comb(alpha[j], y[j]) * (-1)**(alpha[j] - y[j]) for j in range(k)])
         if p_y > 0:
             p_ys[y] = p_y
-
-    sample = rng.choice(list(p_ys.keys()), p=[c.real for c in p_ys.values()])
+            
+    sample = rng.choice(list(p_ys.keys()), p=list(p_ys.values()))
     return sample

--- a/piquasso/_simulators/sampling/utils.py
+++ b/piquasso/_simulators/sampling/utils.py
@@ -20,7 +20,7 @@ from functools import partial
 
 from piquasso.api.exceptions import InvalidSimulation
 
-from piquasso._math.combinatorics import partitions, partitions_bounded_k
+from piquasso._math.combinatorics import comb, partitions, partitions_bounded_k
 
 from piquasso._math.fock import get_fock_space_basis
 from .marginal import (
@@ -548,3 +548,28 @@ def generate_marginal_samples(
         samples.append(tuple(particles[mode_offset:]))
 
     return samples
+
+
+def is_direct_marginal_sampling_cheaper(k: int, d: int, n: int) -> bool:
+    """
+    Estimate whether direct marginal sampling is cheaper than full sampling
+    followed by discarding unmeasured modes. The comparison is based on simple
+    cost estimates.
+
+    Direct marginal sampling is dominated by the cost of calculating the marginal
+    probabilities, which is roughly `n * k^2 * sum_{s=0}^n binom(s + k - 1, k - 1)^2`,
+    In the case of full sampling, the cost is roughly `n * 2^n + d * n^2`.
+
+    Here, k is the number of measured modes, d is the total number of modes, and
+    n is the total number of photons.
+    """
+    if k == d:
+        return False
+
+    direct_marginal_cost = (
+        n * k**2 * sum(comb(degree + k - 1, k - 1) ** 2 for degree in range(n + 1))
+    )
+
+    full_sampling_cost = n * 2**n + d * n**2
+
+    return direct_marginal_cost < full_sampling_cost

--- a/piquasso/_simulators/sampling/utils.py
+++ b/piquasso/_simulators/sampling/utils.py
@@ -22,7 +22,11 @@ from piquasso.api.exceptions import InvalidSimulation
 
 from piquasso._math.combinatorics import partitions, partitions_bounded_k
 
-from .marginal import get_marginal_probabilities
+from piquasso._math.fock import get_fock_space_basis
+from .marginal import (
+    _get_diagonal_coefficients,
+    _probabilities_from_diagonal_coefficients,
+)
 
 """
 This is a contribution from `theboss`, see https://github.com/Tomev-CTP/theboss.
@@ -154,6 +158,7 @@ def generate_samples(
     reject_condition,
     postselect_data,
     selected_modes,
+    lossy=False,
 ):
     """
     Generates samples corresponding to the Clifford & Clifford algorithm B from
@@ -179,16 +184,15 @@ def generate_samples(
     Returns:
         The generated samples.
     """
-
-    if len(postselect_data[0]) > 0:
+    if 0 < len(selected_modes) < len(input) and not lossy:
+        return _generate_marginal_samples(
+            input, interferometer, selected_modes, shots, rng, postselect_data
+        )
+    elif len(postselect_data[0]) > 0:
         sample_generator = partial(
             _generate_sample_with_postselect,
             reject_condition=reject_condition,
             postselect_data=postselect_data,
-        )
-    elif 0 < len(selected_modes) < len(input) and not reject_condition:
-        return _generate_marginal_samples(
-            input, interferometer, selected_modes, shots, rng
         )
     else:
         sample_generator = partial(_generate_sample, reject_condition=reject_condition)
@@ -235,6 +239,7 @@ def generate_lossy_samples(
         reject_condition=lambda: False,
         postselect_data=postselect_data,
         selected_modes=selected_modes,
+        lossy=True,
     )
 
     # Trim output state
@@ -488,32 +493,136 @@ def _calculate_singular_values_matrix_expansion(singular_values_vector):
 
 
 def _generate_marginal_samples(
-    initial_state, interferometer, selected_modes, shots, rng
+    initial_state, interferometer, selected_modes, shots, rng, postselect_data
 ):
     """
-    Implements mode-by-mode sampling.
+    Implements mode-by-mode sampling with postselection.
     """
-    if sum(initial_state) == 0:
-        return [(0,) * len(selected_modes)] * shots
+    n = sum(initial_state)
+    k = len(selected_modes)
+
+    if n == 0:
+        return [(0,) * k] * shots
+
+    postselect_modes, postselect_photons, max_sample_generation_trials = postselect_data
+    selected_modes = np.array(selected_modes)
+    for postselected in postselect_modes:
+        selected_modes[selected_modes >= postselected] += 1
+    all_selected_modes = np.array(sorted(tuple(selected_modes) + postselect_modes))
+
+    compositions = get_fock_space_basis(len(all_selected_modes), n + 1)
+    diagonal_coefficients = _get_diagonal_coefficients(
+        input_photons=initial_state,
+        interferometer=interferometer,
+        all_modes=all_selected_modes,
+        compositions=compositions,
+    )
+
     samples = []
     while len(samples) < shots:
-        sample = np.zeros(len(selected_modes), dtype=int)
-        postselections = {}
-        for i_mode, mode in enumerate(selected_modes):
-            probs = get_marginal_probabilities(
-                initial_state,
-                interferometer,
-                tuple(postselections.keys()),
-                tuple(postselections.values()),
-                (mode,),
-            )
-            n_photons_list = np.array(list(probs.keys()))
-            n_photons_probs = np.array(list(probs.values()))
-            positive_probs = np.where(n_photons_probs > 0)
-            n_photons = rng.choice(
-                n_photons_list[positive_probs], p=n_photons_probs[positive_probs]
-            )[0]
-            sample[i_mode] += n_photons
-            postselections[mode] = n_photons
-        samples.append(tuple(sample.tolist()))
+        sample = []
+
+        postselections = {
+            postselect_modes[i]: postselect_photons[i]
+            for i in range(len(postselect_data[0]))
+        }
+
+        retry = True
+        trial_count = 0
+
+        while retry:
+            trial_count += 1
+
+            if trial_count > max_sample_generation_trials:
+                raise InvalidSimulation(
+                    "Too many trials during sample generation. "
+                    "The specified postselection criteria may be very highly unlikely. "
+                    "Aborting. "
+                    "To increase the limit, set Config.max_sample_generation_trials "
+                    f"to a higher value. Current value: {max_sample_generation_trials}."
+                )
+
+            for mode in selected_modes:
+
+                if mode in postselections:
+                    continue
+
+                cutoff = int(n - np.sum(list(postselections.values())) + 1)
+                outcomes = get_fock_space_basis(1, cutoff)
+                num_postselected_modes = len(postselections.keys())
+                ordered_modes = sorted(list(postselections.keys()) + [mode])
+                current_index = ordered_modes.index(mode)
+
+                outcomes_with_postselection = np.zeros(
+                    (len(outcomes), num_postselected_modes + 1), dtype=np.int64
+                )
+                if num_postselected_modes:
+                    postselected_array = np.array(
+                        [list(postselections.keys()), list(postselections.values())],
+                        dtype=int,
+                    )
+                    postselected_array[0, postselected_array[0, :] < mode] = range(
+                        current_index
+                    )
+                    postselected_array[0, postselected_array[0, :] > mode] = range(
+                        current_index + 1, num_postselected_modes + 1
+                    )
+                    outcomes_with_postselection[:, postselected_array[0]] = np.asarray(
+                        postselected_array[1], dtype=np.int64
+                    )
+                outcomes_with_postselection[:, current_index : current_index + 1] = (
+                    outcomes
+                )
+
+                intermediate_compositions = get_fock_space_basis(
+                    num_postselected_modes + 1, n + 1
+                )
+                intermediate_diagonal = diagonal_coefficients
+                if intermediate_compositions.shape[1] < len(all_selected_modes):
+                    intermediate_compositions_full = np.zeros(
+                        (intermediate_compositions.shape[0], len(all_selected_modes)),
+                        dtype=int,
+                    )
+                    columns_ordering = [
+                        i
+                        for i in range(len(all_selected_modes))
+                        if all_selected_modes[i] in ordered_modes
+                    ]
+                    intermediate_compositions_full[:, columns_ordering] = (
+                        intermediate_compositions
+                    )
+                    intermediate_compositions_dict = {
+                        tuple(row) for row in intermediate_compositions_full
+                    }
+                    relevant_indices = [
+                        i
+                        for i, row in enumerate(compositions)
+                        if tuple(row) in intermediate_compositions_dict
+                    ]
+                    intermediate_diagonal = diagonal_coefficients[relevant_indices]
+
+                probabilities = _probabilities_from_diagonal_coefficients(
+                    intermediate_diagonal,
+                    intermediate_compositions,
+                    outcomes_with_postselection,
+                )
+                if np.all(probabilities == 0):
+                    break
+                probabilities /= np.sum(probabilities)
+
+                n_photons_list = outcomes.flatten()
+                n_photons_probs = probabilities.real
+                positive_probs = np.where(n_photons_probs > 0)
+
+                n_photons = rng.choice(
+                    n_photons_list[positive_probs], p=n_photons_probs[positive_probs]
+                )
+
+                sample.append(n_photons)
+                postselections[mode] = n_photons
+
+            if len(sample) > 0:
+                retry = False
+
+        samples.append(tuple(sample))
     return samples

--- a/piquasso/_simulators/sampling/utils.py
+++ b/piquasso/_simulators/sampling/utils.py
@@ -22,6 +22,12 @@ from piquasso.api.exceptions import InvalidSimulation
 
 from piquasso._math.combinatorics import partitions, partitions_bounded_k
 
+from piquasso._math.fock import get_fock_space_basis
+from .marginal import (
+    get_binomial_moments,
+    get_single_marginal_probability_from_binomial_moments,
+)
+
 """
 This is a contribution from `theboss`, see https://github.com/Tomev-CTP/theboss.
 
@@ -469,3 +475,76 @@ def _calculate_singular_values_matrix_expansion(singular_values_vector):
     expansion_values = np.sqrt(vector_of_squared_expansions)
 
     return np.diag(expansion_values)
+
+
+def map_to_original_modes(modes, postselected_modes):
+    modes = np.asarray(modes, dtype=int).copy()
+
+    for postselected in sorted(postselected_modes):
+        modes[modes >= postselected] += 1
+
+    return tuple(modes)
+
+
+def generate_marginal_samples(
+    initial_state, interferometer, modes, shots, rng, postselect_data
+):
+    n = sum(initial_state)
+    k = len(modes)
+
+    postselect_modes = postselect_data[0]
+    postselect_photons = np.asarray(postselect_data[1], dtype=int)
+
+    all_modes = np.array(postselect_modes + modes)
+
+    binomial_moments = get_binomial_moments(
+        input_photons=initial_state,
+        interferometer=interferometer,
+        all_modes=all_modes,
+        compositions=get_fock_space_basis(len(all_modes), n + 1),
+    )
+
+    get_probability = partial(
+        get_single_marginal_probability_from_binomial_moments,
+        n=n,
+        binomial_moments=binomial_moments,
+        d=len(all_modes),
+    )
+
+    postselection_probability = get_probability(particles=postselect_photons)
+
+    particle_offset = sum(postselect_photons)
+    mode_offset = len(postselect_photons)
+
+    samples = []
+
+    for _ in range(shots):
+        previous_probability = postselection_probability
+        remaining_particles = n - particle_offset
+
+        particles = np.concatenate([postselect_photons, np.zeros(k, dtype=int)])
+
+        for mode_idx in range(k):
+            threshold = rng.random()
+
+            cumulative_probability = 0.0
+
+            total_mode_idx = mode_offset + mode_idx
+
+            for photon_number in range(remaining_particles + 1):
+                particles[total_mode_idx] = photon_number
+
+                probability = get_probability(particles=particles[: total_mode_idx + 1])
+
+                conditional_probability = probability / previous_probability
+                cumulative_probability += conditional_probability
+
+                if cumulative_probability >= threshold:
+                    break
+
+            remaining_particles -= photon_number
+            previous_probability = probability
+
+        samples.append(tuple(particles[mode_offset:]))
+
+    return samples

--- a/piquasso/_simulators/sampling/utils.py
+++ b/piquasso/_simulators/sampling/utils.py
@@ -153,6 +153,7 @@ def generate_samples(
     rng,
     reject_condition,
     postselect_data,
+    selected_modes,
 ):
     """
     Generates samples corresponding to the Clifford & Clifford algorithm B from
@@ -178,7 +179,17 @@ def generate_samples(
     Returns:
         The generated samples.
     """
+    n = np.sum(input)
+    k = len(selected_modes)
 
+    if k == 1 and n>=3 and n<10:
+        return _generate_marginal_samples(
+            input, 
+            shots, 
+            interferometer, 
+            rng, 
+            selected_modes,
+            n)
     if len(postselect_data[0]) > 0:
         sample_generator = partial(
             _generate_sample_with_postselect,
@@ -195,6 +206,8 @@ def generate_samples(
         sample_generator=sample_generator,
         interferometer=interferometer,
         rng=rng,
+        selected_modes=selected_modes,
+        n=n,
     )
 
 
@@ -205,6 +218,7 @@ def generate_lossy_samples(
     interferometer_svd,
     rng,
     postselect_data,
+    selected_modes,
 ):
     """
     Basically the same algorithm as in `generate_samples`, but doubles the system size
@@ -227,6 +241,7 @@ def generate_lossy_samples(
         rng,
         reject_condition=lambda: False,
         postselect_data=postselect_data,
+        selected_modes=selected_modes,
     )
 
     # Trim output state
@@ -248,10 +263,9 @@ def _get_first_quantized(occupation_numbers):
 
 
 def _generate_samples(
-    input, shots, calculate_permanent_laplace, interferometer, sample_generator, rng
+    input, shots, calculate_permanent_laplace, interferometer, sample_generator, rng, selected_modes, n
 ):
     d = len(input)
-    n = np.sum(input)
 
     samples = []
 
@@ -267,7 +281,7 @@ def _generate_samples(
             rng=rng,
         )
         samples.append(tuple(sample))
-
+    samples = [ tuple(sample[mode] for mode in selected_modes) for sample in samples ]
     return samples
 
 
@@ -473,6 +487,20 @@ def _calculate_singular_values_matrix_expansion(singular_values_vector):
     return np.diag(expansion_values)
 
 
+def _generate_marginal_samples(
+        input, shots, interferometer, rng, selected_modes, n
+):
+    '''
+        Generates multiple samples with specified selected modes.
+    '''
+    samples = []
+
+    while len(samples) < shots:
+        sample = _generate_marginal_sample(selected_modes, n, input, interferometer, rng)
+        samples.append(tuple(sample))
+
+    return samples
+
 def multiply_polynomials(poly_arr_shape, arr):
     '''
         Multiplies arrays of polynomial coefficients with fft.
@@ -507,7 +535,7 @@ def compute_laguerre(k, x, ra):
         coeffs[:, i, relevant_indices] = poly_coeffs
     return coeffs
 
-def generate_k_modes_marginal_sample(modes, n, inputs, interferometer, rng):
+def _generate_marginal_sample(modes, n, inputs, interferometer, rng):
     '''
         Implements sampling when k-modes have been selected for measurement.
     '''
@@ -515,7 +543,7 @@ def generate_k_modes_marginal_sample(modes, n, inputs, interferometer, rng):
     occupied_inputs = inputs[inputs!=0]
     s = len(occupied_inputs)
     if s == 0:
-        return [0]*k
+        return np.zeros(k, dtype=int)
     N = n+1
 
     V = np.conj(interferometer)[modes, :][:, np.where(inputs!=0)[0]]

--- a/piquasso/_simulators/sampling/utils.py
+++ b/piquasso/_simulators/sampling/utils.py
@@ -473,33 +473,38 @@ def _calculate_singular_values_matrix_expansion(singular_values_vector):
     return np.diag(expansion_values)
 
 
-def multiply_polynomials(poly_arr_shape, arr_1, arr_2):
+def multiply_polynomials(poly_arr_shape, arr):
     '''
-        Multiplies two arrays of polynomial coefficients with fft.
+        Multiplies arrays of polynomial coefficients with fft.
     '''
-    if arr_1 is None:
-        return arr_2
-    concerned_axes = range(1, len(arr_1.shape))
-    fft_1 = np.fft.fftn(arr_1, poly_arr_shape, axes=concerned_axes)
-    fft_2 = np.fft.fftn(arr_2, poly_arr_shape, axes=concerned_axes)
-    fft_i = np.fft.ifftn(fft_1 * fft_2, axes=concerned_axes)
-    return fft_i
+    fft_arr = np.fft.fftn(arr, poly_arr_shape, axes=range(2, len(arr.shape)))
+    prod_arr = np.prod(fft_arr, axis=1)
+    ifft_arr = np.fft.ifftn(prod_arr, axes=range(1, len(prod_arr.shape)))
+    return ifft_arr
 
 def compute_laguerre(k, x, ra):
     '''
         Computes the Laguerre series at degree ra and returns an array of its polynomials.
     '''
-    coeffs = np.zeros([x.shape[0]]+[ra+1]*k, dtype=complex)
+    max_deg = max(ra)+1
+    poly_arr_shape = [max_deg]*k
+    coeffs = np.zeros([x.shape[0], x.shape[1]]+poly_arr_shape, dtype=complex)
 
-    poly_indices = np.indices(coeffs[0].shape).sum(axis=0)
-    relevant_indices = (poly_indices <= ra)
+    alphas = np.indices(poly_arr_shape,)
+    poly_indices = alphas.sum(axis=0)
 
-    coeffs[:, relevant_indices] = ((-1) ** poly_indices[relevant_indices]) * comb(ra, poly_indices[relevant_indices])
-    alphas = np.array(np.where(relevant_indices))
-    alphas = np.repeat(alphas[None,...], x.shape[0], axis=0)
-    for i in range(k):
-        coeffs[:, relevant_indices] *= x[:, i].reshape((-1,1))**alphas[:, i] / factorial(alphas[:, i])
+    fact = factorial(np.arange(max_deg))
+    for i, a in enumerate(ra):
+        relevant_indices = (poly_indices <= a)
 
+        alpha_i = alphas[:, relevant_indices]
+        poly_values = poly_indices[relevant_indices]
+
+        poly_coeffs = ((-1) ** poly_values) * comb(a, poly_values)
+        for j in range(k):
+            poly_coeffs = poly_coeffs[None, :] * x[:, i, j:j+1] ** alpha_i[j] / fact[alpha_i[j]]
+
+        coeffs[:, i, relevant_indices] = poly_coeffs
     return coeffs
 
 def generate_k_modes_marginal_sample(modes, n, inputs, interferometer, rng):
@@ -518,12 +523,13 @@ def generate_k_modes_marginal_sample(modes, n, inputs, interferometer, rng):
     
     poly_arr_shape = [N]*k
     omegas = np.exp(2j * np.pi / N) ** all_ys
-    P_omega = None
-    for a in range(s):
-        xa = np.einsum('ni,nj->nij', V[:, a]*omegas, np.conj(V[:, a])*np.power(omegas, -1))
-        xa = np.sum(-xa, axis=1)
-        l_ra = compute_laguerre(k, xa, occupied_inputs[a])
-        P_omega = multiply_polynomials(poly_arr_shape, P_omega, l_ra)
+    
+    faz = V.T[:, None, :]*omegas[None,...]
+    faw = np.conj(V).T[:, None, :]*np.power(omegas, -1)[None,...]
+    xa = np.einsum('nmi,nmj->mnij', faz, faw)
+    xa = np.sum(-xa, axis=2)
+    l_ra = compute_laguerre(k, xa, occupied_inputs)
+    P_omega = multiply_polynomials(poly_arr_shape, l_ra)
     D_t = np.sum(P_omega, axis=0)
     D_t /= N**k
 

--- a/piquasso/_simulators/sampling/utils.py
+++ b/piquasso/_simulators/sampling/utils.py
@@ -501,36 +501,17 @@ def _generate_k_modes_samples(
 
     return samples
 
-def _get_non_empty_alphas(poly, N, k, d):
+def _get_support_points(alphas_to_indices, N, k, P, Q):
     '''
-        Retrieves the non empty indices in the polynomial array and their corresponding (alpha, beta).
+        Finds the points to evaluate in R based on the non-empty alphas in P and Q.
     '''
-    indices = {}
-    alphas = []
-    while len(alphas)<poly.shape[0]:
-        alphas = [alpha for alpha in product(range(N), repeat=k) if sum(alpha) <= d]
-        d+=1
-    for i in range(len(alphas)):
-        for j in range(len(alphas)):
-            indices[(i, j)] = alphas[i]+alphas[j]
-    non_empty = np.array(np.where(poly)).T.tolist()
-    S = {tuple(i): np.array(indices[tuple(i)]) for i in non_empty}
-    return S
-
-def _get_support_points(alphas_to_indices, N, k, d, P,Q):
-    '''
-        Finds the points to evaluate in R based on the non-empty points in P and Q.
-    '''
-    SP = _get_non_empty_alphas(P, N, k, d[0])
-    SQ = _get_non_empty_alphas(Q, N, k, d[1])
-
     X = set()
-    for a in SP.values():
-        for b in SQ.values():
-            new_tuple = tuple(a+b)
-            if sum(new_tuple[:k]) == sum(new_tuple[k:]) and sum(new_tuple[:k])<N:
-                X.add(alphas_to_indices[new_tuple])
-    return sorted(X), SP, SQ
+    for alpha_beta_P in P.keys():
+        for alpha_beta_Q in Q.keys():
+            new_alpha_beta = tuple([sum(x) for x in zip(alpha_beta_P,alpha_beta_Q)])
+            if sum(new_alpha_beta[:k]) == sum(new_alpha_beta[k:]) and sum(new_alpha_beta[:k])<N:
+                X.add(alphas_to_indices[new_alpha_beta])
+    return sorted(X)
 
 def _build_exponent(alpha, N):
     '''
@@ -547,14 +528,15 @@ def _build_kronecker_exponents(N, max_exponent, row_exponent, col_exponent):
     '''
     return _build_exponent(row_exponent, N) + max_exponent * _build_exponent(col_exponent, N)
 
-def _set_evaluation_points(all_ys, X, N, d):
+def _set_evaluation_points(all_ys, X, N):
     '''
         Creates the set of T pairwise distinct omega points. 
     '''
-    max_exponent = max(_build_exponent(alpha, N) for alpha in all_ys)
-    T = max_exponent**2
+    max_exponent = max([_build_exponent(alpha, N) for alpha in all_ys])
+    exponents = [_build_kronecker_exponents(N, max_exponent, all_ys[r], all_ys[c]) for r, c in X]
+    T = max(exponents)+1
     omega = np.exp(2j * np.pi / T)
-    points = np.array([omega ** _build_kronecker_exponents(N, max_exponent, all_ys[r], all_ys[c]) for r, c in X])
+    points = np.array(omega ** exponents)
     return points
 
 def _build_V_matrix(points):
@@ -567,37 +549,31 @@ def _build_V_matrix(points):
         for i in range(s)
     ])
 
-def _project_coefficients(indices_to_alphas, X, poly, poly_support):
+def _project_coefficients(indices_to_alphas, X, poly):
     '''
         Gets the polynomial's coefficients at the support X alphas.
     '''
-    coeffs = {tuple(alpha):poly[index[0], [index[1]]][0] for index, alpha in poly_support.items()}
-    return np.array([coeffs.get(indices_to_alphas[i], 0) for i in X])
+    return np.array([poly.get(indices_to_alphas[i], 0) for i in X])
 
-def _multiply_polynomials(all_ys, alphas_to_indices, indices_to_alphas, P, Q, N, k, d, return_dense=False):
+def _multiply_polynomials(all_ys, alphas_to_indices, indices_to_alphas, P, Q, N, k):
     '''
-        Multiplies arrays of polynomial coefficients using "Sparse polynomial multiplication" algorithm by Joris van der Hoeven.
+        Multiplies polynomial coefficients using "Sparse polynomial multiplication" algorithm by Joris van der Hoeven.
     '''
-    X, SP, SQ = _get_support_points(alphas_to_indices, N, k, d, P,Q)
-    points = _set_evaluation_points(all_ys, X, N, d)
+    X = _get_support_points(alphas_to_indices, N, k, P, Q)
+    points = _set_evaluation_points(all_ys, X, N)
 
     V = _build_V_matrix(points)
     V_inv = np.linalg.pinv(V)
 
-    p = _project_coefficients(indices_to_alphas, X, P, SP)
-    q = _project_coefficients(indices_to_alphas, X, Q, SQ)
+    p = _project_coefficients(indices_to_alphas, X, P)
+    q = _project_coefficients(indices_to_alphas, X, Q)
     
     EP = V @ p
     EQ = V @ q
     ER = EP * EQ
     R_vals = V_inv @ ER
 
-    if return_dense:
-        R = np.zeros((X[-1][0]+1, X[-1][0]+1), dtype=complex)
-        X = tuple(np.array(X).T)
-        R[X] = R_vals
-        return R
-    return R_vals
+    return { indices_to_alphas[X[i]]: R_vals[i].real for i in range(len(X)) if R_vals[i].real > 0.0 }
 
 def _compute_degree(degree, alphas_by_degree, powers_by_degree, x):
     '''
@@ -633,15 +609,15 @@ def _compute_laguerre(x, d, k):
         powers_by_degree[degree] = _compute_degree(degree, alphas_by_degree, powers_by_degree, x)
 
     coeffs = [(-1) ** j * comb(d, j) / factorial(j) for j in range(d + 1)]
-    current_alphas = [alpha for alpha in product(range(d + 1), repeat=k) if sum(alpha) <= d]
-    indices = {alpha: i for i, alpha in enumerate(current_alphas)}
-    l_ra = np.zeros((len(current_alphas), len(current_alphas)))
+    l_ra = {}
     for degree in range(d + 1):
         power_block = coeffs[degree] * powers_by_degree[degree]
         degree_alphas = alphas_by_degree[degree]
         for i, row in enumerate(degree_alphas):
             for j, col in enumerate(degree_alphas):
-                l_ra[indices[row], indices[col]] = power_block[i, j].real
+                coeff = power_block[i, j].real
+                if coeff != 0.0:
+                    l_ra[(row + col)] = coeff
     return l_ra
 
 def _generate_k_modes_sample(modes, n, inputs, interferometer, rng):
@@ -671,14 +647,12 @@ def _generate_k_modes_sample(modes, n, inputs, interferometer, rng):
 
     polys = deque([], maxlen=2)
     for a in range(s):
-        R = _compute_laguerre(xa[a], occupied_inputs[a], k)
-        polys.append(R)
+        l_ra = _compute_laguerre(xa[a], occupied_inputs[a], k)
+        polys.append(l_ra)
         if len(polys) == 2:
-            R = _multiply_polynomials(all_ys, alphas_to_indices, indices_to_alphas, polys[0], polys[1], N, k, (sum(occupied_inputs[:a]), occupied_inputs[a]), return_dense=True)
-            polys.append(R)
-
-    diag = np.diag(R).real
-    p_zw_diag = {indices_to_alphas[i, i][:k]:coeff for i, coeff in enumerate(diag)}
+            X_R = _multiply_polynomials(all_ys, alphas_to_indices, indices_to_alphas, polys[0], polys[1], N, k)
+            polys.append(X_R)
+    p_zw_diag = {alpha_beta[:k]:coeff for alpha_beta, coeff in polys[-1].items() if alpha_beta[:k] == alpha_beta[k:]}
 
     p_ys = {}
     for y in p_zw_diag.keys():

--- a/piquasso/_simulators/sampling/utils.py
+++ b/piquasso/_simulators/sampling/utils.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from collections import defaultdict
+from itertools import product
 import math
 import numpy as np
 from scipy.special import factorial
@@ -475,38 +475,31 @@ def _calculate_singular_values_matrix_expansion(singular_values_vector):
     return np.diag(expansion_values)
 
 
-def update_coefficients(current_coeffs, new_coeffs):
-    '''
-        Merges two dictionaries of polynomial coefficients.
-    '''
-    new_dict = defaultdict(complex)
-    for (prev_z_exp, prev_w_exp), prev_coeff in current_coeffs.items():
-        for (new_z_exp, new_wb_exp), new_coeff in new_coeffs.items():
-            new_z = tuple(i+j for i,j in zip(prev_z_exp, new_z_exp))
-            new_w = tuple(i+j for i,j in zip(prev_w_exp, new_wb_exp))
-            new_dict[(new_z, new_w)] += prev_coeff*new_coeff
-    return dict(new_dict)
-
-def generate_k_modes_marginal_sample(modes, inputs, interferometer, rng):
+def generate_k_modes_marginal_sample(modes, n, inputs, interferometer, rng):
     '''
         Implements sampling when k-modes have been selected for measurement.
     '''
     k = len(modes)
     occupied_inputs = inputs[inputs!=0]
     s = len(occupied_inputs)
+    N = n+1
 
     V = np.conj(interferometer)[modes, :][:, np.where(inputs!=0)[0]]
-    symbols_list = list(symbols(f'z1:{k+1}'))+list(symbols(f'w1:{k+1}'))
-    p_zw_dict = {(tuple([0]*k), tuple([0]*k)): 1.0}
-    for a in range(s): 
-        faz = sum([V[j][a]*symbols(f'z{j+1}') for j in range(k)]) 
-        faw_conj = sum([np.conj(V[j][a])*symbols(f'w{j+1}') for j in range(k)]) 
-        xa = -faz * faw_conj
-        l_ra = laguerre(occupied_inputs[a], xa)
-        poly_ra = Poly(l_ra, *symbols_list)
-        coeff_dict = { (exponents[:k], exponents[k:]):coeff for exponents, coeff in poly_ra.terms() }
-        p_zw_dict = update_coefficients(p_zw_dict, coeff_dict)
-    p_zw_diag = { z_exp:coeff for (z_exp, w_exp), coeff in p_zw_dict.items() if z_exp == w_exp }
+    t = symbols(f't1:{k+1}')
+    possible_ys = list(product(range(N), repeat=k))
+    D_t = 0
+    for y in possible_ys:
+        omegas = [np.exp(2j*np.pi/N)**i for i in y]
+        P_omega = 1
+        for a in range(s):
+            faz = sum([V[j][a]*t[j]*omegas[j] for j in range(k)]) 
+            faw_conj = sum([np.conj(V[j][a])*omegas[j]**(-1) for j in range(k)]) 
+            xa = -faz * faw_conj
+            l_ra = laguerre(occupied_inputs[a], xa)
+            P_omega *= l_ra
+        D_t += P_omega
+    D_t /= N**k
+    p_zw_diag = { alpha:complex(coeff) for alpha, coeff in Poly(D_t).terms() }
             
     p_ys = {}
     for y in p_zw_diag.keys():

--- a/piquasso/_simulators/sampling/utils.py
+++ b/piquasso/_simulators/sampling/utils.py
@@ -22,6 +22,8 @@ from piquasso.api.exceptions import InvalidSimulation
 
 from piquasso._math.combinatorics import partitions, partitions_bounded_k
 
+from .marginal import get_marginal_probabilities
+
 """
 This is a contribution from `theboss`, see https://github.com/Tomev-CTP/theboss.
 
@@ -151,6 +153,7 @@ def generate_samples(
     rng,
     reject_condition,
     postselect_data,
+    selected_modes,
 ):
     """
     Generates samples corresponding to the Clifford & Clifford algorithm B from
@@ -183,6 +186,10 @@ def generate_samples(
             reject_condition=reject_condition,
             postselect_data=postselect_data,
         )
+    elif 0 < len(selected_modes) < len(input) and not reject_condition:
+        return _generate_marginal_samples(
+            input, interferometer, selected_modes, shots, rng
+        )
     else:
         sample_generator = partial(_generate_sample, reject_condition=reject_condition)
 
@@ -193,6 +200,7 @@ def generate_samples(
         sample_generator=sample_generator,
         interferometer=interferometer,
         rng=rng,
+        selected_modes=selected_modes,
     )
 
 
@@ -203,6 +211,7 @@ def generate_lossy_samples(
     interferometer_svd,
     rng,
     postselect_data,
+    selected_modes,
 ):
     """
     Basically the same algorithm as in `generate_samples`, but doubles the system size
@@ -225,6 +234,7 @@ def generate_lossy_samples(
         rng,
         reject_condition=lambda: False,
         postselect_data=postselect_data,
+        selected_modes=selected_modes,
     )
 
     # Trim output state
@@ -246,7 +256,13 @@ def _get_first_quantized(occupation_numbers):
 
 
 def _generate_samples(
-    input, shots, calculate_permanent_laplace, interferometer, sample_generator, rng
+    input,
+    shots,
+    calculate_permanent_laplace,
+    interferometer,
+    sample_generator,
+    rng,
+    selected_modes,
 ):
     d = len(input)
     n = np.sum(input)
@@ -265,7 +281,7 @@ def _generate_samples(
             rng=rng,
         )
         samples.append(tuple(sample))
-
+    samples = [tuple(sample[mode] for mode in selected_modes) for sample in samples]
     return samples
 
 
@@ -469,3 +485,35 @@ def _calculate_singular_values_matrix_expansion(singular_values_vector):
     expansion_values = np.sqrt(vector_of_squared_expansions)
 
     return np.diag(expansion_values)
+
+
+def _generate_marginal_samples(
+    initial_state, interferometer, selected_modes, shots, rng
+):
+    """
+    Implements mode-by-mode sampling.
+    """
+    if sum(initial_state) == 0:
+        return [(0,) * len(selected_modes)] * shots
+    samples = []
+    while len(samples) < shots:
+        sample = np.zeros(len(selected_modes), dtype=int)
+        postselections = {}
+        for i_mode, mode in enumerate(selected_modes):
+            probs = get_marginal_probabilities(
+                initial_state,
+                interferometer,
+                tuple(postselections.keys()),
+                tuple(postselections.values()),
+                (mode,),
+            )
+            n_photons_list = np.array(list(probs.keys()))
+            n_photons_probs = np.array(list(probs.values()))
+            positive_probs = np.where(n_photons_probs > 0)
+            n_photons = rng.choice(
+                n_photons_list[positive_probs], p=n_photons_probs[positive_probs]
+            )[0]
+            sample[i_mode] += n_photons
+            postselections[mode] = n_photons
+        samples.append(tuple(sample.tolist()))
+    return samples

--- a/piquasso/_simulators/sampling/utils.py
+++ b/piquasso/_simulators/sampling/utils.py
@@ -509,13 +509,15 @@ def generate_k_modes_marginal_sample(modes, n, inputs, interferometer, rng):
     k = len(modes)
     occupied_inputs = inputs[inputs!=0]
     s = len(occupied_inputs)
+    if s == 0:
+        return [0]*k
     N = n+1
 
     V = np.conj(interferometer)[modes, :][:, np.where(inputs!=0)[0]]
-    possible_ys = list(product(range(N), repeat=k))
+    all_ys = np.array(list(product(range(N), repeat=k)))
     
     poly_arr_shape = [N]*k
-    omegas = np.array([[np.exp(2j*np.pi/N)**i for i in y] for y in possible_ys])
+    omegas = np.exp(2j * np.pi / N) ** all_ys
     P_omega = None
     for a in range(s):
         xa = np.einsum('ni,nj->nij', V[:, a]*omegas, np.conj(V[:, a])*np.power(omegas, -1))
@@ -525,16 +527,25 @@ def generate_k_modes_marginal_sample(modes, n, inputs, interferometer, rng):
     D_t = np.sum(P_omega, axis=0)
     D_t /= N**k
 
-    p_zw_diag = { tuple(alpha):D_t[*alpha] for alpha in possible_ys if sum(alpha)<=n }
+    poly_indices = np.indices(D_t.shape).sum(axis=0)
+    possible_ys = np.argwhere(poly_indices <= n)
+    superior_ys = np.all(possible_ys[:, None, :] >= possible_ys[None, :, :], axis=2)
 
-    p_ys = {}
-    for y in p_zw_diag.keys():
-        p_y = 0
-        superior_ys = [alpha for alpha in p_zw_diag.keys() if (np.array(alpha) >= np.array(y)).all()]
-        for alpha in superior_ys:
-            p_y += np.prod(factorial(alpha)) * p_zw_diag[alpha] * np.prod([math.comb(alpha[j], y[j]) * (-1)**(alpha[j] - y[j]) for j in range(k)])
-        if p_y > 0:
-            p_ys[y] = p_y
-            
-    sample = rng.choice(list(p_ys.keys()), p=list(p_ys.values()))
+    fact = factorial(np.arange(N))
+    P_alpha_factorial = np.prod(fact[possible_ys], axis=1) * D_t[*possible_ys.T]
+
+    combination_alpha_y = np.zeros((N, N))
+    for alpha in range(N):
+        for y in range(alpha + 1):
+            combination_alpha_y[alpha, y] = math.comb(alpha, y) * (-1) ** (alpha - y)
+
+    Y = len(possible_ys)
+    coeffs = np.ones((Y, Y))
+    for j in range(possible_ys.shape[1]):
+        coeffs *= combination_alpha_y[possible_ys[:, j][:, None], possible_ys[:, j][None, :]]
+    coeffs *= superior_ys
+    p_ys = (P_alpha_factorial @ coeffs).real
+
+    positive_probs = np.where(p_ys>0)
+    sample = rng.choice(possible_ys[positive_probs], p=p_ys[positive_probs])
     return sample

--- a/piquasso/_simulators/sampling/utils.py
+++ b/piquasso/_simulators/sampling/utils.py
@@ -13,12 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from collections import defaultdict
 from itertools import product
 import math
 import numpy as np
 from scipy.special import factorial
-from sympy import symbols, Poly
-from sympy.functions.special.polynomials import laguerre
+from numpy.polynomial.laguerre import lag2poly
 
 from functools import partial
 
@@ -475,6 +475,89 @@ def _calculate_singular_values_matrix_expansion(singular_values_vector):
     return np.diag(expansion_values)
 
 
+def multiply_polynomials(dict_1, dict_2):
+    '''
+        Multiplies two dictionaries of polynomial coefficients.
+    '''
+    if not dict_1:
+        return dict_2
+        
+    new_dict = defaultdict(complex)
+
+    for exp_1, coeff_1 in dict_1.items():
+        exp_1 = np.asarray(exp_1)
+
+        for exp_2, coeff_2 in dict_2.items():
+            new_dict[tuple(exp_1 + exp_2)] += coeff_1 * coeff_2
+
+    return { exp:coeff for exp, coeff in new_dict.items() if coeff != 0 }
+
+def add_polynomials(dict_1, dict_2):
+    '''
+        Adds two dictionaries of polynomial coefficients.
+    '''
+    new_dict = defaultdict(complex)
+
+    for exp, coeff in dict_1.items():
+        new_dict[exp] += coeff
+
+    for exp, coeff in dict_2.items():
+        new_dict[exp] += coeff
+
+    return { exp:coeff for exp, coeff in new_dict.items() if coeff != 0 }
+
+def decompositions(d, k):
+    '''
+        Yields all decompositions whose sum is d.
+        For example: decompositions(2, 2) yields
+            [2, 0]
+            [1, 1]
+            [0, 2]
+    '''
+    if k == 1:
+        yield (d,)
+        return
+
+    decomp = np.zeros(k, dtype=int)
+    decomp[0] = d
+
+    while True:
+        yield decomp
+
+        for i in range(k-2, -1, -1):
+            if decomp[i] > 0:
+                break
+            else:
+                return
+
+        decomp[i] -= 1
+        right_sum = decomp[i + 1:].sum() + 1
+        decomp[i + 1:] = 0
+        decomp[i + 1] = right_sum
+
+def compute_laguerre(coeffs, ra, k):
+    '''
+        Computes the Laguerre series at degree ra and returns a dict of its polynomials.
+    '''
+    poly_dict = defaultdict(complex)
+
+    l_coeffs = lag2poly([0] * ra + [1])
+    factorials = np.array([factorial(i) for i in range(ra + 1)])
+
+    for d, ld in enumerate(l_coeffs):
+        if ld == 0:
+            continue
+
+        for alpha in decompositions(d, k):
+            polynomial = factorials[d]
+            for i in alpha:
+                polynomial /= factorials[i]
+
+            coeff = ld * polynomial * np.prod(coeffs**alpha)
+            poly_dict[tuple(alpha)] += coeff
+
+    return { exp:coeff for exp, coeff in poly_dict.items() if coeff != 0 }
+
 def generate_k_modes_marginal_sample(modes, n, inputs, interferometer, rng):
     '''
         Implements sampling when k-modes have been selected for measurement.
@@ -485,21 +568,18 @@ def generate_k_modes_marginal_sample(modes, n, inputs, interferometer, rng):
     N = n+1
 
     V = np.conj(interferometer)[modes, :][:, np.where(inputs!=0)[0]]
-    t = symbols(f't1:{k+1}')
     possible_ys = list(product(range(N), repeat=k))
-    D_t = 0
+    D_t = {}
     for y in possible_ys:
-        omegas = [np.exp(2j*np.pi/N)**i for i in y]
-        P_omega = 1
-        for a in range(s):
-            faz = sum([V[j][a]*t[j]*omegas[j] for j in range(k)]) 
-            faw_conj = sum([np.conj(V[j][a])*omegas[j]**(-1) for j in range(k)]) 
-            xa = -faz * faw_conj
-            l_ra = laguerre(occupied_inputs[a], xa)
-            P_omega *= l_ra
-        D_t += P_omega
-    D_t /= N**k
-    p_zw_diag = { alpha:complex(coeff) for alpha, coeff in Poly(D_t).terms() }
+        omegas = np.array([np.exp(2j*np.pi/N)**i for i in y])
+        xa = np.array([-np.outer(V[:, a]*omegas, np.conj(V[:, a])*np.power(omegas, -1)) for a in range(s)])
+        xa = np.sum(xa, 1)
+        P_omega = {}
+        for a, ra in enumerate(occupied_inputs):
+            res = compute_laguerre(xa[a], ra, k)
+            P_omega = multiply_polynomials(P_omega, res)
+        D_t = add_polynomials(D_t, P_omega)
+    p_zw_diag = { alpha:coeff/N**k for (alpha, coeff) in D_t.items() }
             
     p_ys = {}
     for y in p_zw_diag.keys():
@@ -509,6 +589,6 @@ def generate_k_modes_marginal_sample(modes, n, inputs, interferometer, rng):
             p_y += np.prod(factorial(alpha)) * p_zw_diag[alpha] * np.prod([math.comb(alpha[j], y[j]) * (-1)**(alpha[j] - y[j]) for j in range(k)])
         if p_y > 0:
             p_ys[y] = p_y
-            
-    sample = rng.choice(list(p_ys.keys()), p=list(p_ys.values()))
+
+    sample = rng.choice(list(p_ys.keys()), p=[c.real for c in p_ys.values()])
     return sample

--- a/piquasso/_simulators/sampling/utils.py
+++ b/piquasso/_simulators/sampling/utils.py
@@ -479,24 +479,26 @@ def multiply_polynomials(poly_arr_shape, arr_1, arr_2):
     '''
     if arr_1 is None:
         return arr_2
-    fft_1 = np.fft.fftn(arr_1, poly_arr_shape)
-    fft_2 = np.fft.fftn(arr_2, poly_arr_shape)
-    fft_i = np.fft.ifftn(fft_1 * fft_2)
+    concerned_axes = range(1, len(arr_1.shape))
+    fft_1 = np.fft.fftn(arr_1, poly_arr_shape, axes=concerned_axes)
+    fft_2 = np.fft.fftn(arr_2, poly_arr_shape, axes=concerned_axes)
+    fft_i = np.fft.ifftn(fft_1 * fft_2, axes=concerned_axes)
     return fft_i
 
 def compute_laguerre(k, x, ra):
     '''
         Computes the Laguerre series at degree ra and returns an array of its polynomials.
     '''
-    coeffs = np.zeros([ra+1]*k, dtype=complex)
+    coeffs = np.zeros([x.shape[0]]+[ra+1]*k, dtype=complex)
 
-    poly_indices = np.indices(coeffs.shape).sum(axis=0)
+    poly_indices = np.indices(coeffs[0].shape).sum(axis=0)
     relevant_indices = (poly_indices <= ra)
 
-    coeffs[relevant_indices] = ((-1) ** poly_indices[relevant_indices]) * comb(ra, poly_indices[relevant_indices])
-    alphas = np.where(relevant_indices)
+    coeffs[:, relevant_indices] = ((-1) ** poly_indices[relevant_indices]) * comb(ra, poly_indices[relevant_indices])
+    alphas = np.array(np.where(relevant_indices))
+    alphas = np.repeat(alphas[None,...], x.shape[0], axis=0)
     for i in range(k):
-        coeffs[relevant_indices] *= x[i]**alphas[i] / factorial(alphas[i])
+        coeffs[:, relevant_indices] *= x[:, i].reshape((-1,1))**alphas[:, i] / factorial(alphas[:, i])
 
     return coeffs
 
@@ -511,22 +513,20 @@ def generate_k_modes_marginal_sample(modes, n, inputs, interferometer, rng):
 
     V = np.conj(interferometer)[modes, :][:, np.where(inputs!=0)[0]]
     possible_ys = list(product(range(N), repeat=k))
+    
     poly_arr_shape = [N]*k
-    D_t = np.zeros(poly_arr_shape, dtype=complex)
-
-    for y in possible_ys:
-        omegas = [np.exp(2j*np.pi/N)**i for i in y]
-        xa = np.array([-np.outer(V[:, a]*omegas, np.conj(V[:, a])*np.power(omegas, -1)) for a in range(s)])
-        xa = np.sum(xa, 1)
-        P_omega = None
-        for a in range(s):
-            l_ra = compute_laguerre(k, xa[a], occupied_inputs[a])
-            P_omega = multiply_polynomials(poly_arr_shape, P_omega, l_ra)
-        D_t += P_omega
+    omegas = np.array([[np.exp(2j*np.pi/N)**i for i in y] for y in possible_ys])
+    P_omega = None
+    for a in range(s):
+        xa = np.einsum('ni,nj->nij', V[:, a]*omegas, np.conj(V[:, a])*np.power(omegas, -1))
+        xa = np.sum(-xa, axis=1)
+        l_ra = compute_laguerre(k, xa, occupied_inputs[a])
+        P_omega = multiply_polynomials(poly_arr_shape, P_omega, l_ra)
+    D_t = np.sum(P_omega, axis=0)
     D_t /= N**k
 
     p_zw_diag = { tuple(alpha):D_t[*alpha] for alpha in possible_ys if sum(alpha)<=n }
-            
+
     p_ys = {}
     for y in p_zw_diag.keys():
         p_y = 0

--- a/piquasso/_simulators/sampling/utils.py
+++ b/piquasso/_simulators/sampling/utils.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from collections import defaultdict
 import math
 import numpy as np
 from scipy.special import factorial
@@ -474,6 +475,18 @@ def _calculate_singular_values_matrix_expansion(singular_values_vector):
     return np.diag(expansion_values)
 
 
+def update_coefficients(current_coeffs, new_coeffs):
+    '''
+        Merges two dictionaries of polynomial coefficients.
+    '''
+    new_dict = defaultdict(complex)
+    for (prev_z_exp, prev_w_exp), prev_coeff in current_coeffs.items():
+        for (new_z_exp, new_wb_exp), new_coeff in new_coeffs.items():
+            new_z = tuple(i+j for i,j in zip(prev_z_exp, new_z_exp))
+            new_w = tuple(i+j for i,j in zip(prev_w_exp, new_wb_exp))
+            new_dict[(new_z, new_w)] += prev_coeff*new_coeff
+    return dict(new_dict)
+
 def generate_k_modes_marginal_sample(modes, inputs, interferometer, rng):
     '''
         Implements sampling when k-modes have been selected for measurement.
@@ -483,15 +496,17 @@ def generate_k_modes_marginal_sample(modes, inputs, interferometer, rng):
     s = len(occupied_inputs)
 
     V = np.conj(interferometer)[modes, :][:, np.where(inputs!=0)[0]]
-    p_zw = 1
+    symbols_list = list(symbols(f'z1:{k+1}'))+list(symbols(f'w1:{k+1}'))
+    p_zw_dict = {(tuple([0]*k), tuple([0]*k)): 1.0}
     for a in range(s): 
         faz = sum([V[j][a]*symbols(f'z{j+1}') for j in range(k)]) 
         faw_conj = sum([np.conj(V[j][a])*symbols(f'w{j+1}') for j in range(k)]) 
         xa = -faz * faw_conj
         l_ra = laguerre(occupied_inputs[a], xa)
-        p_zw *= l_ra
-    poly_p_zw = Poly(p_zw, *(list(symbols(f'z1:{k+1}'))+list(symbols(f'w1:{k+1}'))))
-    p_zw_diag = {exponents[:k]:coeff for exponents, coeff in poly_p_zw.terms() if exponents[:k] == exponents[k:]}
+        poly_ra = Poly(l_ra, *symbols_list)
+        coeff_dict = { (exponents[:k], exponents[k:]):coeff for exponents, coeff in poly_ra.terms() }
+        p_zw_dict = update_coefficients(p_zw_dict, coeff_dict)
+    p_zw_diag = { z_exp:coeff for (z_exp, w_exp), coeff in p_zw_dict.items() if z_exp == w_exp }
             
     p_ys = {}
     for y in p_zw_diag.keys():

--- a/piquasso/_simulators/sampling/utils.py
+++ b/piquasso/_simulators/sampling/utils.py
@@ -13,10 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from itertools import product
-from collections import deque
 import numpy as np
-from scipy.special import factorial, comb
+from scipy.special import factorial
 
 from functools import partial
 
@@ -179,17 +177,7 @@ def generate_samples(
     Returns:
         The generated samples.
     """
-    n = np.sum(input)
-    k = len(selected_modes)
 
-    if k == 1 and n>3 and n<10:
-        return _generate_k_modes_samples(
-            input, 
-            shots, 
-            interferometer, 
-            rng, 
-            selected_modes,
-            n)
     if len(postselect_data[0]) > 0:
         sample_generator = partial(
             _generate_sample_with_postselect,
@@ -206,8 +194,7 @@ def generate_samples(
         sample_generator=sample_generator,
         interferometer=interferometer,
         rng=rng,
-        selected_modes=selected_modes,
-        n=n,
+        selected_modes=selected_modes
     )
 
 
@@ -263,9 +250,10 @@ def _get_first_quantized(occupation_numbers):
 
 
 def _generate_samples(
-    input, shots, calculate_permanent_laplace, interferometer, sample_generator, rng, selected_modes, n
+    input, shots, calculate_permanent_laplace, interferometer, sample_generator, rng, selected_modes
 ):
     d = len(input)
+    n = np.sum(input)
 
     samples = []
 
@@ -485,179 +473,3 @@ def _calculate_singular_values_matrix_expansion(singular_values_vector):
     expansion_values = np.sqrt(vector_of_squared_expansions)
 
     return np.diag(expansion_values)
-
-
-def _generate_k_modes_samples(
-        input, shots, interferometer, rng, selected_modes, n
-):
-    '''
-        Generates multiple samples with specified selected modes.
-    '''
-    samples = []
-
-    while len(samples) < shots:
-        sample = _generate_k_modes_sample(selected_modes, n, input, interferometer, rng)
-        samples.append(tuple(sample))
-
-    return samples
-
-def _get_support_points(alphas_to_indices, N, k, polynomials_list):
-    '''
-        Finds the points to evaluate in R based on the non-empty alphas in the polynomials list.
-    '''
-    X = set()
-    for alpha_betas in product(*(poly.keys() for poly in polynomials_list)):
-        new_alpha_beta = tuple(map(sum, zip(*alpha_betas)))
-        if sum(new_alpha_beta[:k]) == sum(new_alpha_beta[k:]) and sum(new_alpha_beta[:k])<N:
-                X.add(alphas_to_indices[new_alpha_beta])
-    return sorted(X)
-
-def _build_exponent(alpha, N):
-    '''
-        Converts alpha to an integer in N.
-    '''
-    u = 0
-    for a in alpha:
-        u = u * N + a
-    return u
-
-def _build_kronecker_exponents(N, max_exponent, row_exponent, col_exponent):
-    '''
-        Builds the Kronecker exponents for the support values X by converting rows and cols to integers.
-    '''
-    return _build_exponent(row_exponent, N) + max_exponent * _build_exponent(col_exponent, N)
-
-def _set_evaluation_points(all_ys, X, N):
-    '''
-        Creates the set of T pairwise distinct omega points. 
-    '''
-    max_exponent = max([_build_exponent(alpha, N) for alpha in all_ys])
-    exponents = [_build_kronecker_exponents(N, max_exponent, all_ys[r], all_ys[c]) for r, c in X]
-    T = max(exponents)+1
-    omega = np.exp(2j * np.pi / T)
-    points = np.array(omega ** exponents)
-    return points
-
-def _build_V_matrix(points):
-    '''
-        Creates the Vandermonde matrix based on the T omega points.
-    '''
-    s = len(points)
-    return np.array([
-        [points[j] ** i for j in range(s)]
-        for i in range(s)
-    ])
-
-def _project_coefficients(indices_to_alphas, X, poly):
-    '''
-        Gets the polynomial's coefficients at the support X alphas.
-    '''
-    return np.array([poly.get(indices_to_alphas[i], 0) for i in X])
-
-def _multiply_polynomials(all_ys, alphas_to_indices, indices_to_alphas, polynomials_list, N, k):
-    '''
-        Multiplies polynomial coefficients using "Sparse polynomial multiplication" algorithm by Joris van der Hoeven.
-    '''
-    X = _get_support_points(alphas_to_indices, N, k, polynomials_list)
-    points = _set_evaluation_points(all_ys, X, N)
-
-    V = _build_V_matrix(points)
-    V_inv = np.linalg.inv(V)
-
-    E_polys = [ V @ _project_coefficients(indices_to_alphas, X, poly) for poly in polynomials_list ]
-    ER = np.prod(E_polys, axis=0)
-    
-    R_vals = V_inv @ ER
-
-    return { indices_to_alphas[X[i]]: R_vals[i].real for i in range(len(X)) if R_vals[i].real > 0.0 }
-
-def _compute_degree(degree, alphas_by_degree, powers_by_degree, x):
-    '''
-        Computes the Laguerre polynomials at one degree.
-    '''
-    previous_powers = powers_by_degree[degree-1]
-    alphas_1 = alphas_by_degree[1]
-    previous_alphas = alphas_by_degree[degree-1]
-    current_alphas = alphas_by_degree[degree]
-
-    indices = {alpha: index for index, alpha in enumerate(current_alphas)}
-    l_ra = np.zeros((len(current_alphas), len(current_alphas)), dtype=complex)
-    for i1, alpha in enumerate(previous_alphas):
-        for i2, beta in enumerate(previous_alphas):
-            for j1, alpha_1 in enumerate(alphas_1):
-                for j2, beta_1 in enumerate(alphas_1):
-                    row = tuple(np.add(alpha, alpha_1))
-                    col = tuple(np.add(beta, beta_1))
-                    l_ra[indices[row], indices[col]] += previous_powers[i1, i2] * x[j1, j2]
-    return l_ra
-
-def _compute_laguerre(x, d, k):
-    '''
-        Computes the Laguerre series of degree d and returns an array of its polynomials.
-    '''
-    x = x[::-1, ::-1]
-
-    alphas_1 = [alpha for alpha in product(range(2), repeat=k) if sum(alpha) == 1]
-    alphas_by_degree = {0: [(0,) * k], 1: alphas_1}
-    powers_by_degree = {0: np.array([[1.0 + 0j]]), 1:x}
-    for degree in range(2, d + 1):
-        alphas_by_degree[degree] = [alpha for alpha in product(range(degree+1), repeat=k) if sum(alpha) == degree]
-        powers_by_degree[degree] = _compute_degree(degree, alphas_by_degree, powers_by_degree, x)
-
-    coeffs = [(-1) ** j * comb(d, j) / factorial(j) for j in range(d + 1)]
-    l_ra = {}
-    for degree in range(d + 1):
-        power_block = coeffs[degree] * powers_by_degree[degree]
-        degree_alphas = alphas_by_degree[degree]
-        for i, row in enumerate(degree_alphas):
-            for j, col in enumerate(degree_alphas):
-                coeff = power_block[i, j].real
-                if coeff != 0.0:
-                    l_ra[(row + col)] = coeff
-    return l_ra
-
-def _generate_k_modes_sample(modes, n, inputs, interferometer, rng):
-    '''
-        Implements sampling when k-modes have been selected for measurement.
-    '''
-    k = len(modes)
-    occupied_inputs = inputs[inputs!=0]
-    s = len(occupied_inputs)
-    if s == 0:
-        return np.zeros(k, dtype=int)
-    
-    N = n+1
-    all_ys = [alpha for alpha in product(range(N), repeat=k) if sum(alpha) <= n]
-    alphas_to_indices = {}
-    indices_to_alphas = {}
-    for i in range(len(all_ys)):
-        for j in range(len(all_ys)):
-            indices = (i, j)
-            alpha = all_ys[i]+all_ys[j]
-            indices_to_alphas[indices] = alpha
-            alphas_to_indices[alpha] = indices
-
-    V = np.conj(interferometer)[modes, :][:, np.where(inputs!=0)[0]]
-
-    xa = -np.einsum('ai,aj->aij', V.T, np.conj(V.T))
-
-    laguerre_polynomials = []
-    for a in range(s):
-        X_R = _compute_laguerre(xa[a], occupied_inputs[a], k)
-        laguerre_polynomials.append(X_R)
-    if len(laguerre_polynomials) > 1:
-        X_R = _multiply_polynomials(all_ys, alphas_to_indices, indices_to_alphas, laguerre_polynomials, N, k)
-    p_zw_diag = {alpha_beta[:k]:coeff for alpha_beta, coeff in X_R.items() if alpha_beta[:k] == alpha_beta[k:]}
-
-    alphas = np.array(list(p_zw_diag.keys()))
-    P_alpha_factorial = np.prod(factorial(alphas), axis=1) * np.array(list(p_zw_diag.values()))
-
-    y = alphas[:, None, :]
-    alpha = alphas[None, :, :]
-    combination_alpha_y = comb(alpha, y) * (-1) ** ((alpha - y)%2)
-
-    p_ys = np.prod(combination_alpha_y, axis=2) @ P_alpha_factorial
-    positive_probs = np.where(p_ys>0)
-
-    sample = rng.choice(alphas[positive_probs], p=p_ys[positive_probs])
-    return sample

--- a/piquasso/_simulators/sampling/utils.py
+++ b/piquasso/_simulators/sampling/utils.py
@@ -194,7 +194,7 @@ def generate_samples(
         sample_generator=sample_generator,
         interferometer=interferometer,
         rng=rng,
-        selected_modes=selected_modes
+        selected_modes=selected_modes,
     )
 
 
@@ -250,7 +250,13 @@ def _get_first_quantized(occupation_numbers):
 
 
 def _generate_samples(
-    input, shots, calculate_permanent_laplace, interferometer, sample_generator, rng, selected_modes
+    input,
+    shots,
+    calculate_permanent_laplace,
+    interferometer,
+    sample_generator,
+    rng,
+    selected_modes,
 ):
     d = len(input)
     n = np.sum(input)
@@ -269,7 +275,7 @@ def _generate_samples(
             rng=rng,
         )
         samples.append(tuple(sample))
-    samples = [ tuple(sample[mode] for mode in selected_modes) for sample in samples ]
+    samples = [tuple(sample[mode] for mode in selected_modes) for sample in samples]
     return samples
 
 

--- a/piquasso/_simulators/sampling/utils.py
+++ b/piquasso/_simulators/sampling/utils.py
@@ -151,7 +151,6 @@ def generate_samples(
     rng,
     reject_condition,
     postselect_data,
-    selected_modes,
 ):
     """
     Generates samples corresponding to the Clifford & Clifford algorithm B from
@@ -194,7 +193,6 @@ def generate_samples(
         sample_generator=sample_generator,
         interferometer=interferometer,
         rng=rng,
-        selected_modes=selected_modes,
     )
 
 
@@ -205,7 +203,6 @@ def generate_lossy_samples(
     interferometer_svd,
     rng,
     postselect_data,
-    selected_modes,
 ):
     """
     Basically the same algorithm as in `generate_samples`, but doubles the system size
@@ -228,7 +225,6 @@ def generate_lossy_samples(
         rng,
         reject_condition=lambda: False,
         postselect_data=postselect_data,
-        selected_modes=selected_modes,
     )
 
     # Trim output state
@@ -250,13 +246,7 @@ def _get_first_quantized(occupation_numbers):
 
 
 def _generate_samples(
-    input,
-    shots,
-    calculate_permanent_laplace,
-    interferometer,
-    sample_generator,
-    rng,
-    selected_modes,
+    input, shots, calculate_permanent_laplace, interferometer, sample_generator, rng
 ):
     d = len(input)
     n = np.sum(input)
@@ -275,7 +265,7 @@ def _generate_samples(
             rng=rng,
         )
         samples.append(tuple(sample))
-    samples = [tuple(sample[mode] for mode in selected_modes) for sample in samples]
+
     return samples
 
 

--- a/piquasso/_simulators/sampling/utils.py
+++ b/piquasso/_simulators/sampling/utils.py
@@ -182,7 +182,7 @@ def generate_samples(
     n = np.sum(input)
     k = len(selected_modes)
 
-    if k == 1 and n>=3 and n<10:
+    if k == 1 and n>3 and n<10:
         return _generate_k_modes_samples(
             input, 
             shots, 
@@ -501,15 +501,14 @@ def _generate_k_modes_samples(
 
     return samples
 
-def _get_support_points(alphas_to_indices, N, k, P, Q):
+def _get_support_points(alphas_to_indices, N, k, polynomials_list):
     '''
-        Finds the points to evaluate in R based on the non-empty alphas in P and Q.
+        Finds the points to evaluate in R based on the non-empty alphas in the polynomials list.
     '''
     X = set()
-    for alpha_beta_P in P.keys():
-        for alpha_beta_Q in Q.keys():
-            new_alpha_beta = tuple([sum(x) for x in zip(alpha_beta_P,alpha_beta_Q)])
-            if sum(new_alpha_beta[:k]) == sum(new_alpha_beta[k:]) and sum(new_alpha_beta[:k])<N:
+    for alpha_betas in product(*(poly.keys() for poly in polynomials_list)):
+        new_alpha_beta = tuple(map(sum, zip(*alpha_betas)))
+        if sum(new_alpha_beta[:k]) == sum(new_alpha_beta[k:]) and sum(new_alpha_beta[:k])<N:
                 X.add(alphas_to_indices[new_alpha_beta])
     return sorted(X)
 
@@ -555,22 +554,19 @@ def _project_coefficients(indices_to_alphas, X, poly):
     '''
     return np.array([poly.get(indices_to_alphas[i], 0) for i in X])
 
-def _multiply_polynomials(all_ys, alphas_to_indices, indices_to_alphas, P, Q, N, k):
+def _multiply_polynomials(all_ys, alphas_to_indices, indices_to_alphas, polynomials_list, N, k):
     '''
         Multiplies polynomial coefficients using "Sparse polynomial multiplication" algorithm by Joris van der Hoeven.
     '''
-    X = _get_support_points(alphas_to_indices, N, k, P, Q)
+    X = _get_support_points(alphas_to_indices, N, k, polynomials_list)
     points = _set_evaluation_points(all_ys, X, N)
 
     V = _build_V_matrix(points)
     V_inv = np.linalg.inv(V)
 
-    p = _project_coefficients(indices_to_alphas, X, P)
-    q = _project_coefficients(indices_to_alphas, X, Q)
+    E_polys = [ V @ _project_coefficients(indices_to_alphas, X, poly) for poly in polynomials_list ]
+    ER = np.prod(E_polys, axis=0)
     
-    EP = V @ p
-    EQ = V @ q
-    ER = EP * EQ
     R_vals = V_inv @ ER
 
     return { indices_to_alphas[X[i]]: R_vals[i].real for i in range(len(X)) if R_vals[i].real > 0.0 }
@@ -645,14 +641,13 @@ def _generate_k_modes_sample(modes, n, inputs, interferometer, rng):
 
     xa = -np.einsum('ai,aj->aij', V.T, np.conj(V.T))
 
-    polys = deque([], maxlen=2)
+    laguerre_polynomials = []
     for a in range(s):
-        l_ra = _compute_laguerre(xa[a], occupied_inputs[a], k)
-        polys.append(l_ra)
-        if len(polys) == 2:
-            X_R = _multiply_polynomials(all_ys, alphas_to_indices, indices_to_alphas, polys[0], polys[1], N, k)
-            polys.append(X_R)
-    p_zw_diag = {alpha_beta[:k]:coeff for alpha_beta, coeff in polys[-1].items() if alpha_beta[:k] == alpha_beta[k:]}
+        X_R = _compute_laguerre(xa[a], occupied_inputs[a], k)
+        laguerre_polynomials.append(X_R)
+    if len(laguerre_polynomials) > 1:
+        X_R = _multiply_polynomials(all_ys, alphas_to_indices, indices_to_alphas, laguerre_polynomials, N, k)
+    p_zw_diag = {alpha_beta[:k]:coeff for alpha_beta, coeff in X_R.items() if alpha_beta[:k] == alpha_beta[k:]}
 
     alphas = np.array(list(p_zw_diag.keys()))
     P_alpha_factorial = np.prod(factorial(alphas), axis=1) * np.array(list(p_zw_diag.values()))

--- a/piquasso/_simulators/sampling/utils.py
+++ b/piquasso/_simulators/sampling/utils.py
@@ -563,7 +563,7 @@ def _multiply_polynomials(all_ys, alphas_to_indices, indices_to_alphas, P, Q, N,
     points = _set_evaluation_points(all_ys, X, N)
 
     V = _build_V_matrix(points)
-    V_inv = np.linalg.pinv(V)
+    V_inv = np.linalg.inv(V)
 
     p = _project_coefficients(indices_to_alphas, X, P)
     q = _project_coefficients(indices_to_alphas, X, Q)
@@ -654,14 +654,15 @@ def _generate_k_modes_sample(modes, n, inputs, interferometer, rng):
             polys.append(X_R)
     p_zw_diag = {alpha_beta[:k]:coeff for alpha_beta, coeff in polys[-1].items() if alpha_beta[:k] == alpha_beta[k:]}
 
-    p_ys = {}
-    for y in p_zw_diag.keys():
-        p_y = 0
-        superior_ys = [alpha for alpha in p_zw_diag.keys() if (np.array(alpha) >= np.array(y)).all()]
-        for alpha in superior_ys:
-            p_y += np.prod(factorial(alpha)) * p_zw_diag[alpha] * np.prod([comb(alpha[j], y[j]) * (-1)**(alpha[j] - y[j]) for j in range(k)])
-        if p_y > 0:
-            p_ys[y] = p_y
-            
-    sample = rng.choice(list(p_ys.keys()), p=list(p_ys.values()))
+    alphas = np.array(list(p_zw_diag.keys()))
+    P_alpha_factorial = np.prod(factorial(alphas), axis=1) * np.array(list(p_zw_diag.values()))
+
+    y = alphas[:, None, :]
+    alpha = alphas[None, :, :]
+    combination_alpha_y = comb(alpha, y) * (-1) ** ((alpha - y)%2)
+
+    p_ys = np.prod(combination_alpha_y, axis=2) @ P_alpha_factorial
+    positive_probs = np.where(p_ys>0)
+
+    sample = rng.choice(alphas[positive_probs], p=p_ys[positive_probs])
     return sample

--- a/piquasso/_simulators/sampling/utils.py
+++ b/piquasso/_simulators/sampling/utils.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 from itertools import product
-import math
+from collections import deque
 import numpy as np
 from scipy.special import factorial, comb
 
@@ -501,39 +501,148 @@ def _generate_k_modes_samples(
 
     return samples
 
-def _multiply_polynomials(poly_arr_shape, arr):
+def _get_non_empty_alphas(poly, N, k, d):
     '''
-        Multiplies arrays of polynomial coefficients with fft.
+        Retrieves the non empty indices in the polynomial array and their corresponding (alpha, beta).
     '''
-    fft_arr = np.fft.fftn(arr, poly_arr_shape, axes=range(2, len(arr.shape)))
-    prod_arr = np.prod(fft_arr, axis=1)
-    ifft_arr = np.fft.ifftn(prod_arr, axes=range(1, len(prod_arr.shape)))
-    return ifft_arr
+    indices = {}
+    alphas = []
+    while len(alphas)<poly.shape[0]:
+        alphas = [alpha for alpha in product(range(N), repeat=k) if sum(alpha) <= d]
+        d+=1
+    for i in range(len(alphas)):
+        for j in range(len(alphas)):
+            indices[(i, j)] = alphas[i]+alphas[j]
+    non_empty = np.array(np.where(poly)).T.tolist()
+    S = {tuple(i): np.array(indices[tuple(i)]) for i in non_empty}
+    return S
 
-def _compute_laguerre(k, x, ra):
+def _get_support_points(alphas_to_indices, N, k, d, P,Q):
     '''
-        Computes the Laguerre series at degree ra and returns an array of its polynomials.
+        Finds the points to evaluate in R based on the non-empty points in P and Q.
     '''
-    max_deg = max(ra)+1
-    poly_arr_shape = [max_deg]*k
-    coeffs = np.zeros([x.shape[0], x.shape[1]]+poly_arr_shape, dtype=complex)
+    SP = _get_non_empty_alphas(P, N, k, d[0])
+    SQ = _get_non_empty_alphas(Q, N, k, d[1])
 
-    alphas = np.indices(poly_arr_shape,)
-    poly_indices = alphas.sum(axis=0)
+    X = set()
+    for a in SP.values():
+        for b in SQ.values():
+            new_tuple = tuple(a+b)
+            if sum(new_tuple[:k]) == sum(new_tuple[k:]) and sum(new_tuple[:k])<N:
+                X.add(alphas_to_indices[new_tuple])
+    return sorted(X), SP, SQ
 
-    fact = factorial(np.arange(max_deg))
-    for i, a in enumerate(ra):
-        relevant_indices = (poly_indices <= a)
+def _build_exponent(alpha, N):
+    '''
+        Converts alpha to an integer in N.
+    '''
+    u = 0
+    for a in alpha:
+        u = u * N + a
+    return u
 
-        alpha_i = alphas[:, relevant_indices]
-        poly_values = poly_indices[relevant_indices]
+def _build_kronecker_exponents(N, max_exponent, row_exponent, col_exponent):
+    '''
+        Builds the Kronecker exponents for the support values X by converting rows and cols to integers.
+    '''
+    return _build_exponent(row_exponent, N) + max_exponent * _build_exponent(col_exponent, N)
 
-        poly_coeffs = ((-1) ** poly_values) * comb(a, poly_values)
-        for j in range(k):
-            poly_coeffs = poly_coeffs[None, :] * x[:, i, j:j+1] ** alpha_i[j] / fact[alpha_i[j]]
+def _set_evaluation_points(all_ys, X, N, d):
+    '''
+        Creates the set of T pairwise distinct omega points. 
+    '''
+    max_exponent = max(_build_exponent(alpha, N) for alpha in all_ys)
+    T = max_exponent**2
+    omega = np.exp(2j * np.pi / T)
+    points = np.array([omega ** _build_kronecker_exponents(N, max_exponent, all_ys[r], all_ys[c]) for r, c in X])
+    return points
 
-        coeffs[:, i, relevant_indices] = poly_coeffs
-    return coeffs
+def _build_V_matrix(points):
+    '''
+        Creates the Vandermonde matrix based on the T omega points.
+    '''
+    s = len(points)
+    return np.array([
+        [points[j] ** i for j in range(s)]
+        for i in range(s)
+    ])
+
+def _project_coefficients(indices_to_alphas, X, poly, poly_support):
+    '''
+        Gets the polynomial's coefficients at the support X alphas.
+    '''
+    coeffs = {tuple(alpha):poly[index[0], [index[1]]][0] for index, alpha in poly_support.items()}
+    return np.array([coeffs.get(indices_to_alphas[i], 0) for i in X])
+
+def _multiply_polynomials(all_ys, alphas_to_indices, indices_to_alphas, P, Q, N, k, d, return_dense=False):
+    '''
+        Multiplies arrays of polynomial coefficients using "Sparse polynomial multiplication" algorithm by Joris van der Hoeven.
+    '''
+    X, SP, SQ = _get_support_points(alphas_to_indices, N, k, d, P,Q)
+    points = _set_evaluation_points(all_ys, X, N, d)
+
+    V = _build_V_matrix(points)
+    V_inv = np.linalg.pinv(V)
+
+    p = _project_coefficients(indices_to_alphas, X, P, SP)
+    q = _project_coefficients(indices_to_alphas, X, Q, SQ)
+    
+    EP = V @ p
+    EQ = V @ q
+    ER = EP * EQ
+    R_vals = V_inv @ ER
+
+    if return_dense:
+        R = np.zeros((X[-1][0]+1, X[-1][0]+1), dtype=complex)
+        X = tuple(np.array(X).T)
+        R[X] = R_vals
+        return R
+    return R_vals
+
+def _compute_degree(degree, alphas_by_degree, powers_by_degree, x):
+    '''
+        Computes the Laguerre polynomials at one degree.
+    '''
+    previous_powers = powers_by_degree[degree-1]
+    alphas_1 = alphas_by_degree[1]
+    previous_alphas = alphas_by_degree[degree-1]
+    current_alphas = alphas_by_degree[degree]
+
+    indices = {alpha: index for index, alpha in enumerate(current_alphas)}
+    l_ra = np.zeros((len(current_alphas), len(current_alphas)), dtype=complex)
+    for i1, alpha in enumerate(previous_alphas):
+        for i2, beta in enumerate(previous_alphas):
+            for j1, alpha_1 in enumerate(alphas_1):
+                for j2, beta_1 in enumerate(alphas_1):
+                    row = tuple(np.add(alpha, alpha_1))
+                    col = tuple(np.add(beta, beta_1))
+                    l_ra[indices[row], indices[col]] += previous_powers[i1, i2] * x[j1, j2]
+    return l_ra
+
+def _compute_laguerre(x, d, k):
+    '''
+        Computes the Laguerre series of degree d and returns an array of its polynomials.
+    '''
+    x = x[::-1, ::-1]
+
+    alphas_1 = [alpha for alpha in product(range(2), repeat=k) if sum(alpha) == 1]
+    alphas_by_degree = {0: [(0,) * k], 1: alphas_1}
+    powers_by_degree = {0: np.array([[1.0 + 0j]]), 1:x}
+    for degree in range(2, d + 1):
+        alphas_by_degree[degree] = [alpha for alpha in product(range(degree+1), repeat=k) if sum(alpha) == degree]
+        powers_by_degree[degree] = _compute_degree(degree, alphas_by_degree, powers_by_degree, x)
+
+    coeffs = [(-1) ** j * comb(d, j) / factorial(j) for j in range(d + 1)]
+    current_alphas = [alpha for alpha in product(range(d + 1), repeat=k) if sum(alpha) <= d]
+    indices = {alpha: i for i, alpha in enumerate(current_alphas)}
+    l_ra = np.zeros((len(current_alphas), len(current_alphas)))
+    for degree in range(d + 1):
+        power_block = coeffs[degree] * powers_by_degree[degree]
+        degree_alphas = alphas_by_degree[degree]
+        for i, row in enumerate(degree_alphas):
+            for j, col in enumerate(degree_alphas):
+                l_ra[indices[row], indices[col]] = power_block[i, j].real
+    return l_ra
 
 def _generate_k_modes_sample(modes, n, inputs, interferometer, rng):
     '''
@@ -544,42 +653,41 @@ def _generate_k_modes_sample(modes, n, inputs, interferometer, rng):
     s = len(occupied_inputs)
     if s == 0:
         return np.zeros(k, dtype=int)
+    
     N = n+1
+    all_ys = [alpha for alpha in product(range(N), repeat=k) if sum(alpha) <= n]
+    alphas_to_indices = {}
+    indices_to_alphas = {}
+    for i in range(len(all_ys)):
+        for j in range(len(all_ys)):
+            indices = (i, j)
+            alpha = all_ys[i]+all_ys[j]
+            indices_to_alphas[indices] = alpha
+            alphas_to_indices[alpha] = indices
 
     V = np.conj(interferometer)[modes, :][:, np.where(inputs!=0)[0]]
-    all_ys = np.array(list(product(range(N), repeat=k)))
-    
-    poly_arr_shape = [N]*k
-    omegas = np.exp(2j * np.pi / N) ** all_ys
-    
-    faz = V.T[:, None, :]*omegas[None,...]
-    faw = np.conj(V).T[:, None, :]*np.power(omegas, -1)[None,...]
-    xa = np.einsum('nmi,nmj->mnij', faz, faw)
-    xa = np.sum(-xa, axis=2)
-    l_ra = _compute_laguerre(k, xa, occupied_inputs)
-    P_omega = _multiply_polynomials(poly_arr_shape, l_ra)
-    D_t = np.sum(P_omega, axis=0)
-    D_t /= N**k
 
-    poly_indices = np.indices(D_t.shape).sum(axis=0)
-    possible_ys = np.argwhere(poly_indices <= n)
-    superior_ys = np.all(possible_ys[:, None, :] >= possible_ys[None, :, :], axis=2)
+    xa = -np.einsum('ai,aj->aij', V.T, np.conj(V.T))
 
-    fact = factorial(np.arange(N))
-    P_alpha_factorial = np.prod(fact[possible_ys], axis=1) * D_t[*possible_ys.T]
+    polys = deque([], maxlen=2)
+    for a in range(s):
+        R = _compute_laguerre(xa[a], occupied_inputs[a], k)
+        polys.append(R)
+        if len(polys) == 2:
+            R = _multiply_polynomials(all_ys, alphas_to_indices, indices_to_alphas, polys[0], polys[1], N, k, (sum(occupied_inputs[:a]), occupied_inputs[a]), return_dense=True)
+            polys.append(R)
 
-    combination_alpha_y = np.zeros((N, N))
-    for alpha in range(N):
-        for y in range(alpha + 1):
-            combination_alpha_y[alpha, y] = math.comb(alpha, y) * (-1) ** (alpha - y)
+    diag = np.diag(R).real
+    p_zw_diag = {indices_to_alphas[i, i][:k]:coeff for i, coeff in enumerate(diag)}
 
-    Y = len(possible_ys)
-    coeffs = np.ones((Y, Y))
-    for j in range(possible_ys.shape[1]):
-        coeffs *= combination_alpha_y[possible_ys[:, j][:, None], possible_ys[:, j][None, :]]
-    coeffs *= superior_ys
-    p_ys = (P_alpha_factorial @ coeffs).real
-
-    positive_probs = np.where(p_ys>0)
-    sample = rng.choice(possible_ys[positive_probs], p=p_ys[positive_probs])
+    p_ys = {}
+    for y in p_zw_diag.keys():
+        p_y = 0
+        superior_ys = [alpha for alpha in p_zw_diag.keys() if (np.array(alpha) >= np.array(y)).all()]
+        for alpha in superior_ys:
+            p_y += np.prod(factorial(alpha)) * p_zw_diag[alpha] * np.prod([comb(alpha[j], y[j]) * (-1)**(alpha[j] - y[j]) for j in range(k)])
+        if p_y > 0:
+            p_ys[y] = p_y
+            
+    sample = rng.choice(list(p_ys.keys()), p=list(p_ys.values()))
     return sample

--- a/piquasso/_simulators/sampling/utils.py
+++ b/piquasso/_simulators/sampling/utils.py
@@ -13,8 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import math
 import numpy as np
 from scipy.special import factorial
+from sympy import symbols, Poly
+from sympy.functions.special.polynomials import laguerre
 
 from functools import partial
 
@@ -469,3 +472,35 @@ def _calculate_singular_values_matrix_expansion(singular_values_vector):
     expansion_values = np.sqrt(vector_of_squared_expansions)
 
     return np.diag(expansion_values)
+
+
+def generate_k_modes_marginal_sample(modes, inputs, interferometer, rng):
+    '''
+        Implements sampling when k-modes have been selected for measurement.
+    '''
+    k = len(modes)
+    occupied_inputs = inputs[inputs!=0]
+    s = len(occupied_inputs)
+
+    V = np.conj(interferometer)[modes, :][:, np.where(inputs!=0)[0]]
+    p_zw = 1
+    for a in range(s): 
+        faz = sum([V[j][a]*symbols(f'z{j+1}') for j in range(k)]) 
+        faw_conj = sum([np.conj(V[j][a])*symbols(f'w{j+1}') for j in range(k)]) 
+        xa = -faz * faw_conj
+        l_ra = laguerre(occupied_inputs[a], xa)
+        p_zw *= l_ra
+    poly_p_zw = Poly(p_zw, *(list(symbols(f'z1:{k+1}'))+list(symbols(f'w1:{k+1}'))))
+    p_zw_diag = {exponents[:k]:coeff for exponents, coeff in poly_p_zw.terms() if exponents[:k] == exponents[k:]}
+            
+    p_ys = {}
+    for y in p_zw_diag.keys():
+        p_y = 0
+        superior_ys = [alpha for alpha in p_zw_diag.keys() if (np.array(alpha) >= np.array(y)).all()]
+        for alpha in superior_ys:
+            p_y += np.prod(factorial(alpha)) * p_zw_diag[alpha] * np.prod([math.comb(alpha[j], y[j]) * (-1)**(alpha[j] - y[j]) for j in range(k)])
+        if p_y > 0:
+            p_ys[y] = p_y
+            
+    sample = rng.choice(list(p_ys.keys()), p=list(p_ys.values()))
+    return sample

--- a/piquasso/api/state.py
+++ b/piquasso/api/state.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Tuple, Type, Optional
+from typing import Any, Tuple, Type, Optional, Self
 
 import abc
 import copy
@@ -51,7 +51,7 @@ class State(abc.ABC):
     def _get_auxiliary_modes(self, modes: Tuple[int, ...]) -> Tuple[int, ...]:
         return get_auxiliary_modes(self.d, modes)
 
-    def copy(self) -> "State":
+    def copy(self) -> Self:
         """Returns an exact copy of this state.
 
         Returns:

--- a/piquasso/api/state.py
+++ b/piquasso/api/state.py
@@ -13,7 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Tuple, Type, Optional, Self
+from typing import Any, Tuple, Type, Optional
+from typing_extensions import Self
 
 import abc
 import copy

--- a/tests/_simulators/sampling/test_measurements.py
+++ b/tests/_simulators/sampling/test_measurements.py
@@ -857,3 +857,195 @@ class TestMidCircuitMeasurements:
         assert state_1 == state_2
 
         assert np.allclose(state_1.state_vector, state_2.state_vector)
+
+
+class TestMarginalBosonSampling:
+    """Test programs that contain marginal boson sampling."""
+
+    @pytest.mark.monkey
+    def test_marginal_boson_sampling_conserves_particle_number_bound(
+        self, generate_unitary_matrix
+    ):
+        input_state = np.array([1, 1, 1, 0, 0], dtype=int)
+        d = len(input_state)
+
+        unitary = generate_unitary_matrix(d)
+
+        program = pq.Program(
+            instructions=[
+                pq.NumberState(input_state),
+                pq.Interferometer(unitary),
+                pq.ParticleNumberMeasurement().on_modes(0, 2),
+            ]
+        )
+
+        simulator = pq.SamplingSimulator(d=d, config=pq.Config(seed_sequence=42))
+        result = simulator.execute(program, shots=10)
+
+        for sample in result.samples:
+            assert sum(sample) <= sum(input_state)
+            assert all(particle_number >= 0 for particle_number in sample)
+
+    @pytest.mark.monkey
+    def test_full_boson_sampling_conserves_particle_number(
+        self, generate_unitary_matrix
+    ):
+        input_state = np.array([1, 1, 1, 0, 0], dtype=int)
+        d = len(input_state)
+
+        unitary = generate_unitary_matrix(d)
+
+        program = pq.Program(
+            instructions=[
+                pq.NumberState(input_state),
+                pq.Interferometer(unitary),
+                pq.ParticleNumberMeasurement().on_modes(*range(d)),
+            ]
+        )
+
+        simulator = pq.SamplingSimulator(d=d, config=pq.Config(seed_sequence=42))
+        result = simulator.execute(program, shots=10)
+
+        for sample in result.samples:
+            assert sum(sample) == sum(input_state)
+
+    def test_identity_interferometer_marginal_boson_sampling(self):
+        input_state = np.array([2, 0, 1, 0], dtype=int)
+        d = len(input_state)
+
+        program = pq.Program(
+            instructions=[
+                pq.NumberState(input_state),
+                pq.Interferometer(np.identity(d)),
+                pq.ParticleNumberMeasurement().on_modes(0, 2),
+            ]
+        )
+
+        simulator = pq.SamplingSimulator(d=d, config=pq.Config(seed_sequence=42))
+        result = simulator.execute(program, shots=10)
+
+        for sample in result.samples:
+            assert tuple(sample) == (2, 1)
+
+    def test_permutation_interferometer_marginal_boson_sampling(self):
+        input_state = np.array([1, 0, 2, 0], dtype=int)
+        d = len(input_state)
+
+        unitary = np.array(
+            [
+                [0, 0, 1, 0],
+                [1, 0, 0, 0],
+                [0, 0, 0, 1],
+                [0, 1, 0, 0],
+            ],
+            dtype=complex,
+        )
+
+        program = pq.Program(
+            instructions=[
+                pq.NumberState(input_state),
+                pq.Interferometer(unitary),
+                pq.ParticleNumberMeasurement().on_modes(0, 1),
+            ]
+        )
+
+        simulator = pq.SamplingSimulator(d=d, config=pq.Config(seed_sequence=42))
+        result = simulator.execute(program, shots=10)
+
+        for sample in result.samples:
+            assert tuple(sample) == (2, 1)
+
+    def test_lossy_marginal_sampling_raises_NotImplementedCalculation(self):
+        input_state = np.array([1, 1, 1, 0, 0], dtype=int)
+        d = len(input_state)
+
+        program = pq.Program(
+            instructions=[
+                pq.NumberState(input_state),
+                pq.Loss(transmissivity=0.5).on_modes(0),
+                pq.ParticleNumberMeasurement().on_modes(0, 2),
+            ]
+        )
+
+        simulator = pq.SamplingSimulator(d=d, config=pq.Config(seed_sequence=42))
+
+        with pytest.raises(pq.api.exceptions.NotImplementedCalculation) as error:
+            simulator.execute(program, shots=10)
+
+        assert error.value.args[0] == (
+            "The instruction ParticleNumberMeasurement(modes=(0, 2)) is not supported "
+            "for lossy states with postselection on a subset of modes.\nIf you need "
+            "this feature to be implemented, please create an issue at "
+            "https://github.com/Budapest-Quantum-Computing-Group/piquasso/issues"
+        )
+
+    def test_postselected_marginal_sampling_with_permutation_interferometer(self):
+        input_state = np.array([1, 1, 1, 0, 0], dtype=int)
+        d = len(input_state)
+        shots = 10
+
+        unitary = np.array(
+            [
+                [0, 1, 0, 0, 0],
+                [0, 0, 0, 1, 0],
+                [1, 0, 0, 0, 0],
+                [0, 0, 1, 0, 0],
+                [0, 0, 0, 0, 1],
+            ],
+            dtype=complex,
+        )
+
+        program = pq.Program(
+            instructions=[
+                pq.NumberState(input_state),
+                pq.Interferometer(unitary),
+                pq.PostSelectPhotons(photon_counts=[1]).on_modes(0),
+                pq.ParticleNumberMeasurement().on_modes(1, 2),
+            ]
+        )
+
+        simulator = pq.SamplingSimulator(d=d, config=pq.Config(seed_sequence=42))
+        result = simulator.execute(program, shots=shots)
+
+        for sample in result.samples:
+            assert tuple(sample) == (0, 1)
+
+        analytic_result = simulator.execute(
+            pq.Program(
+                instructions=[
+                    pq.NumberState(input_state),
+                    pq.Interferometer(unitary),
+                    pq.PostSelectPhotons(photon_counts=[1]).on_modes(0),
+                ]
+            )
+        )
+
+        analytic_probabilities = analytic_result.state.get_marginal_probabilities(
+            modes=(1, 2),
+        )
+
+        assert np.isclose(sum(analytic_probabilities.values()), 1.0)
+        assert np.isclose(analytic_probabilities[(0, 1)], 1.0)
+
+    def test_postselected_marginal_sampling_on_same_modes_raises_ValueError(self):
+        input_state = np.array([1, 1, 1, 0, 0], dtype=int)
+        d = len(input_state)
+
+        program = pq.Program(
+            instructions=[
+                pq.NumberState(input_state),
+                pq.PostSelectPhotons(photon_counts=[1]).on_modes(0),
+                pq.ParticleNumberMeasurement().on_modes(0, 2),
+            ]
+        )
+
+        simulator = pq.SamplingSimulator(d=d, config=pq.Config(seed_sequence=42))
+
+        with pytest.raises(
+            ValueError,
+            match=re.escape(
+                "Some modes of instruction ParticleNumberMeasurement(modes=(0, 2)) are "
+                "not active: {0}."
+            ),
+        ):
+            simulator.execute(program, shots=10)

--- a/tests/_simulators/sampling/test_measurements.py
+++ b/tests/_simulators/sampling/test_measurements.py
@@ -857,14 +857,3 @@ class TestMidCircuitMeasurements:
         assert state_1 == state_2
 
         assert np.allclose(state_1.state_vector, state_2.state_vector)
-
-    def test_k_modes_measurement(self):
-        with pq.Program() as program:
-            pq.Q() | pq.NumberState([1, 1, 0, 0, 0])
-            pq.Q(0, 1) | pq.ParticleNumberMeasurement()
-
-        s_simulator = pq.SamplingSimulator(d=5)
-        s_res = s_simulator.execute(program, shots=1)
-        samples = np.array(s_res.samples)
-        assert samples.shape[1] == 2
-        assert np.allclose(samples, [1, 1])

--- a/tests/_simulators/sampling/test_measurements.py
+++ b/tests/_simulators/sampling/test_measurements.py
@@ -860,7 +860,7 @@ class TestMidCircuitMeasurements:
 
     def test_k_modes_measurement(self):
         with pq.Program() as program:
-            pq.Q() | pq.StateVector([1, 1, 0, 0, 0])
+            pq.Q() | pq.NumberState([1, 1, 0, 0, 0])
             pq.Q(0, 1) | pq.ParticleNumberMeasurement()
 
         s_simulator = pq.SamplingSimulator(d=5)

--- a/tests/_simulators/sampling/test_measurements.py
+++ b/tests/_simulators/sampling/test_measurements.py
@@ -857,3 +857,14 @@ class TestMidCircuitMeasurements:
         assert state_1 == state_2
 
         assert np.allclose(state_1.state_vector, state_2.state_vector)
+
+    def test_k_modes_measurement(self):
+        with pq.Program() as program:
+            pq.Q() | pq.StateVector([1, 1, 0, 0, 0])
+            pq.Q(0,1) | pq.ParticleNumberMeasurement()
+
+        s_simulator = pq.SamplingSimulator(d=5)
+        s_res = s_simulator.execute(program, shots=1)
+        samples = np.array(s_res.samples)
+        assert samples.shape[1] == 2
+        assert np.allclose(samples, [1,1])

--- a/tests/_simulators/sampling/test_measurements.py
+++ b/tests/_simulators/sampling/test_measurements.py
@@ -861,10 +861,10 @@ class TestMidCircuitMeasurements:
     def test_k_modes_measurement(self):
         with pq.Program() as program:
             pq.Q() | pq.StateVector([1, 1, 0, 0, 0])
-            pq.Q(0,1) | pq.ParticleNumberMeasurement()
+            pq.Q(0, 1) | pq.ParticleNumberMeasurement()
 
         s_simulator = pq.SamplingSimulator(d=5)
         s_res = s_simulator.execute(program, shots=1)
         samples = np.array(s_res.samples)
         assert samples.shape[1] == 2
-        assert np.allclose(samples, [1,1])
+        assert np.allclose(samples, [1, 1])

--- a/tests/_simulators/sampling/test_measurements.py
+++ b/tests/_simulators/sampling/test_measurements.py
@@ -955,7 +955,7 @@ class TestMarginalBosonSampling:
         for sample in result.samples:
             assert tuple(sample) == (2, 1)
 
-    def test_lossy_marginal_sampling_raises_NotImplementedCalculation(self):
+    def test_lossy_marginal_sampling(self):
         input_state = np.array([1, 1, 1, 0, 0], dtype=int)
         d = len(input_state)
 
@@ -969,15 +969,24 @@ class TestMarginalBosonSampling:
 
         simulator = pq.SamplingSimulator(d=d, config=pq.Config(seed_sequence=42))
 
-        with pytest.raises(pq.api.exceptions.NotImplementedCalculation) as error:
-            simulator.execute(program, shots=10)
+        shots = 10
+        result = simulator.execute(program, shots=shots)
 
-        assert error.value.args[0] == (
-            "The instruction ParticleNumberMeasurement(modes=(0, 2)) is not supported "
-            "for lossy states with postselection on a subset of modes.\nIf you need "
-            "this feature to be implemented, please create an issue at "
-            "https://github.com/Budapest-Quantum-Computing-Group/piquasso/issues"
-        )
+        assert len(result.samples) == shots
+
+        for sample in result.samples:
+            assert len(sample) == 2
+
+            assert sample[0] in (0, 1), "Mode 0 initially has one photon and is lossy."
+
+            assert (
+                sample[1] == 1
+            ), "Mode 2 is untouched, so it should always contain one photon."
+
+            assert sum(sample) in (
+                1,
+                2,
+            ), "The total number of photons should be either 1 or 2."
 
     def test_postselected_marginal_sampling_with_permutation_interferometer(self):
         input_state = np.array([1, 1, 1, 0, 0], dtype=int)


### PR DESCRIPTION
Closes #499 

## What
I've added the ability to measure only the specified modes for ParticleNumberMeasurement on SamplingSimulator, as was requested in the issue.

## How
I used the same logic as in the PureFockSimulator since that one was working correctly: I added a method to the SamplingState that creates a reduced version of the state with only the selected modes, and this method is called in the SamplingSimulator's particle_number_measurement function.

## Testing
I added a function in the SamplingSimulator's test_measurements that tries the example given in the related issue.

## Notes
I used Claude's assistance to understand how the properties of the SamplingState should be modified, especially the interferometer.