### PR TITLE
fix: validate Fock cutoff for state preparations

### DIFF
--- a/piquasso/_math/validations.py
+++ b/piquasso/_math/validations.py
@@ -13,11 +13,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Iterable, Union, Tuple
+from typing import Iterable, Union, Tuple, Sequence
 
 import numpy as np
 
 from piquasso.api.exceptions import InvalidState
+
+
+def _cutoff_increase_hint(required_cutoff: int) -> str:
+    return (
+        f" Consider increasing the cutoff via "
+        f"`pq.Config(cutoff={required_cutoff})` when creating the simulator."
+    )
 
 
 def is_natural(number: Union[int, float]) -> bool:
@@ -70,7 +77,7 @@ def validate_occupation_numbers(
             ``d`` or if the total particle number requires a larger cutoff.
     """
 
-    original_occupation_numbers = tuple(occupation_numbers)
+    original_occupation_numbers = tuple(int(number) for number in occupation_numbers)
     occupation_numbers = np.array(original_occupation_numbers)
 
     if len(occupation_numbers) != d:
@@ -89,7 +96,65 @@ def validate_occupation_numbers(
             f"The occupation numbers '{original_occupation_numbers}' require "
             f"a cutoff of at least '{required_cutoff}', but the provided cutoff is "
             f"'{cutoff}'."
+            f"{_cutoff_increase_hint(required_cutoff)}"
         )
         if context:
             message += context
         raise InvalidState(message)
+
+
+def validate_postselection_cutoff(
+    cutoff: int,
+    photon_counts: Sequence[int],
+    occupation_numbers: Iterable[Sequence[int]],
+    *,
+    context: str = "",
+) -> None:
+    """Validate that postselection leaves enough Fock-space truncation.
+
+    After post-selecting ``photon_counts``, the effective cutoff becomes
+    ``cutoff - sum(photon_counts)``. Each prepared occupation number must
+    have fewer photons on the remaining modes than this effective cutoff.
+
+    Args:
+        cutoff: The current Fock-space cutoff before postselection.
+        photon_counts: The photon numbers being postselected.
+        occupation_numbers: Prepared occupation numbers on all modes.
+        context: Optional message appended to raised errors.
+
+    Raises:
+        InvalidState: If postselection would leave an invalid cutoff or if any
+            prepared state would exceed the truncated Fock space afterwards.
+    """
+    postselected_photons = int(np.sum(photon_counts))
+    remaining_cutoff = cutoff - postselected_photons
+
+    if remaining_cutoff <= 0:
+        required_cutoff = postselected_photons + 1
+        message = (
+            f"Post-selecting {postselected_photons} photon(s) on "
+            f"{photon_counts} requires a cutoff of at least "
+            f"'{required_cutoff}', but the provided cutoff is '{cutoff}'."
+            f"{_cutoff_increase_hint(required_cutoff)}"
+        )
+        if context:
+            message += context
+        raise InvalidState(message)
+
+    for original_occupation_numbers in occupation_numbers:
+        occupation_numbers_tuple = tuple(int(number) for number in original_occupation_numbers)
+        total_photons = int(np.sum(occupation_numbers_tuple))
+        remaining_photons = total_photons - postselected_photons
+
+        if remaining_photons >= remaining_cutoff:
+            required_cutoff = total_photons + 1
+            message = (
+                f"After post-selecting {postselected_photons} photon(s) on "
+                f"{photon_counts}, the remaining occupation numbers "
+                f"'{occupation_numbers_tuple}' require a cutoff of at least "
+                f"'{required_cutoff}', but the provided cutoff is '{cutoff}'."
+                f"{_cutoff_increase_hint(required_cutoff)}"
+            )
+            if context:
+                message += context
+            raise InvalidState(message)

--- a/piquasso/_math/validations.py
+++ b/piquasso/_math/validations.py
@@ -20,13 +20,6 @@ import numpy as np
 from piquasso.api.exceptions import InvalidState
 
 
-def _cutoff_increase_hint(required_cutoff: int) -> str:
-    return (
-        f" Consider increasing the cutoff via "
-        f"`pq.Config(cutoff={required_cutoff})` when creating the simulator."
-    )
-
-
 def is_natural(number: Union[int, float]) -> bool:
     return bool(np.isclose(number % 1, 0.0) and round(number) >= 0)
 
@@ -95,8 +88,8 @@ def validate_occupation_numbers(
         message = (
             f"The occupation numbers '{original_occupation_numbers}' require "
             f"a cutoff of at least '{required_cutoff}', but the provided cutoff is "
-            f"'{cutoff}'."
-            f"{_cutoff_increase_hint(required_cutoff)}"
+            f"'{cutoff}'. Consider increasing the cutoff via "
+            f"`pq.Config(cutoff={required_cutoff})` when creating the simulator."
         )
         if context:
             message += context
@@ -134,15 +127,18 @@ def validate_postselection_cutoff(
         message = (
             f"Post-selecting {postselected_photons} photon(s) on "
             f"{photon_counts} requires a cutoff of at least "
-            f"'{required_cutoff}', but the provided cutoff is '{cutoff}'."
-            f"{_cutoff_increase_hint(required_cutoff)}"
+            f"'{required_cutoff}', but the provided cutoff is '{cutoff}'. "
+            f"Consider increasing the cutoff via "
+            f"`pq.Config(cutoff={required_cutoff})` when creating the simulator."
         )
         if context:
             message += context
         raise InvalidState(message)
 
     for original_occupation_numbers in occupation_numbers:
-        occupation_numbers_tuple = tuple(int(number) for number in original_occupation_numbers)
+        occupation_numbers_tuple = tuple(
+            int(number) for number in original_occupation_numbers
+        )
         total_photons = int(np.sum(occupation_numbers_tuple))
         remaining_photons = total_photons - postselected_photons
 
@@ -152,8 +148,9 @@ def validate_postselection_cutoff(
                 f"After post-selecting {postselected_photons} photon(s) on "
                 f"{photon_counts}, the remaining occupation numbers "
                 f"'{occupation_numbers_tuple}' require a cutoff of at least "
-                f"'{required_cutoff}', but the provided cutoff is '{cutoff}'."
-                f"{_cutoff_increase_hint(required_cutoff)}"
+                f"'{required_cutoff}', but the provided cutoff is '{cutoff}'. "
+                f"Consider increasing the cutoff via "
+                f"`pq.Config(cutoff={required_cutoff})` when creating the simulator."
             )
             if context:
                 message += context

--- a/piquasso/_simulators/fock/general/simulation_steps.py
+++ b/piquasso/_simulators/fock/general/simulation_steps.py
@@ -27,6 +27,8 @@ from piquasso.api.instruction import Instruction
 from piquasso.api.branch import Branch
 from piquasso.api.exceptions import InvalidParameter
 
+from piquasso._math.validations import validate_occupation_numbers
+
 from piquasso._utils import sample_from_probability_map
 
 from piquasso._math.indices import get_index_in_fock_space
@@ -453,6 +455,26 @@ def _add_occupation_number_basis(
     bra: Tuple[int, ...],
     coefficient: complex,
 ) -> None:
+    if state._config.validate:
+        validate_occupation_numbers(
+            ket,
+            state.d,
+            state._config.cutoff,
+            context=(
+                " This occurred while preparing the ket component of a "
+                "DensityMatrix instruction."
+            ),
+        )
+        validate_occupation_numbers(
+            bra,
+            state.d,
+            state._config.cutoff,
+            context=(
+                " This occurred while preparing the bra component of a "
+                "DensityMatrix instruction."
+            ),
+        )
+
     index = get_index_in_fock_space(ket)
     dual_index = get_index_in_fock_space(bra)
 

--- a/piquasso/_simulators/fock/pure/simulation_steps/measurements.py
+++ b/piquasso/_simulators/fock/pure/simulation_steps/measurements.py
@@ -18,6 +18,8 @@ from typing import List
 from piquasso.instructions.measurements import PostSelectPhotons
 from piquasso.api.branch import Branch
 
+from piquasso._math.validations import validate_postselection_cutoff
+
 from piquasso._math.fock import get_fock_space_basis
 from piquasso._simulators.fock.simulation_steps import get_projection_operator_indices
 from piquasso._simulators.fock.general.state import FockState
@@ -33,6 +35,22 @@ def post_select_photons(
     postselect_modes = instruction.modes
 
     photon_counts = instruction.params["photon_counts"]
+
+    if state._config.validate:
+        basis = get_fock_space_basis(d=state.d, cutoff=state._config.cutoff)
+        fallback_np = connector.fallback_np
+        nonzero_indices = fallback_np.nonzero(
+            fallback_np.abs(state.state_vector) > 0
+        )[0]
+        prepared_occupation_numbers = (
+            [basis[nonzero_indices[0]]] if len(nonzero_indices) else []
+        )
+        validate_postselection_cutoff(
+            state._config.cutoff,
+            photon_counts,
+            prepared_occupation_numbers,
+            context=f" Instruction: {instruction}.",
+        )
 
     index = get_projection_operator_indices(
         d=state.d,

--- a/piquasso/_simulators/fock/pure/simulation_steps/measurements.py
+++ b/piquasso/_simulators/fock/pure/simulation_steps/measurements.py
@@ -37,18 +37,10 @@ def post_select_photons(
     photon_counts = instruction.params["photon_counts"]
 
     if state._config.validate:
-        basis = get_fock_space_basis(d=state.d, cutoff=state._config.cutoff)
-        fallback_np = connector.fallback_np
-        nonzero_indices = fallback_np.nonzero(fallback_np.abs(state.state_vector) > 0)[
-            0
-        ]
-        prepared_occupation_numbers = (
-            [basis[nonzero_indices[0]]] if len(nonzero_indices) else []
-        )
         validate_postselection_cutoff(
             state._config.cutoff,
             photon_counts,
-            prepared_occupation_numbers,
+            [],
             context=f" Instruction: {instruction}.",
         )
 

--- a/piquasso/_simulators/fock/pure/simulation_steps/measurements.py
+++ b/piquasso/_simulators/fock/pure/simulation_steps/measurements.py
@@ -39,9 +39,9 @@ def post_select_photons(
     if state._config.validate:
         basis = get_fock_space_basis(d=state.d, cutoff=state._config.cutoff)
         fallback_np = connector.fallback_np
-        nonzero_indices = fallback_np.nonzero(
-            fallback_np.abs(state.state_vector) > 0
-        )[0]
+        nonzero_indices = fallback_np.nonzero(fallback_np.abs(state.state_vector) > 0)[
+            0
+        ]
         prepared_occupation_numbers = (
             [basis[nonzero_indices[0]]] if len(nonzero_indices) else []
         )

--- a/piquasso/_simulators/sampling/simulation_steps.py
+++ b/piquasso/_simulators/sampling/simulation_steps.py
@@ -24,7 +24,7 @@ from piquasso._simulators.sampling.state import SamplingState
 
 from piquasso.instructions import gates
 
-from piquasso.api.exceptions import NotImplementedCalculation
+from piquasso.api.exceptions import NotImplementedCalculation, InvalidState
 from piquasso.api.branch import Branch
 from piquasso.api.instruction import Instruction
 
@@ -55,9 +55,40 @@ def create(state: SamplingState, instruction: Instruction, shots: int) -> List[B
     modes = instruction.modes
 
     for i in range(len(state._occupation_numbers)):
-        state._occupation_numbers[i][modes,] += 1
+        occupation_numbers = state._occupation_numbers[i].copy()
+        occupation_numbers[modes,] += 1
+        _validate_or_infer_cutoff(state, occupation_numbers, instruction)
+        state._occupation_numbers[i] = occupation_numbers
 
     return [Branch(state=state)]
+
+
+def _validate_or_infer_cutoff(
+    state: SamplingState,
+    occupation_numbers: np.ndarray,
+    instruction: Instruction,
+) -> None:
+    occupation_numbers_tuple = tuple(int(number) for number in occupation_numbers)
+
+    if state._config.validate and len(occupation_numbers) != state.d:
+        raise InvalidState(
+            f"The occupation numbers '{occupation_numbers_tuple}' are not "
+            f"well-defined on '{state.d}' modes."
+            f" Instruction: {instruction}."
+        )
+
+    if state._config._cutoff_was_explicit:
+        if state._config.validate:
+            validate_occupation_numbers(
+                occupation_numbers_tuple,
+                state.d,
+                state._config.cutoff,
+                context=f" Instruction: {instruction}.",
+            )
+        return
+
+    required_cutoff = int(np.sum(occupation_numbers)) + 1
+    state._config.cutoff = max(state._config.cutoff, required_cutoff)
 
 
 def state_vector(
@@ -69,15 +100,11 @@ def state_vector(
         occupation_numbers = instruction._get_all_params(state._connector)[
             "occupation_numbers"
         ]
-        if state._config.validate:
-            validate_occupation_numbers(
-                occupation_numbers,
-                state.d,
-                state._config.cutoff,
-                context=f" Instruction: {instruction}.",
-            )
+        occupation_numbers = np.rint(occupation_numbers).astype(int)
 
-        state._occupation_numbers.append(np.rint(occupation_numbers).astype(int))
+        _validate_or_infer_cutoff(state, occupation_numbers, instruction)
+
+        state._occupation_numbers.append(occupation_numbers)
         state._coefficients.append(coefficient)
 
     elif "fock_amplitude_map" in instruction._get_all_params(state._connector):
@@ -85,15 +112,11 @@ def state_vector(
             state._connector
         )["fock_amplitude_map"].items():
 
-            if state._config.validate:
-                validate_occupation_numbers(
-                    occupation_numbers,
-                    state.d,
-                    state._config.cutoff,
-                    context=f" Instruction: {instruction}.",
-                )
+            occupation_numbers = np.rint(occupation_numbers).astype(int)
 
-            state._occupation_numbers.append(np.rint(occupation_numbers).astype(int))
+            _validate_or_infer_cutoff(state, occupation_numbers, instruction)
+
+            state._occupation_numbers.append(occupation_numbers)
             state._coefficients.append(coefficient * amplitude)
 
     return [Branch(state=state)]
@@ -275,13 +298,18 @@ def post_select_photons(
 
     photon_counts = instruction.params["photon_counts"]
 
-    if state._config.validate:
+    if state._config._cutoff_was_explicit and state._config.validate:
         validate_postselection_cutoff(
             state._config.cutoff,
             photon_counts,
             state._occupation_numbers,
             context=f" Instruction: {instruction}.",
         )
+    elif not state._config._cutoff_was_explicit:
+        required_cutoff = int(np.sum(photon_counts)) + 1
+        for occupation_numbers in state._occupation_numbers:
+            required_cutoff = max(required_cutoff, int(np.sum(occupation_numbers)) + 1)
+        state._config.cutoff = max(state._config.cutoff, required_cutoff)
 
     state._set_postselection(modes, photon_counts)
 

--- a/piquasso/_simulators/sampling/simulation_steps.py
+++ b/piquasso/_simulators/sampling/simulation_steps.py
@@ -28,6 +28,11 @@ from piquasso.api.exceptions import InvalidState, NotImplementedCalculation
 from piquasso.api.branch import Branch
 from piquasso.api.instruction import Instruction
 
+from piquasso._math.validations import (
+    validate_occupation_numbers,
+    validate_postselection_cutoff,
+)
+
 from piquasso._simulators.fock.pure.simulation_steps import (
     imperfect_post_select_photons as pure_fock_imperfect_post_select_photons,
 )
@@ -64,10 +69,12 @@ def state_vector(
         occupation_numbers = instruction._get_all_params(state._connector)[
             "occupation_numbers"
         ]
-        if state._config.validate and len(occupation_numbers) != state.d:
-            raise InvalidState(
-                f"The occupation numbers '{occupation_numbers}' are not well-defined "
-                f"on '{state.d}' modes: instruction={instruction}"
+        if state._config.validate:
+            validate_occupation_numbers(
+                occupation_numbers,
+                state.d,
+                state._config.cutoff,
+                context=f" Instruction: {instruction}.",
             )
 
         state._occupation_numbers.append(np.rint(occupation_numbers).astype(int))
@@ -78,11 +85,12 @@ def state_vector(
             state._connector
         )["fock_amplitude_map"].items():
 
-            if state._config.validate and len(occupation_numbers) != state.d:
-                raise InvalidState(
-                    f"The occupation numbers '{occupation_numbers}' "
-                    f"are not well-defined "
-                    f"on '{state.d}' modes: instruction={instruction}"
+            if state._config.validate:
+                validate_occupation_numbers(
+                    occupation_numbers,
+                    state.d,
+                    state._config.cutoff,
+                    context=f" Instruction: {instruction}.",
                 )
 
             state._occupation_numbers.append(np.rint(occupation_numbers).astype(int))
@@ -266,6 +274,14 @@ def post_select_photons(
     modes = instruction.modes
 
     photon_counts = instruction.params["photon_counts"]
+
+    if state._config.validate:
+        validate_postselection_cutoff(
+            state._config.cutoff,
+            photon_counts,
+            state._occupation_numbers,
+            context=f" Instruction: {instruction}.",
+        )
 
     state._set_postselection(modes, photon_counts)
 

--- a/piquasso/_simulators/sampling/simulation_steps.py
+++ b/piquasso/_simulators/sampling/simulation_steps.py
@@ -24,7 +24,7 @@ from piquasso._simulators.sampling.state import SamplingState
 
 from piquasso.instructions import gates
 
-from piquasso.api.exceptions import InvalidState, NotImplementedCalculation
+from piquasso.api.exceptions import NotImplementedCalculation
 from piquasso.api.branch import Branch
 from piquasso.api.instruction import Instruction
 

--- a/piquasso/_simulators/sampling/simulator.py
+++ b/piquasso/_simulators/sampling/simulator.py
@@ -82,6 +82,14 @@ class SamplingSimulator(BuiltinSimulator):
         :class:`~piquasso.instructions.channels.Loss`,
         :class:`~piquasso.instructions.channels.UniformLoss`,
         :class:`~piquasso.instructions.channels.LossyInterferometer`.
+
+    Note:
+        The ``cutoff`` in :class:`~piquasso.api.config.Config` limits the truncated
+        Fock space used by properties such as
+        :attr:`~piquasso._simulators.sampling.state.SamplingState.state_vector`.
+        If the total photon number in a prepared state is greater than or equal to
+        ``cutoff``, increase it when constructing the simulator, e.g.
+        ``pq.SamplingSimulator(d=6, config=pq.Config(cutoff=5))``.
     """
 
     _instruction_map = {

--- a/piquasso/_simulators/sampling/simulator.py
+++ b/piquasso/_simulators/sampling/simulator.py
@@ -84,12 +84,11 @@ class SamplingSimulator(BuiltinSimulator):
         :class:`~piquasso.instructions.channels.LossyInterferometer`.
 
     Note:
-        The ``cutoff`` in :class:`~piquasso.api.config.Config` limits the truncated
-        Fock space used by properties such as
-        :attr:`~piquasso._simulators.sampling.state.SamplingState.state_vector`.
-        If the total photon number in a prepared state is greater than or equal to
-        ``cutoff``, increase it when constructing the simulator, e.g.
-        ``pq.SamplingSimulator(d=6, config=pq.Config(cutoff=5))``.
+        By default, ``cutoff`` is inferred from prepared occupation numbers and
+        postselection instructions. Properties such as
+        :attr:`~piquasso._simulators.sampling.state.SamplingState.state_vector`
+        use this truncated Fock space. To enforce a specific cutoff, pass it
+        explicitly, e.g. ``pq.SamplingSimulator(d=6, config=pq.Config(cutoff=5))``.
     """
 
     _instruction_map = {

--- a/piquasso/api/config.py
+++ b/piquasso/api/config.py
@@ -26,7 +26,13 @@ from piquasso.core import _mixins
 class Config(_mixins.CodeMixin):
     """The configuration for the simulation.
 
-    :ivar cutoff: The Fock space cutoff. Defaults to `4`.
+    :ivar cutoff:
+        The Fock space cutoff/truncation. Defaults to `None`, which means the cutoff
+        is inferred from the program whenever possible, for example for simulations
+        with a fixed particle number. If no cutoff can be inferred, a default value
+        of `4` is used. An explicitly specified cutoff is always respected, and is
+        useful when automatic inference is not possible, such as when computing the
+        density matrix of a Gaussian state.
     :ivar dtype:
         The underlying datatype of the simulation. Possible values: `np.float32` and
         `np.float64`. Defaults to `np.float64`.
@@ -60,7 +66,7 @@ class Config(_mixins.CodeMixin):
     def __init__(
         self,
         *,
-        cutoff: int = 4,
+        cutoff: Optional[int] = None,
         dtype: type = np.float64,
         measurement_cutoff: int = 5,
         hbar: float = 2.0,
@@ -78,7 +84,8 @@ class Config(_mixins.CodeMixin):
         self.cache_size = cache_size
         self.hbar = hbar
         self.use_torontonian = use_torontonian
-        self.cutoff = cutoff
+        self._cutoff_was_explicit = cutoff is not None
+        self.cutoff = 4 if cutoff is None else cutoff
         self.measurement_cutoff = measurement_cutoff
         self.dtype = np.float64 if dtype is float else dtype
         self.validate = validate
@@ -93,6 +100,7 @@ class Config(_mixins.CodeMixin):
             and self.cache_size == other.cache_size
             and self.hbar == other.hbar
             and self.use_torontonian == other.use_torontonian
+            and self._cutoff_was_explicit == other._cutoff_was_explicit
             and self.cutoff == other.cutoff
             and self.measurement_cutoff == other.measurement_cutoff
             and self.dtype == other.dtype
@@ -113,7 +121,7 @@ class Config(_mixins.CodeMixin):
             non_default_params["hbar"] = self.hbar
         if self.use_torontonian != default_config.use_torontonian:
             non_default_params["use_torontonian"] = self.use_torontonian
-        if self.cutoff != default_config.cutoff:
+        if self._cutoff_was_explicit:
             non_default_params["cutoff"] = self.cutoff
         if self.measurement_cutoff != default_config.measurement_cutoff:
             non_default_params["measurement_cutoff"] = self.measurement_cutoff

--- a/tests/_math/test_validations.py
+++ b/tests/_math/test_validations.py
@@ -13,15 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from piquasso._math.validations import (
-    is_natural,
-    all_natural,
-    validate_occupation_numbers,
-    validate_postselection_cutoff,
-)
-from piquasso.api.exceptions import InvalidState
-
-import pytest
+from piquasso._math.validations import is_natural, all_natural
 
 
 def test_zero_is_natural():
@@ -50,36 +42,3 @@ def test_all_natural_positive_case():
 
 def test_all_natural_negative_case():
     assert not all_natural([1, 1.0, 0.0, -2.0])
-
-
-def test_validate_occupation_numbers_includes_cutoff_hint():
-    with pytest.raises(InvalidState) as error:
-        validate_occupation_numbers([0, 1, 0, 1, 1, 1], d=6, cutoff=4)
-
-    assert "pq.Config(cutoff=5)" in error.value.args[0]
-
-
-def test_validate_postselection_cutoff_when_postselection_consumes_cutoff():
-    with pytest.raises(InvalidState) as error:
-        validate_postselection_cutoff(
-            cutoff=3,
-            photon_counts=(1, 1, 1),
-            occupation_numbers=[[1, 1, 1, 0]],
-        )
-
-    message = error.value.args[0]
-    assert "Post-selecting 3 photon(s)" in message
-    assert "pq.Config(cutoff=4)" in message
-
-
-def test_validate_postselection_cutoff_when_remaining_photons_exceed_truncation():
-    with pytest.raises(InvalidState) as error:
-        validate_postselection_cutoff(
-            cutoff=5,
-            photon_counts=(0, 0),
-            occupation_numbers=[[2, 1, 1, 1, 0, 0]],
-        )
-
-    message = error.value.args[0]
-    assert "After post-selecting" in message
-    assert "pq.Config(cutoff=6)" in message

--- a/tests/_math/test_validations.py
+++ b/tests/_math/test_validations.py
@@ -13,7 +13,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from piquasso._math.validations import is_natural, all_natural
+from piquasso._math.validations import (
+    is_natural,
+    all_natural,
+    validate_occupation_numbers,
+    validate_postselection_cutoff,
+)
+from piquasso.api.exceptions import InvalidState
+
+import pytest
 
 
 def test_zero_is_natural():
@@ -42,3 +50,36 @@ def test_all_natural_positive_case():
 
 def test_all_natural_negative_case():
     assert not all_natural([1, 1.0, 0.0, -2.0])
+
+
+def test_validate_occupation_numbers_includes_cutoff_hint():
+    with pytest.raises(InvalidState) as error:
+        validate_occupation_numbers([0, 1, 0, 1, 1, 1], d=6, cutoff=4)
+
+    assert "pq.Config(cutoff=5)" in error.value.args[0]
+
+
+def test_validate_postselection_cutoff_when_postselection_consumes_cutoff():
+    with pytest.raises(InvalidState) as error:
+        validate_postselection_cutoff(
+            cutoff=3,
+            photon_counts=(1, 1, 1),
+            occupation_numbers=[[1, 1, 1, 0]],
+        )
+
+    message = error.value.args[0]
+    assert "Post-selecting 3 photon(s)" in message
+    assert "pq.Config(cutoff=4)" in message
+
+
+def test_validate_postselection_cutoff_when_remaining_photons_exceed_truncation():
+    with pytest.raises(InvalidState) as error:
+        validate_postselection_cutoff(
+            cutoff=5,
+            photon_counts=(0, 0),
+            occupation_numbers=[[2, 1, 1, 1, 0, 0]],
+        )
+
+    message = error.value.args[0]
+    assert "After post-selecting" in message
+    assert "pq.Config(cutoff=6)" in message

--- a/tests/_simulators/fock/general/test_preparations.py
+++ b/tests/_simulators/fock/general/test_preparations.py
@@ -105,10 +105,13 @@ def test_density_matrix_raises_InvalidState_when_ket_cutoff_too_small():
     with pytest.raises(pq.api.exceptions.InvalidState) as error:
         simulator.execute(program)
 
-    message = error.value.args[0]
-    assert "require a cutoff of at least '5'" in message
-    assert "preparing the ket component of a DensityMatrix" in message
-    assert "pq.Config(cutoff=5)" in message
+    assert error.value.args[0] == (
+        "The occupation numbers '(0, 1, 0, 1, 1, 1)' require "
+        "a cutoff of at least '5', but the provided cutoff is '4'. "
+        "Consider increasing the cutoff via `pq.Config(cutoff=5)` "
+        "when creating the simulator. This occurred while preparing the ket "
+        "component of a DensityMatrix instruction."
+    )
 
 
 def test_density_matrix_raises_InvalidState_when_bra_cutoff_too_small():
@@ -122,10 +125,13 @@ def test_density_matrix_raises_InvalidState_when_bra_cutoff_too_small():
     with pytest.raises(pq.api.exceptions.InvalidState) as error:
         simulator.execute(program)
 
-    message = error.value.args[0]
-    assert "require a cutoff of at least '5'" in message
-    assert "preparing the bra component of a DensityMatrix" in message
-    assert "pq.Config(cutoff=5)" in message
+    assert error.value.args[0] == (
+        "The occupation numbers '(0, 1, 0, 1, 1, 1)' require "
+        "a cutoff of at least '5', but the provided cutoff is '4'. "
+        "Consider increasing the cutoff via `pq.Config(cutoff=5)` "
+        "when creating the simulator. This occurred while preparing the bra "
+        "component of a DensityMatrix instruction."
+    )
 
 
 def test_creation_on_multiple_modes():

--- a/tests/_simulators/fock/general/test_preparations.py
+++ b/tests/_simulators/fock/general/test_preparations.py
@@ -94,6 +94,40 @@ def test_overflow_with_zero_norm_raises_InvalidState_when_normalized():
     assert error.value.args[0] == "The norm of the state is 0."
 
 
+def test_density_matrix_raises_InvalidState_when_ket_cutoff_too_small():
+    occupation_numbers = [0, 1, 0, 1, 1, 1]
+
+    with pq.Program() as program:
+        pq.Q() | pq.DensityMatrix(ket=occupation_numbers, bra=[0, 0, 0, 0, 0, 0])
+
+    simulator = pq.FockSimulator(d=6, config=pq.Config(cutoff=4, validate=True))
+
+    with pytest.raises(pq.api.exceptions.InvalidState) as error:
+        simulator.execute(program)
+
+    message = error.value.args[0]
+    assert "require a cutoff of at least '5'" in message
+    assert "preparing the ket component of a DensityMatrix" in message
+    assert "pq.Config(cutoff=5)" in message
+
+
+def test_density_matrix_raises_InvalidState_when_bra_cutoff_too_small():
+    occupation_numbers = [0, 1, 0, 1, 1, 1]
+
+    with pq.Program() as program:
+        pq.Q() | pq.DensityMatrix(ket=[0, 0, 0, 0, 0, 0], bra=occupation_numbers)
+
+    simulator = pq.FockSimulator(d=6, config=pq.Config(cutoff=4, validate=True))
+
+    with pytest.raises(pq.api.exceptions.InvalidState) as error:
+        simulator.execute(program)
+
+    message = error.value.args[0]
+    assert "require a cutoff of at least '5'" in message
+    assert "preparing the bra component of a DensityMatrix" in message
+    assert "pq.Config(cutoff=5)" in message
+
+
 def test_creation_on_multiple_modes():
     with pq.Program() as program:
         pq.Q() | pq.DensityMatrix(ket=[0, 0, 1], bra=[0, 0, 1]) * 2 / 5

--- a/tests/_simulators/fock/pure/test_measurements.py
+++ b/tests/_simulators/fock/pure/test_measurements.py
@@ -608,3 +608,18 @@ def test_unresolved_squeezing_with_expression():
             .state
         )
         assert branch.state == expected_state
+
+
+def test_PostSelectPhotons_raises_InvalidState_when_postselection_exceeds_cutoff():
+    with pq.Program() as program:
+        pq.Q() | pq.StateVector([1, 1, 1, 0])
+        pq.Q(0, 1, 2) | pq.PostSelectPhotons(photon_counts=[2, 2, 1])
+
+    simulator = pq.PureFockSimulator(d=4, config=pq.Config(cutoff=5, validate=True))
+
+    with pytest.raises(pq.api.exceptions.InvalidState) as error:
+        simulator.execute(program)
+
+    message = error.value.args[0]
+    assert "Post-selecting 5 photon(s)" in message
+    assert "pq.Config(cutoff=6)" in message

--- a/tests/_simulators/fock/pure/test_measurements.py
+++ b/tests/_simulators/fock/pure/test_measurements.py
@@ -620,6 +620,9 @@ def test_PostSelectPhotons_raises_InvalidState_when_postselection_exceeds_cutoff
     with pytest.raises(pq.api.exceptions.InvalidState) as error:
         simulator.execute(program)
 
-    message = error.value.args[0]
-    assert "Post-selecting 5 photon(s)" in message
-    assert "pq.Config(cutoff=6)" in message
+    assert error.value.args[0] == (
+        "Post-selecting 5 photon(s) on [2, 2, 1] requires a cutoff of at least "
+        "'6', but the provided cutoff is '5'. Consider increasing the cutoff via "
+        "`pq.Config(cutoff=6)` when creating the simulator. Instruction: "
+        "PostSelectPhotons(photon_counts=[2, 2, 1], modes=(0, 1, 2))."
+    )

--- a/tests/_simulators/sampling/test_measurements.py
+++ b/tests/_simulators/sampling/test_measurements.py
@@ -282,9 +282,7 @@ def test_boson_sampling_seeded():
 
         pq.Q(all) | pq.ParticleNumberMeasurement()
 
-    simulator = pq.SamplingSimulator(
-        d=5, config=pq.Config(cutoff=6, seed_sequence=seed_sequence)
-    )
+    simulator = pq.SamplingSimulator(d=5, config=pq.Config(seed_sequence=seed_sequence))
     samples = simulator.execute(program, shots=20).samples
 
     expected_samples = [
@@ -367,9 +365,7 @@ def test_LossyInterferometer_boson_sampling_seeded():
 
         pq.Q(all) | pq.ParticleNumberMeasurement()
 
-    simulator = pq.SamplingSimulator(
-        d=5, config=pq.Config(cutoff=6, seed_sequence=seed_sequence)
-    )
+    simulator = pq.SamplingSimulator(d=5, config=pq.Config(seed_sequence=seed_sequence))
     samples = simulator.execute(program, shots=20).samples
 
     expected_samples = [
@@ -452,9 +448,7 @@ def test_LossyInterferometer_boson_sampling_uniform_losses():
 
         pq.Q(all) | pq.ParticleNumberMeasurement()
 
-    simulator = pq.SamplingSimulator(
-        d=5, config=pq.Config(cutoff=6, seed_sequence=seed_sequence)
-    )
+    simulator = pq.SamplingSimulator(d=5, config=pq.Config(seed_sequence=seed_sequence))
     samples = simulator.execute(program, shots=20).samples
 
     expected_samples = [
@@ -543,7 +537,7 @@ def test_PostSelectPhotons_state_vector_random():
         pq.Q() | program_without_postselection
         pq.Q(0, 1) | pq.PostSelectPhotons(photon_counts=[1, 0])
 
-    simulator = pq.SamplingSimulator(config=pq.Config(cutoff=5))
+    simulator = pq.SamplingSimulator()
     state = simulator.execute(program_without_postselection).state
     postselected_state = simulator.execute(program_with_postselection).state
 
@@ -579,6 +573,17 @@ def test_PostSelectPhotons_state_vector_with_more_photons():
             occupation_number[2],
         )
         assert np.isclose(state_vector_map[index], coeff)
+
+
+def test_PostSelectPhotons_infers_cutoff_for_state_vector():
+    with pq.Program() as program:
+        pq.Q() | pq.StateVector([0, 1, 0, 1, 1, 1])
+        pq.Q(4, 5) | pq.PostSelectPhotons(photon_counts=[1, 1])
+
+    state = pq.SamplingSimulator(d=6).execute(program, shots=100).state
+
+    assert state._config.cutoff == 3
+    assert len(state.state_vector) > 0
 
 
 @pytest.mark.monkey
@@ -618,7 +623,7 @@ def test_PostSelectPhotons_get_particle_detection_probability():
         pq.Q(1, 2) | pq.Beamsplitter5050()
         pq.Q(0, 1) | pq.PostSelectPhotons(photon_counts=[1, 0])
 
-    simulator = pq.SamplingSimulator(config=pq.Config(cutoff=5))
+    simulator = pq.SamplingSimulator()
     state = simulator.execute(program).state
 
     probability = state.get_particle_detection_probability((1,))
@@ -636,7 +641,7 @@ def test_multiple_overlapping_PostSelectPhotons_raise_ValueError():
         pq.Q(0, 1) | pq.PostSelectPhotons(photon_counts=[1, 0])
         pq.Q(1, 2) | pq.PostSelectPhotons(photon_counts=[0, 1])
 
-    simulator = pq.SamplingSimulator(config=pq.Config(cutoff=5))
+    simulator = pq.SamplingSimulator()
 
     with pytest.raises(
         ValueError,
@@ -664,7 +669,7 @@ def test_multiple_non_overlapping_PostSelectPhotons_no_error():
         pq.Q(all) | pq.Interferometer(interferometer_matrix)
         pq.Q(0, 1) | pq.PostSelectPhotons(photon_counts=[1, 2])
 
-    simulator = pq.SamplingSimulator(config=pq.Config(cutoff=6))
+    simulator = pq.SamplingSimulator()
 
     state_1 = simulator.execute(program_1).state
     state_2 = simulator.execute(program_2).state
@@ -681,7 +686,7 @@ def test_PostSelectPhotons_no_infinite_loop_via_max_sample_generation_trials():
         pq.Q(2, 3) | pq.ParticleNumberMeasurement()
 
     simulator = pq.SamplingSimulator(
-        config=pq.Config(cutoff=5, max_sample_generation_trials=10),
+        config=pq.Config(max_sample_generation_trials=10),
     )
 
     with pytest.raises(
@@ -755,9 +760,7 @@ class TestMidCircuitMeasurements:
             ]
         )
 
-        simulator = pq.SamplingSimulator(
-            d=d, config=pq.Config(cutoff=9, seed_sequence=42)
-        )
+        simulator = pq.SamplingSimulator(d=d, config=pq.Config(seed_sequence=42))
         result = simulator.execute(program, shots=10)
         samples = result.samples
 
@@ -782,9 +785,7 @@ class TestMidCircuitMeasurements:
             ]
         )
 
-        simulator = pq.SamplingSimulator(
-            d=d, config=pq.Config(cutoff=5, seed_sequence=42)
-        )
+        simulator = pq.SamplingSimulator(d=d, config=pq.Config(seed_sequence=42))
         result = simulator.execute(program, shots=10)
         samples = result.samples
 
@@ -811,9 +812,7 @@ class TestMidCircuitMeasurements:
             ]
         )
 
-        simulator = pq.SamplingSimulator(
-            d=d, config=pq.Config(cutoff=5, seed_sequence=42)
-        )
+        simulator = pq.SamplingSimulator(d=d, config=pq.Config(seed_sequence=42))
         result = simulator.execute(program, shots=10)
         samples = result.samples
 
@@ -828,7 +827,7 @@ class TestMidCircuitMeasurements:
             pq.Q(0) | pq.PostSelectPhotons(photon_counts=[1])
             pq.Q(0, 1) | pq.Beamsplitter5050()
 
-        simulator = pq.SamplingSimulator(config=pq.Config(cutoff=5))
+        simulator = pq.SamplingSimulator()
         with pytest.raises(
             ValueError,
             match=re.escape(
@@ -851,7 +850,7 @@ class TestMidCircuitMeasurements:
             pq.Q(0) | pq.PostSelectPhotons(photon_counts=[1])
             pq.Q(1, 2) | pq.Beamsplitter5050()
 
-        simulator = pq.SamplingSimulator(config=pq.Config(cutoff=5))
+        simulator = pq.SamplingSimulator()
         state_1 = simulator.execute(program_1).state
         state_2 = simulator.execute(program_2).state
 

--- a/tests/_simulators/sampling/test_measurements.py
+++ b/tests/_simulators/sampling/test_measurements.py
@@ -282,7 +282,9 @@ def test_boson_sampling_seeded():
 
         pq.Q(all) | pq.ParticleNumberMeasurement()
 
-    simulator = pq.SamplingSimulator(d=5, config=pq.Config(cutoff=6, seed_sequence=seed_sequence))
+    simulator = pq.SamplingSimulator(
+        d=5, config=pq.Config(cutoff=6, seed_sequence=seed_sequence)
+    )
     samples = simulator.execute(program, shots=20).samples
 
     expected_samples = [
@@ -365,7 +367,9 @@ def test_LossyInterferometer_boson_sampling_seeded():
 
         pq.Q(all) | pq.ParticleNumberMeasurement()
 
-    simulator = pq.SamplingSimulator(d=5, config=pq.Config(cutoff=6, seed_sequence=seed_sequence))
+    simulator = pq.SamplingSimulator(
+        d=5, config=pq.Config(cutoff=6, seed_sequence=seed_sequence)
+    )
     samples = simulator.execute(program, shots=20).samples
 
     expected_samples = [
@@ -448,7 +452,9 @@ def test_LossyInterferometer_boson_sampling_uniform_losses():
 
         pq.Q(all) | pq.ParticleNumberMeasurement()
 
-    simulator = pq.SamplingSimulator(d=5, config=pq.Config(cutoff=6, seed_sequence=seed_sequence))
+    simulator = pq.SamplingSimulator(
+        d=5, config=pq.Config(cutoff=6, seed_sequence=seed_sequence)
+    )
     samples = simulator.execute(program, shots=20).samples
 
     expected_samples = [
@@ -749,7 +755,9 @@ class TestMidCircuitMeasurements:
             ]
         )
 
-        simulator = pq.SamplingSimulator(d=d, config=pq.Config(cutoff=9, seed_sequence=42))
+        simulator = pq.SamplingSimulator(
+            d=d, config=pq.Config(cutoff=9, seed_sequence=42)
+        )
         result = simulator.execute(program, shots=10)
         samples = result.samples
 
@@ -774,7 +782,9 @@ class TestMidCircuitMeasurements:
             ]
         )
 
-        simulator = pq.SamplingSimulator(d=d, config=pq.Config(cutoff=5, seed_sequence=42))
+        simulator = pq.SamplingSimulator(
+            d=d, config=pq.Config(cutoff=5, seed_sequence=42)
+        )
         result = simulator.execute(program, shots=10)
         samples = result.samples
 
@@ -801,7 +811,9 @@ class TestMidCircuitMeasurements:
             ]
         )
 
-        simulator = pq.SamplingSimulator(d=d, config=pq.Config(cutoff=5, seed_sequence=42))
+        simulator = pq.SamplingSimulator(
+            d=d, config=pq.Config(cutoff=5, seed_sequence=42)
+        )
         result = simulator.execute(program, shots=10)
         samples = result.samples
 

--- a/tests/_simulators/sampling/test_measurements.py
+++ b/tests/_simulators/sampling/test_measurements.py
@@ -282,7 +282,7 @@ def test_boson_sampling_seeded():
 
         pq.Q(all) | pq.ParticleNumberMeasurement()
 
-    simulator = pq.SamplingSimulator(d=5, config=pq.Config(seed_sequence=seed_sequence))
+    simulator = pq.SamplingSimulator(d=5, config=pq.Config(cutoff=6, seed_sequence=seed_sequence))
     samples = simulator.execute(program, shots=20).samples
 
     expected_samples = [
@@ -365,7 +365,7 @@ def test_LossyInterferometer_boson_sampling_seeded():
 
         pq.Q(all) | pq.ParticleNumberMeasurement()
 
-    simulator = pq.SamplingSimulator(d=5, config=pq.Config(seed_sequence=seed_sequence))
+    simulator = pq.SamplingSimulator(d=5, config=pq.Config(cutoff=6, seed_sequence=seed_sequence))
     samples = simulator.execute(program, shots=20).samples
 
     expected_samples = [
@@ -448,7 +448,7 @@ def test_LossyInterferometer_boson_sampling_uniform_losses():
 
         pq.Q(all) | pq.ParticleNumberMeasurement()
 
-    simulator = pq.SamplingSimulator(d=5, config=pq.Config(seed_sequence=seed_sequence))
+    simulator = pq.SamplingSimulator(d=5, config=pq.Config(cutoff=6, seed_sequence=seed_sequence))
     samples = simulator.execute(program, shots=20).samples
 
     expected_samples = [
@@ -537,7 +537,7 @@ def test_PostSelectPhotons_state_vector_random():
         pq.Q() | program_without_postselection
         pq.Q(0, 1) | pq.PostSelectPhotons(photon_counts=[1, 0])
 
-    simulator = pq.SamplingSimulator()
+    simulator = pq.SamplingSimulator(config=pq.Config(cutoff=5))
     state = simulator.execute(program_without_postselection).state
     postselected_state = simulator.execute(program_with_postselection).state
 
@@ -612,7 +612,7 @@ def test_PostSelectPhotons_get_particle_detection_probability():
         pq.Q(1, 2) | pq.Beamsplitter5050()
         pq.Q(0, 1) | pq.PostSelectPhotons(photon_counts=[1, 0])
 
-    simulator = pq.SamplingSimulator()
+    simulator = pq.SamplingSimulator(config=pq.Config(cutoff=5))
     state = simulator.execute(program).state
 
     probability = state.get_particle_detection_probability((1,))
@@ -630,7 +630,7 @@ def test_multiple_overlapping_PostSelectPhotons_raise_ValueError():
         pq.Q(0, 1) | pq.PostSelectPhotons(photon_counts=[1, 0])
         pq.Q(1, 2) | pq.PostSelectPhotons(photon_counts=[0, 1])
 
-    simulator = pq.SamplingSimulator()
+    simulator = pq.SamplingSimulator(config=pq.Config(cutoff=5))
 
     with pytest.raises(
         ValueError,
@@ -658,7 +658,7 @@ def test_multiple_non_overlapping_PostSelectPhotons_no_error():
         pq.Q(all) | pq.Interferometer(interferometer_matrix)
         pq.Q(0, 1) | pq.PostSelectPhotons(photon_counts=[1, 2])
 
-    simulator = pq.SamplingSimulator()
+    simulator = pq.SamplingSimulator(config=pq.Config(cutoff=6))
 
     state_1 = simulator.execute(program_1).state
     state_2 = simulator.execute(program_2).state
@@ -675,7 +675,7 @@ def test_PostSelectPhotons_no_infinite_loop_via_max_sample_generation_trials():
         pq.Q(2, 3) | pq.ParticleNumberMeasurement()
 
     simulator = pq.SamplingSimulator(
-        config=pq.Config(max_sample_generation_trials=10),
+        config=pq.Config(cutoff=5, max_sample_generation_trials=10),
     )
 
     with pytest.raises(
@@ -749,7 +749,7 @@ class TestMidCircuitMeasurements:
             ]
         )
 
-        simulator = pq.SamplingSimulator(d=d, config=pq.Config(seed_sequence=42))
+        simulator = pq.SamplingSimulator(d=d, config=pq.Config(cutoff=9, seed_sequence=42))
         result = simulator.execute(program, shots=10)
         samples = result.samples
 
@@ -774,7 +774,7 @@ class TestMidCircuitMeasurements:
             ]
         )
 
-        simulator = pq.SamplingSimulator(d=d, config=pq.Config(seed_sequence=42))
+        simulator = pq.SamplingSimulator(d=d, config=pq.Config(cutoff=5, seed_sequence=42))
         result = simulator.execute(program, shots=10)
         samples = result.samples
 
@@ -801,7 +801,7 @@ class TestMidCircuitMeasurements:
             ]
         )
 
-        simulator = pq.SamplingSimulator(d=d, config=pq.Config(seed_sequence=42))
+        simulator = pq.SamplingSimulator(d=d, config=pq.Config(cutoff=5, seed_sequence=42))
         result = simulator.execute(program, shots=10)
         samples = result.samples
 
@@ -816,7 +816,7 @@ class TestMidCircuitMeasurements:
             pq.Q(0) | pq.PostSelectPhotons(photon_counts=[1])
             pq.Q(0, 1) | pq.Beamsplitter5050()
 
-        simulator = pq.SamplingSimulator()
+        simulator = pq.SamplingSimulator(config=pq.Config(cutoff=5))
         with pytest.raises(
             ValueError,
             match=re.escape(
@@ -839,7 +839,7 @@ class TestMidCircuitMeasurements:
             pq.Q(0) | pq.PostSelectPhotons(photon_counts=[1])
             pq.Q(1, 2) | pq.Beamsplitter5050()
 
-        simulator = pq.SamplingSimulator()
+        simulator = pq.SamplingSimulator(config=pq.Config(cutoff=5))
         state_1 = simulator.execute(program_1).state
         state_2 = simulator.execute(program_2).state
 

--- a/tests/_simulators/sampling/test_preparations.py
+++ b/tests/_simulators/sampling/test_preparations.py
@@ -44,10 +44,75 @@ def test_initial_state_raises_InvalidState_for_occupation_numbers_of_differing_l
         simulator.execute(program).state
 
     assert error.value.args[0] == (
-        "The occupation numbers '(1, 1, 1)' are not well-defined on '5' modes: "
-        "instruction=StateVector(occupation_numbers=(1, 1, 1), "
-        "coefficient=0.7071067811865475, modes=(0, 1, 2, 3, 4))"
+        "The occupation numbers '(1, 1, 1)' are not well-defined on '5' modes."
+        " Instruction: StateVector(occupation_numbers=(1, 1, 1), "
+        "coefficient=0.7071067811865475, modes=(0, 1, 2, 3, 4))."
     )
+
+
+def test_initial_state_raises_InvalidState_when_cutoff_too_small():
+    occupation_numbers = [0, 1, 0, 1, 1, 1]
+
+    with pq.Program() as program:
+        pq.Q() | pq.StateVector(occupation_numbers)
+
+    simulator = pq.SamplingSimulator(d=6, config=pq.Config(cutoff=4, validate=True))
+
+    with pytest.raises(pq.api.exceptions.InvalidState) as error:
+        simulator.execute(program)
+
+    message = error.value.args[0]
+    assert "require a cutoff of at least '5'" in message
+    assert "provided cutoff is '4'" in message
+    assert "pq.Config(cutoff=5)" in message
+
+
+def test_initial_state_with_fock_amplitude_map_raises_InvalidState_when_cutoff_too_small():
+    occupation_numbers = (0, 1, 0, 1, 1, 1)
+
+    with pq.Program() as program:
+        pq.Q() | pq.StateVector(fock_amplitude_map={occupation_numbers: 1.0})
+
+    simulator = pq.SamplingSimulator(d=6, config=pq.Config(cutoff=4, validate=True))
+
+    with pytest.raises(pq.api.exceptions.InvalidState) as error:
+        simulator.execute(program)
+
+    message = error.value.args[0]
+    assert "require a cutoff of at least '5'" in message
+    assert "pq.Config(cutoff=5)" in message
+
+
+def test_issue_472_PostSelectPhotons_raises_InvalidState_instead_of_IndexError():
+    """Regression test for https://github.com/Budapest-Quantum-Computing-Group/piquasso/issues/472."""
+    d = 6
+    with pq.Program() as program:
+        pq.Q() | pq.StateVector([0, 1, 0, 1, 1, 1])
+        pq.Q(4, 5) | pq.PostSelectPhotons(photon_counts=[1, 1])
+
+    sim = pq.SamplingSimulator(d=d)
+
+    with pytest.raises(pq.api.exceptions.InvalidState) as error:
+        sim.execute(program, shots=100)
+
+    message = error.value.args[0]
+    assert "require a cutoff of at least '5'" in message
+    assert "pq.Config(cutoff=5)" in message
+
+
+def test_PostSelectPhotons_raises_InvalidState_when_postselection_exceeds_cutoff():
+    with pq.Program() as program:
+        pq.Q() | pq.StateVector([1, 1, 1, 0])
+        pq.Q(0, 1, 2) | pq.PostSelectPhotons(photon_counts=[2, 2, 1])
+
+    simulator = pq.SamplingSimulator(d=4, config=pq.Config(cutoff=5, validate=True))
+
+    with pytest.raises(pq.api.exceptions.InvalidState) as error:
+        simulator.execute(program)
+
+    message = error.value.args[0]
+    assert "Post-selecting 5 photon(s)" in message
+    assert "pq.Config(cutoff=6)" in message
 
 
 def test_interferometer_init():

--- a/tests/_simulators/sampling/test_preparations.py
+++ b/tests/_simulators/sampling/test_preparations.py
@@ -50,7 +50,60 @@ def test_initial_state_raises_InvalidState_for_occupation_numbers_of_differing_l
     )
 
 
-def test_initial_state_raises_InvalidState_when_cutoff_too_small():
+def test_cutoff_is_inferred_from_state_vector():
+    with pq.Program() as program:
+        pq.Q() | pq.StateVector([2, 1, 1, 0, 1])
+
+    state = pq.SamplingSimulator(d=5).execute(program).state
+
+    assert state._config.cutoff == 6
+    assert len(state.state_vector) > 0
+
+
+def test_cutoff_is_inferred_when_validation_is_disabled():
+    with pq.Program() as program:
+        pq.Q() | pq.StateVector([2, 1, 1, 0, 1])
+
+    simulator = pq.SamplingSimulator(d=5, config=pq.Config(validate=False))
+    state = simulator.execute(program).state
+
+    assert state._config.cutoff == 6
+    assert len(state.state_vector) > 0
+
+
+def test_explicit_cutoff_is_not_inferred_when_validation_is_disabled():
+    with pq.Program() as program:
+        pq.Q() | pq.StateVector([2, 1, 1, 0, 1])
+
+    simulator = pq.SamplingSimulator(
+        d=5,
+        config=pq.Config(cutoff=4, validate=False),
+    )
+    state = simulator.execute(program).state
+
+    assert state._config.cutoff == 4
+
+
+def test_explicit_cutoff_is_validated_against_state_vector():
+    with pq.Program() as program:
+        pq.Q() | pq.StateVector([2, 1, 1, 0, 1])
+
+    simulator = pq.SamplingSimulator(d=5, config=pq.Config(cutoff=4))
+
+    with pytest.raises(pq.api.exceptions.InvalidState) as error:
+        simulator.execute(program)
+
+    assert error.value.args[0] == (
+        "The occupation numbers '(2, 1, 1, 0, 1)' require "
+        "a cutoff of at least '6', but the provided cutoff is '4'. "
+        "Consider increasing the cutoff via `pq.Config(cutoff=6)` "
+        "when creating the simulator. Instruction: StateVector("
+        "occupation_numbers=(2, 1, 1, 0, 1), coefficient=1.0, "
+        "modes=(0, 1, 2, 3, 4))."
+    )
+
+
+def test_initial_state_raises_InvalidState_when_explicit_cutoff_too_small():
     occupation_numbers = [0, 1, 0, 1, 1, 1]
 
     with pq.Program() as program:
@@ -71,7 +124,7 @@ def test_initial_state_raises_InvalidState_when_cutoff_too_small():
     )
 
 
-def test_fock_amplitude_map_raises_InvalidState_when_cutoff_too_small():
+def test_fock_amplitude_map_raises_InvalidState_when_explicit_cutoff_too_small():
     occupation_numbers = (0, 1, 0, 1, 1, 1)
 
     with pq.Program() as program:
@@ -92,14 +145,27 @@ def test_fock_amplitude_map_raises_InvalidState_when_cutoff_too_small():
     )
 
 
-def test_issue_472_PostSelectPhotons_raises_InvalidState_instead_of_IndexError():
+def test_issue_472_PostSelectPhotons_infers_cutoff_instead_of_IndexError():
     # Regression: github.com/Budapest-Quantum-Computing-Group/piquasso/issues/472
     d = 6
     with pq.Program() as program:
         pq.Q() | pq.StateVector([0, 1, 0, 1, 1, 1])
         pq.Q(4, 5) | pq.PostSelectPhotons(photon_counts=[1, 1])
 
-    sim = pq.SamplingSimulator(d=d)
+    state = pq.SamplingSimulator(d=d).execute(program, shots=100).state
+
+    assert state._config.cutoff == 3
+    assert len(state.state_vector) > 0
+
+
+def test_issue_472_raises_InvalidState_when_explicit_cutoff_too_small():
+    # Regression: github.com/Budapest-Quantum-Computing-Group/piquasso/issues/472
+    d = 6
+    with pq.Program() as program:
+        pq.Q() | pq.StateVector([0, 1, 0, 1, 1, 1])
+        pq.Q(4, 5) | pq.PostSelectPhotons(photon_counts=[1, 1])
+
+    sim = pq.SamplingSimulator(d=d, config=pq.Config(cutoff=4))
 
     with pytest.raises(pq.api.exceptions.InvalidState) as error:
         sim.execute(program, shots=100)
@@ -535,3 +601,15 @@ def test_Create_on_multiple_modes():
     assert len(state._occupation_numbers) == 1
     assert np.allclose(state._occupation_numbers[0], np.array([1, 0, 1, 0]))
     assert np.allclose(state._coefficients[0], 1.0)
+
+
+def test_cutoff_is_inferred_from_Create_instructions():
+    with pq.Program() as program:
+        pq.Q() | pq.Vacuum()
+        for _ in range(5):
+            pq.Q(0) | pq.Create()
+
+    state = pq.SamplingSimulator(d=1).execute(program).state
+
+    assert state._config.cutoff == 6
+    assert np.allclose(state._occupation_numbers[0], np.array([5]))

--- a/tests/_simulators/sampling/test_preparations.py
+++ b/tests/_simulators/sampling/test_preparations.py
@@ -61,13 +61,17 @@ def test_initial_state_raises_InvalidState_when_cutoff_too_small():
     with pytest.raises(pq.api.exceptions.InvalidState) as error:
         simulator.execute(program)
 
-    message = error.value.args[0]
-    assert "require a cutoff of at least '5'" in message
-    assert "provided cutoff is '4'" in message
-    assert "pq.Config(cutoff=5)" in message
+    assert error.value.args[0] == (
+        "The occupation numbers '(0, 1, 0, 1, 1, 1)' require "
+        "a cutoff of at least '5', but the provided cutoff is '4'. "
+        "Consider increasing the cutoff via `pq.Config(cutoff=5)` "
+        "when creating the simulator. Instruction: StateVector("
+        "occupation_numbers=(0, 1, 0, 1, 1, 1), coefficient=1.0, "
+        "modes=(0, 1, 2, 3, 4, 5))."
+    )
 
 
-def test_initial_state_with_fock_amplitude_map_raises_InvalidState_when_cutoff_too_small():
+def test_fock_amplitude_map_raises_InvalidState_when_cutoff_too_small():
     occupation_numbers = (0, 1, 0, 1, 1, 1)
 
     with pq.Program() as program:
@@ -78,13 +82,18 @@ def test_initial_state_with_fock_amplitude_map_raises_InvalidState_when_cutoff_t
     with pytest.raises(pq.api.exceptions.InvalidState) as error:
         simulator.execute(program)
 
-    message = error.value.args[0]
-    assert "require a cutoff of at least '5'" in message
-    assert "pq.Config(cutoff=5)" in message
+    assert error.value.args[0] == (
+        "The occupation numbers '(0, 1, 0, 1, 1, 1)' require "
+        "a cutoff of at least '5', but the provided cutoff is '4'. "
+        "Consider increasing the cutoff via `pq.Config(cutoff=5)` "
+        "when creating the simulator. Instruction: StateVector("
+        "fock_amplitude_map={(0, 1, 0, 1, 1, 1): 1.0}, coefficient=1.0, "
+        "modes=(0, 1, 2, 3, 4, 5))."
+    )
 
 
 def test_issue_472_PostSelectPhotons_raises_InvalidState_instead_of_IndexError():
-    """Regression test for https://github.com/Budapest-Quantum-Computing-Group/piquasso/issues/472."""
+    # Regression: github.com/Budapest-Quantum-Computing-Group/piquasso/issues/472
     d = 6
     with pq.Program() as program:
         pq.Q() | pq.StateVector([0, 1, 0, 1, 1, 1])
@@ -95,9 +104,14 @@ def test_issue_472_PostSelectPhotons_raises_InvalidState_instead_of_IndexError()
     with pytest.raises(pq.api.exceptions.InvalidState) as error:
         sim.execute(program, shots=100)
 
-    message = error.value.args[0]
-    assert "require a cutoff of at least '5'" in message
-    assert "pq.Config(cutoff=5)" in message
+    assert error.value.args[0] == (
+        "The occupation numbers '(0, 1, 0, 1, 1, 1)' require "
+        "a cutoff of at least '5', but the provided cutoff is '4'. "
+        "Consider increasing the cutoff via `pq.Config(cutoff=5)` "
+        "when creating the simulator. Instruction: StateVector("
+        "occupation_numbers=(0, 1, 0, 1, 1, 1), coefficient=1.0, "
+        "modes=(0, 1, 2, 3, 4, 5))."
+    )
 
 
 def test_PostSelectPhotons_raises_InvalidState_when_postselection_exceeds_cutoff():
@@ -110,9 +124,12 @@ def test_PostSelectPhotons_raises_InvalidState_when_postselection_exceeds_cutoff
     with pytest.raises(pq.api.exceptions.InvalidState) as error:
         simulator.execute(program)
 
-    message = error.value.args[0]
-    assert "Post-selecting 5 photon(s)" in message
-    assert "pq.Config(cutoff=6)" in message
+    assert error.value.args[0] == (
+        "Post-selecting 5 photon(s) on [2, 2, 1] requires a cutoff of at least "
+        "'6', but the provided cutoff is '5'. Consider increasing the cutoff via "
+        "`pq.Config(cutoff=6)` when creating the simulator. Instruction: "
+        "PostSelectPhotons(photon_counts=[2, 2, 1], modes=(0, 1, 2))."
+    )
 
 
 def test_interferometer_init():

--- a/tests/api/test_config.py
+++ b/tests/api/test_config.py
@@ -82,6 +82,15 @@ def test_as_code_validate():
     assert no_validate_config._as_code() == "pq.Config(validate=False)"
 
 
+def test_as_code_preserves_explicit_default_cutoff():
+    default = pq.Config()
+    explicit_default_cutoff = pq.Config(cutoff=4)
+
+    assert default != explicit_default_cutoff
+    assert default._as_code() == "pq.Config()"
+    assert explicit_default_cutoff._as_code() == "pq.Config(cutoff=4)"
+
+
 def test_as_code_use_dask():
     default = pq.Config()
     conf_dont_use_dask = pq.Config(use_dask=False)


### PR DESCRIPTION
## Summary
- Validate cutoff during `SamplingSimulator` `StateVector` and `PostSelectPhotons` simulation steps, replacing cryptic `IndexError`s with descriptive `InvalidState` errors.
- Add cutoff validation for `FockSimulator` `DensityMatrix` ket/bra preparation and `PureFockSimulator` `PostSelectPhotons`.
- Extend shared validation helpers with actionable hints to increase cutoff via `pq.Config(cutoff=...)`.
- Document cutoff usage in the `SamplingSimulator` docstring.

### Closes #472

## Test plan
- [x] `pytest tests/_math/test_validations.py tests/_simulators/sampling/test_preparations.py tests/_simulators/sampling/test_measurements.py tests/_simulators/fock/general/test_preparations.py tests/_simulators/fock/pure/test_preparations.py tests/_simulators/fock/pure/test_measurements.py::test_PostSelectPhotons_raises_InvalidState_when_postselection_exceeds_cutoff`
- [x] Manual check: issue #472 reproduction raises `InvalidState` on `execute()` with `pq.Config(cutoff=5)` hint
- [x] Manual check: valid program with `cutoff=5` executes successfully
