### PR TITLE
Implement fermionic PureFock particle number measurement

### DIFF
--- a/piquasso/fermionic/fock/simulation_steps.py
+++ b/piquasso/fermionic/fock/simulation_steps.py
@@ -41,7 +41,7 @@ from .._utils import (
 )
 from .state import PureFockState
 
-from typing import Mapping, TYPE_CHECKING, Tuple
+from typing import Dict, Mapping, TYPE_CHECKING, Tuple
 
 if TYPE_CHECKING:
     from typing import List
@@ -142,7 +142,7 @@ def _get_measurement_probability_map(
     probabilities = state.fock_probabilities
     fock_space_basis = get_fock_space_basis(state.d, state._config.cutoff)
 
-    probability_map = {}
+    probability_map: Dict[Tuple[int, ...], float] = {}
     measured_modes = list(modes)
 
     for index, occupation_number in enumerate(fock_space_basis):

--- a/piquasso/fermionic/fock/simulation_steps.py
+++ b/piquasso/fermionic/fock/simulation_steps.py
@@ -13,15 +13,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import numpy as np
+
 from piquasso.api.branch import Branch
 
 from piquasso.api.exceptions import InvalidParameter
 
+from piquasso._math.indices import get_auxiliary_modes
 from piquasso._math.validations import (
     all_zero_or_one,
     are_modes_consecutive,
     validate_occupation_numbers,
 )
+
+from piquasso._utils import sample_from_probability_map
 
 from ._utils import (
     calculate_indices_for_controlled_phase,
@@ -32,15 +37,17 @@ from .._utils import (
     get_fock_space_index,
     get_cutoff_fock_space_dimension,
     next_second_quantized,
+    get_fock_space_basis,
 )
 from .state import PureFockState
 
-from typing import TYPE_CHECKING
+from typing import Mapping, TYPE_CHECKING, Tuple
 
 if TYPE_CHECKING:
     from typing import List
     from piquasso.instructions.preparations import StateVector
     from piquasso.instructions.gates import _PassiveLinearGate, Squeezing2
+    from piquasso.instructions.measurements import ParticleNumberMeasurement
     from piquasso.fermionic.instructions import ControlledPhase, IsingXX
 
 
@@ -101,6 +108,98 @@ def state_vector(
             )
 
     return [Branch(state=state)]
+
+
+def particle_number_measurement(
+    state: PureFockState, instruction: "ParticleNumberMeasurement", shots: int
+) -> "List[Branch]":
+    probability_map = _get_measurement_probability_map(state, instruction.modes)
+
+    frequency_map = sample_from_probability_map(probability_map, shots)
+
+    branches = []
+
+    for sample, frequency in frequency_map.items():
+        normalization = _get_normalization(probability_map, sample)
+
+        new_state = _project_to_subspace(
+            state=state,
+            subspace_basis=sample,
+            modes=instruction.modes,
+            normalization=normalization,
+        )
+
+        branches.append(Branch(new_state, sample, frequency=frequency))
+
+    return branches
+
+
+def _get_measurement_probability_map(
+    state: PureFockState, modes: Tuple[int, ...]
+) -> Mapping[Tuple[int, ...], float]:
+    fallback_np = state._connector.fallback_np
+
+    probabilities = state.fock_probabilities
+    fock_space_basis = get_fock_space_basis(state.d, state._config.cutoff)
+
+    probability_map = {}
+    measured_modes = list(modes)
+
+    for index, occupation_number in enumerate(fock_space_basis):
+        sample = tuple(occupation_number[measured_modes])
+        probability = fallback_np.real(fallback_np.asarray(probabilities[index]))
+
+        probability_map[sample] = probability_map.get(sample, 0.0) + float(probability)
+
+    return probability_map
+
+
+def _get_normalization(
+    probability_map: Mapping[Tuple[int, ...], float], sample: Tuple[int, ...]
+) -> float:
+    return np.sqrt(1 / probability_map[sample])
+
+
+def _project_to_subspace(
+    state: PureFockState,
+    *,
+    subspace_basis: Tuple[int, ...],
+    modes: Tuple[int, ...],
+    normalization: float,
+) -> PureFockState:
+    connector = state._connector
+    fallback_np = connector.fallback_np
+
+    config_copy = state._config.copy()
+    config_copy.cutoff -= sum(subspace_basis)
+
+    new_state = PureFockState(
+        d=state.d - len(modes),
+        connector=connector,
+        config=config_copy,
+    )
+
+    remaining_modes = get_auxiliary_modes(state.d, modes)
+    fock_space_basis = get_fock_space_basis(state.d, state._config.cutoff)
+    measured_modes = list(modes)
+
+    for index, occupation_number in enumerate(fock_space_basis):
+        if tuple(occupation_number[measured_modes]) != subspace_basis:
+            continue
+
+        remaining_occupation_number = fallback_np.array(
+            occupation_number[remaining_modes]
+        )
+
+        remaining_index = get_fock_space_index(remaining_occupation_number)
+
+        new_state._state_vector = connector.assign(
+            new_state.state_vector,
+            remaining_index,
+            normalization * state.state_vector[index],
+        )
+
+    return new_state
 
 
 def passive_linear(

--- a/piquasso/fermionic/fock/simulation_steps.py
+++ b/piquasso/fermionic/fock/simulation_steps.py
@@ -180,18 +180,14 @@ def _project_to_subspace(
     )
 
     remaining_modes = get_auxiliary_modes(state.d, modes)
-    fock_space_basis = get_fock_space_basis(state.d, state._config.cutoff)
     measured_modes = list(modes)
+    remaining_basis = get_fock_space_basis(new_state.d, config_copy.cutoff)
+    occupation_number = fallback_np.empty(state.d, dtype=int)
+    occupation_number[measured_modes] = subspace_basis
 
-    for index, occupation_number in enumerate(fock_space_basis):
-        if tuple(occupation_number[measured_modes]) != subspace_basis:
-            continue
-
-        remaining_occupation_number = fallback_np.array(
-            occupation_number[remaining_modes]
-        )
-
-        remaining_index = get_fock_space_index(remaining_occupation_number)
+    for remaining_index, remaining_occupation_number in enumerate(remaining_basis):
+        occupation_number[remaining_modes] = remaining_occupation_number
+        index = get_fock_space_index(occupation_number)
 
         new_state._state_vector = connector.assign(
             new_state.state_vector,

--- a/piquasso/fermionic/fock/simulator.py
+++ b/piquasso/fermionic/fock/simulator.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from piquasso.instructions import gates, preparations
+from piquasso.instructions import gates, preparations, measurements
 from .state import PureFockState
 
 from .simulation_steps import (
@@ -22,6 +22,7 @@ from .simulation_steps import (
     squeezing2,
     controlled_phase,
     ising_XX,
+    particle_number_measurement,
 )
 
 from piquasso._simulators.simulator import BuiltinSimulator
@@ -54,6 +55,9 @@ class PureFockSimulator(BuiltinSimulator):
 
     Supported gates:
         :class:`~piquasso.instructions.gates.Interferometer`.
+
+    Supported measurements:
+        :class:`~piquasso.instructions.measurements.ParticleNumberMeasurement`.
     """
 
     _state_class = PureFockState
@@ -69,8 +73,15 @@ class PureFockSimulator(BuiltinSimulator):
         gates.Squeezing2: squeezing2,
         ControlledPhase: controlled_phase,
         IsingXX: ising_XX,
+        measurements.ParticleNumberMeasurement: particle_number_measurement,
     }
 
     _default_connector_class = NumpyConnector
 
     _extra_builtin_connectors = [JaxConnector]
+
+    _measurement_classes_allowed_mid_circuit = (measurements.ParticleNumberMeasurement,)
+
+    _measurement_classes_allowed_with_shots_none = (
+        measurements.ParticleNumberMeasurement,
+    )

--- a/tests/fermionic/fock/test_measurements.py
+++ b/tests/fermionic/fock/test_measurements.py
@@ -1,0 +1,69 @@
+#
+# Copyright 2021-2026 Budapest Quantum Computing Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+
+import piquasso as pq
+
+
+def test_ParticleNumberMeasurement_shots_None_projects_remaining_modes():
+    probability_100 = 0.25
+    probability_011 = 0.75
+
+    with pq.Program() as program:
+        pq.Q() | pq.StateVector([1, 0, 0]) * np.sqrt(probability_100)
+        pq.Q() | pq.StateVector([0, 1, 1]) * np.sqrt(probability_011)
+
+        pq.Q(0) | pq.ParticleNumberMeasurement()
+
+    simulator = pq.fermionic.PureFockSimulator(d=3)
+
+    result = simulator.execute(program, shots=None)
+
+    outcome_map = result.outcome_map
+
+    assert set(outcome_map) == {(0,), (1,)}
+
+    assert np.isclose(outcome_map[(1,)]["frequency"], probability_100)
+    assert np.isclose(outcome_map[(0,)]["frequency"], probability_011)
+
+    assert np.isclose(
+        outcome_map[(1,)]["state"].get_particle_detection_probability([0, 0]),
+        1.0,
+    )
+    assert np.isclose(
+        outcome_map[(0,)]["state"].get_particle_detection_probability([1, 1]),
+        1.0,
+    )
+
+
+def test_ParticleNumberMeasurement_all_modes_seeded_sampling():
+    with pq.Program() as program:
+        pq.Q() | pq.StateVector([1, 0, 0]) / 2
+        pq.Q() | pq.StateVector([0, 1, 1]) * np.sqrt(3) / 2
+
+        pq.Q() | pq.ParticleNumberMeasurement()
+
+    simulator = pq.fermionic.PureFockSimulator(
+        d=3, config=pq.Config(seed_sequence=123)
+    )
+
+    result = simulator.execute(program, shots=8)
+
+    assert result.get_counts() == {
+        (1, 0, 0): 4,
+        (0, 1, 1): 4,
+    }
+    assert all(branch.state is None for branch in result.branches)

--- a/tests/fermionic/fock/test_measurements.py
+++ b/tests/fermionic/fock/test_measurements.py
@@ -49,6 +49,27 @@ def test_ParticleNumberMeasurement_shots_None_projects_remaining_modes():
     )
 
 
+def test_ParticleNumberMeasurement_finite_shots_projects_remaining_modes():
+    with pq.Program() as program:
+        pq.Q() | pq.StateVector([1, 0, 0])
+
+        pq.Q(0) | pq.ParticleNumberMeasurement()
+
+    simulator = pq.fermionic.PureFockSimulator(d=3)
+
+    result = simulator.execute(program, shots=3)
+
+    assert result.get_counts() == {(1,): 3}
+
+    branch = result.branches[0]
+
+    assert branch.outcome == (1,)
+    assert np.isclose(
+        branch.state.get_particle_detection_probability([0, 0]),
+        1.0,
+    )
+
+
 def test_ParticleNumberMeasurement_all_modes_seeded_sampling():
     with pq.Program() as program:
         pq.Q() | pq.StateVector([1, 0, 0]) / 2

--- a/tests/fermionic/fock/test_measurements.py
+++ b/tests/fermionic/fock/test_measurements.py
@@ -56,9 +56,7 @@ def test_ParticleNumberMeasurement_all_modes_seeded_sampling():
 
         pq.Q() | pq.ParticleNumberMeasurement()
 
-    simulator = pq.fermionic.PureFockSimulator(
-        d=3, config=pq.Config(seed_sequence=123)
-    )
+    simulator = pq.fermionic.PureFockSimulator(d=3, config=pq.Config(seed_sequence=123))
 
     result = simulator.execute(program, shots=8)
 


### PR DESCRIPTION
Closes #522.

## Summary

- add `ParticleNumberMeasurement` support for `pq.fermionic.PureFockSimulator`
- return projected branch states for exact `shots=None` measurements
- add focused fermionic pure-Fock measurement coverage

## Validation

- `python -m pytest -q tests/fermionic/fock/test_measurements.py` (`3 passed`)
- `python -m pytest -q tests/fermionic/fock/test_state.py tests/fermionic/fock/test_measurements.py tests/fermionic/test_simulator_equivalence.py` (`43 passed`)
- `python -m pytest -q tests/fermionic/fock` (`58 passed`, 1 existing warning)
- `git diff --check upstream/main...HEAD`

## AI disclosure

I used OpenAI Codex to help inspect the codebase and draft the patch. I reviewed the changes and used the validation above before opening this PR.
