### PR TITLE
Fix partial ParticleNumberMeasurement modes in SamplingSimulator

### DIFF
--- a/piquasso/_simulators/sampling/simulation_steps.py
+++ b/piquasso/_simulators/sampling/simulation_steps.py
@@ -250,7 +250,14 @@ def particle_number_measurement(
         postselect_data=postselect_data,
     )
 
+    modes = instruction.modes
+
     binned_samples = get_counts(samples)
+
+    binned_samples = {
+        tuple(outcome[mode] for mode in modes): multiplicity
+        for outcome, multiplicity in binned_samples.items()
+    }
 
     branches = [
         Branch(state=None, outcome=outcome, frequency=Fraction(multiplicity, shots))

--- a/tests/_simulators/sampling/test_measurements.py
+++ b/tests/_simulators/sampling/test_measurements.py
@@ -69,6 +69,17 @@ def test_sampling_samples_number(interferometer_matrix):
     )
 
 
+def test_measure_particle_number_on_two_modes():
+    with pq.Program() as program:
+        pq.Q() | pq.StateVector([1, 1, 1, 0, 0])
+        pq.Q(0, 1) | pq.ParticleNumberMeasurement()
+
+    simulator = pq.SamplingSimulator(d=5)
+    result = simulator.execute(program, shots=3)
+
+    assert result.samples == [(1, 1), (1, 1), (1, 1)]
+
+
 def test_sampling_mode_permutation(interferometer_matrix):
     shots = 1
 


### PR DESCRIPTION
`SamplingSimulator` ignored which modes you measured, always returned all d modes. Now trims samples to instruction.modes after Clifford sampling (same marginal as PureFock). Adds regression test for Q(0,1). 



Closes: #499