### PR TITLE
Optimize Gaussian density matrix calculation

### DIFF
--- a/piquasso/_simulators/gaussian/probabilities.py
+++ b/piquasso/_simulators/gaussian/probabilities.py
@@ -15,7 +15,7 @@
 
 import abc
 
-from typing import Tuple
+from typing import Dict, Tuple
 
 import numpy as np
 
@@ -31,6 +31,7 @@ class DensityMatrixCalculation(abc.ABC):
 
     def __init__(self, connector: BaseConnector):
         self.connector = connector
+        self._density_matrix_element_cache: Dict[Tuple[int, ...], complex] = {}
 
     @abc.abstractmethod
     def calculate_hafnian(self, reduce_on: np.ndarray) -> float:
@@ -45,14 +46,55 @@ class DensityMatrixCalculation(abc.ABC):
             / np.sqrt(np.prod(factorial(reduce_on)))
         )
 
+    def _get_density_matrix_element_from_recurrence(
+        self, reduce_on: Tuple[int, ...]
+    ) -> complex:
+        if reduce_on in self._density_matrix_element_cache:
+            return self._density_matrix_element_cache[reduce_on]
+
+        k = np.array(reduce_on)
+        i = np.flatnonzero(k)[0]
+        previous = k.copy()
+        previous[i] -= 1
+
+        element = self._linear[i] * self._get_density_matrix_element_from_recurrence(
+            tuple(previous)
+        )
+
+        for j, previous_j in enumerate(previous):
+            if previous_j == 0:
+                continue
+
+            previous_previous = previous.copy()
+            previous_previous[j] -= 1
+            element += (
+                np.sqrt(previous_j)
+                * self._A[i, j]
+                * self._get_density_matrix_element_from_recurrence(
+                    tuple(previous_previous)
+                )
+            )
+
+        element /= np.sqrt(k[i])
+
+        self._density_matrix_element_cache[reduce_on] = element
+
+        return element
+
     def get_density_matrix(self, occupation_numbers: np.ndarray) -> np.ndarray:
         n = occupation_numbers.shape[0]
 
         density_matrix = np.empty(shape=(n, n), dtype=complex)
 
         for i, bra in enumerate(occupation_numbers):
-            for j, ket in enumerate(occupation_numbers):
-                density_matrix[i, j] = self.get_density_matrix_element(bra, ket)
+            for j in range(i, n):
+                ket = occupation_numbers[j]
+                reduce_on = tuple(np.concatenate([ket, bra]))
+                element = self._get_density_matrix_element_from_recurrence(reduce_on)
+                density_matrix[i, j] = element
+
+                if i != j:
+                    density_matrix[j, i] = np.conj(element)
 
         return density_matrix
 
@@ -102,8 +144,10 @@ class NondisplacedDensityMatrixCalculation(DensityMatrixCalculation):
         )
 
         self._A = X @ (np.identity(2 * d, dtype=complex) - Qinv)
+        self._linear = np.zeros(2 * d, dtype=complex)
 
         self._normalization: float = 1 / np.sqrt(np.linalg.det(Q))
+        self._density_matrix_element_cache[(0,) * (2 * d)] = self._normalization
 
     def calculate_hafnian(self, reduce_on: np.ndarray) -> float:
         return self.connector.hafnian(self._A, reduce_on)
@@ -137,10 +181,12 @@ class DisplacedDensityMatrixCalculation(DensityMatrixCalculation):
         self._A = X @ (np.identity(2 * d, dtype=complex) - Qinv)
 
         self._gamma = complex_displacement.conj() @ Qinv
+        self._linear = self._gamma
 
         self._normalization: float = np.exp(
             -0.5 * self._gamma @ complex_displacement
         ) / np.sqrt(np.linalg.det(Q))
+        self._density_matrix_element_cache[(0,) * (2 * d)] = self._normalization
 
     def calculate_hafnian(self, reduce_on: np.ndarray) -> float:
         return self.connector.loop_hafnian(self._A, self._gamma, reduce_on)

--- a/tests/_simulators/gaussian/test_probabilities.py
+++ b/tests/_simulators/gaussian/test_probabilities.py
@@ -1,0 +1,124 @@
+#
+# Copyright 2021-2026 Budapest Quantum Computing Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+
+import piquasso as pq
+
+from piquasso._simulators.gaussian.probabilities import DensityMatrixCalculation
+
+
+class RecurrenceTestDensityMatrixCalculation(DensityMatrixCalculation):
+    def __init__(self, A, linear, normalization, use_loop_hafnian=False):
+        super().__init__(connector=pq.NumpyConnector())
+        self._A = A
+        self._linear = linear
+        self._normalization = normalization
+        self._use_loop_hafnian = use_loop_hafnian
+        self._density_matrix_element_cache[(0,) * len(linear)] = normalization
+
+    def calculate_hafnian(self, reduce_on: np.ndarray) -> complex:
+        if self._use_loop_hafnian:
+            return self.connector.loop_hafnian(self._A, self._linear, reduce_on)
+
+        return self.connector.hafnian(self._A, reduce_on)
+
+
+def test_density_matrix_recurrence_matches_hafnian_elements():
+    A = np.array(
+        [
+            [0.1, 0.2 + 0.1j, -0.3, 0.05j],
+            [0.2 + 0.1j, -0.2, 0.4 - 0.2j, 0.15],
+            [-0.3, 0.4 - 0.2j, 0.25, -0.1j],
+            [0.05j, 0.15, -0.1j, 0.05],
+        ],
+        dtype=complex,
+    )
+    occupation_numbers = np.array(
+        [
+            [0, 0],
+            [1, 0],
+            [0, 1],
+            [2, 0],
+            [1, 1],
+        ]
+    )
+
+    calculation = RecurrenceTestDensityMatrixCalculation(
+        A=A,
+        linear=np.zeros(4, dtype=complex),
+        normalization=0.7 + 0.1j,
+    )
+
+    density_matrix = calculation.get_density_matrix(occupation_numbers)
+
+    for i, bra in enumerate(occupation_numbers):
+        for j in range(i, len(occupation_numbers)):
+            ket = occupation_numbers[j]
+            expected = calculation.get_density_matrix_element(bra=bra, ket=ket)
+
+            assert np.isclose(density_matrix[i, j], expected)
+
+
+def test_density_matrix_recurrence_matches_loop_hafnian_elements():
+    A = np.array(
+        [
+            [0.05, 0.1 + 0.1j, 0.15, -0.05j],
+            [0.1 + 0.1j, -0.05, 0.2 - 0.1j, 0.05],
+            [0.15, 0.2 - 0.1j, 0.1, 0.1j],
+            [-0.05j, 0.05, 0.1j, -0.1],
+        ],
+        dtype=complex,
+    )
+    linear = np.array([0.1, -0.2j, 0.05 + 0.1j, -0.15], dtype=complex)
+    occupation_numbers = np.array(
+        [
+            [0, 0],
+            [1, 0],
+            [0, 1],
+            [2, 0],
+            [1, 1],
+        ]
+    )
+
+    calculation = RecurrenceTestDensityMatrixCalculation(
+        A=A,
+        linear=linear,
+        normalization=0.9 - 0.2j,
+        use_loop_hafnian=True,
+    )
+
+    density_matrix = calculation.get_density_matrix(occupation_numbers)
+
+    for i, bra in enumerate(occupation_numbers):
+        for j in range(i, len(occupation_numbers)):
+            ket = occupation_numbers[j]
+            expected = calculation.get_density_matrix_element(bra=bra, ket=ket)
+
+            assert np.isclose(density_matrix[i, j], expected)
+
+
+def test_density_matrix_uses_hermitian_symmetry():
+    A = np.zeros((2, 2), dtype=complex)
+    calculation = RecurrenceTestDensityMatrixCalculation(
+        A=A,
+        linear=np.zeros(2, dtype=complex),
+        normalization=1.0,
+    )
+    occupation_numbers = np.array([[0], [1], [2]])
+
+    density_matrix = calculation.get_density_matrix(occupation_numbers)
+
+    assert np.allclose(density_matrix, density_matrix.conj().T)


### PR DESCRIPTION
Closes #523.

This replaces independent density-matrix hafnian evaluation with the modified-Hermite recurrence used for the Fock-space amplitudes, while retaining the existing single-element hafnian path for direct probability calls.

The density matrix still fills the lower triangle by Hermitian symmetry.

Verification run:

`python -m pytest tests\_simulators\gaussian\test_probabilities.py tests\_simulators\test_simulator_equivalence.py -q -k "density_matrix or recurrence"`

Result: 5 passed, 198 deselected.
