### PR TITLE
Add GaussianState.get_ladder_string_moment

### DIFF
--- a/piquasso/_simulators/gaussian/state.py
+++ b/piquasso/_simulators/gaussian/state.py
@@ -1114,9 +1114,7 @@ class GaussianState(State):
 
         second_order_moments = cov_xxpp / 2 + 0.5j * hbar * xp_symplectic_form(d)
 
-        return self._string_moment(
-            first_order_moments, second_order_moments, string
-        )
+        return self._string_moment(first_order_moments, second_order_moments, string)
 
     @staticmethod
     def _string_moment(
@@ -1205,9 +1203,7 @@ class GaussianState(State):
             ]
         )
 
-        return self._string_moment(
-            first_order_moments, second_order_moments, string
-        )
+        return self._string_moment(first_order_moments, second_order_moments, string)
 
     def is_pure(self) -> bool:
         return bool(np.isclose(self.get_purity(), 1.0))

--- a/piquasso/_simulators/gaussian/state.py
+++ b/piquasso/_simulators/gaussian/state.py
@@ -1114,6 +1114,26 @@ class GaussianState(State):
 
         second_order_moments = cov_xxpp / 2 + 0.5j * hbar * xp_symplectic_form(d)
 
+        return self._string_moment(
+            first_order_moments, second_order_moments, string
+        )
+
+    @staticmethod
+    def _string_moment(
+        first_order_moments: np.ndarray,
+        second_order_moments: np.ndarray,
+        string: List[int],
+    ) -> complex:
+        r"""Extended Isserlis' (Wick) recursion for an ordered operator string.
+
+        Computes the (non-centered) Gaussian moment of an ordered product of
+        operators as a sum over all partitions of the operator indices into
+        singletons (contributing a first-order moment) and ordered pairs
+        (contributing the connected, ordered two-point moment). This is shared
+        between :meth:`get_xp_string_moment` and :meth:`get_ladder_string_moment`,
+        which only differ in the moment inputs.
+        """
+
         # TODO: Reimplement this using the loop hafnian!
         def recursive(op_list: List[int]) -> complex:
             if not op_list:
@@ -1137,6 +1157,57 @@ class GaussianState(State):
             return total
 
         return recursive(list(string))
+
+    def get_ladder_string_moment(self, string: List[int]) -> complex:
+        r"""Moment corresponding to a product of ladder operators.
+
+        The indices of `string` follow the complex representation used by
+        :attr:`complex_displacement`, i.e., :math:`0, \dots, d-1` denote
+        :math:`a_0, \dots, a_{d-1}` and :math:`d, \dots, 2d-1` denote
+        :math:`a_0^\dagger, \dots, a_{d-1}^\dagger`. The order of the integers in
+        `string` determines the operator ordering in the evaluated moment.
+
+        For example, for a one-mode state:
+
+        .. math::
+            [0, 1] &\mapsto \langle a_0 a_0^\dagger \rangle, \\
+            [1, 0] &\mapsto \langle a_0^\dagger a_0 \rangle.
+
+        The moment is evaluated using the same extended Isserlis' (Wick) formula as
+        :meth:`get_xp_string_moment` (see :meth:`_string_moment`), where the
+        first-order moments are given by :attr:`complex_displacement` and the
+        connected, ordered two-point moments
+        :math:`\langle \Delta \xi_\alpha \Delta \xi_\beta \rangle` (with
+        :math:`\xi = (a_0, \dots, a_{d-1}, a_0^\dagger, \dots, a_{d-1}^\dagger)`)
+        are assembled from the complex correlation blocks :math:`C` and :math:`G`
+        and the canonical commutation relation
+        :math:`[a_i, a_j^\dagger] = \delta_{ij}`:
+
+        .. math::
+            \langle \Delta \xi \Delta \xi \rangle = \begin{bmatrix}
+                G & C^T + I \\
+                C & \overline{G}
+            \end{bmatrix},
+
+        where :math:`C_{ij} = \langle a_i^\dagger a_j \rangle_c` and
+        :math:`G_{ij} = \langle a_i a_j \rangle_c` are the connected correlations.
+        """
+
+        np = self._connector.np
+
+        identity = np.identity(self.d)
+
+        first_order_moments = self.complex_displacement
+        second_order_moments = np.block(
+            [
+                [self._G, self._C.T + identity],
+                [self._C, np.conj(self._G)],
+            ]
+        )
+
+        return self._string_moment(
+            first_order_moments, second_order_moments, string
+        )
 
     def is_pure(self) -> bool:
         return bool(np.isclose(self.get_purity(), 1.0))

--- a/tests/_simulators/gaussian/test_state.py
+++ b/tests/_simulators/gaussian/test_state.py
@@ -1437,6 +1437,127 @@ def test_get_xp_string_moment_hbar_dependence():
     assert np.isclose(value1 * np.sqrt(hbar_2 / hbar_1) ** len(indices), value2)
 
 
+def test_get_ladder_string_moment_vacuum_state():
+    with pq.Program() as program:
+        pq.Q() | pq.Vacuum()
+
+    state = pq.GaussianSimulator(d=1).execute(program).state
+
+    assert np.isclose(state.get_ladder_string_moment([]), 1.0)
+
+    assert np.isclose(state.get_ladder_string_moment([0]), 0.0)
+    assert np.isclose(state.get_ladder_string_moment([1]), 0.0)
+
+    # <a a^dagger> = 1, <a^dagger a> = 0 on the vacuum.
+    assert np.isclose(state.get_ladder_string_moment([0, 1]), 1.0)
+    assert np.isclose(state.get_ladder_string_moment([1, 0]), 0.0)
+
+    # <a a> = <a^dagger a^dagger> = 0 on the vacuum.
+    assert np.isclose(state.get_ladder_string_moment([0, 0]), 0.0)
+    assert np.isclose(state.get_ladder_string_moment([1, 1]), 0.0)
+
+
+def test_get_ladder_string_moment_admits_ccr():
+    with pq.Program() as program:
+        pq.Q() | pq.Vacuum()
+        pq.Q(0) | pq.Squeezing(r=0.3, phi=0.4)
+        pq.Q(0) | pq.Displacement(r=0.5, phi=0.2)
+
+    state = pq.GaussianSimulator(d=1).execute(program).state
+
+    # [a, a^dagger] = 1
+    assert np.isclose(
+        state.get_ladder_string_moment([0, 1]) - state.get_ladder_string_moment([1, 0]),
+        1.0,
+    )
+
+
+def test_get_ladder_string_moment_mean_photon_number_consistency():
+    from scipy.stats import unitary_group
+
+    d = 3
+
+    U = unitary_group.rvs(d, random_state=1)
+
+    with pq.Program() as program:
+        pq.Q() | pq.Vacuum()
+        for i in range(d):
+            pq.Q(i) | pq.Squeezing(r=0.3 * (i + 1), phi=0.5 * i)
+            pq.Q(i) | pq.Displacement(r=0.4 * (i + 1), phi=0.2 * i)
+        pq.Q(all) | pq.Interferometer(U)
+
+    state = pq.GaussianSimulator(d=d).execute(program).state
+
+    mean_photon_number = sum(
+        state.get_ladder_string_moment([d + i, i]) for i in range(d)
+    )
+
+    assert np.isclose(mean_photon_number, state.mean_photon_number())
+
+
+def test_get_ladder_string_moment_matches_xp_string_moment():
+    r"""Cross-check using :math:`a_i = (x_i + i p_i) / \sqrt{2 \hbar}`."""
+    import itertools
+
+    from scipy.stats import unitary_group
+
+    d = 2
+    hbar = 2.0
+
+    U = unitary_group.rvs(d, random_state=3)
+
+    with pq.Program() as program:
+        pq.Q() | pq.Vacuum()
+        for i in range(d):
+            pq.Q(i) | pq.Squeezing(r=0.2 * (i + 1), phi=0.3 * i)
+            pq.Q(i) | pq.Displacement(r=0.5 * (i + 1), phi=0.4 * i)
+        pq.Q(all) | pq.Interferometer(U)
+
+    state = pq.GaussianSimulator(d=d, config=pq.Config(hbar=hbar)).execute(program).state
+
+    # Linear map from xxpp quadratures to ladder operators.
+    W = np.block(
+        [
+            [np.eye(d), 1j * np.eye(d)],
+            [np.eye(d), -1j * np.eye(d)],
+        ]
+    ) / np.sqrt(2 * hbar)
+
+    rng = np.random.default_rng(0)
+
+    for _ in range(50):
+        length = rng.integers(0, 5)
+        ladder_string = list(rng.integers(0, 2 * d, size=length))
+
+        expected = 0.0
+        for xp_string in itertools.product(range(2 * d), repeat=length):
+            coefficient = np.prod(
+                [W[alpha, k] for alpha, k in zip(ladder_string, xp_string)]
+            )
+            if coefficient != 0.0:
+                expected += coefficient * state.get_xp_string_moment(list(xp_string))
+
+        assert np.isclose(state.get_ladder_string_moment(ladder_string), expected)
+
+
+def test_get_ladder_string_moment_jax_connector():
+    with pq.Program() as program:
+        pq.Q() | pq.Vacuum()
+        pq.Q(0) | pq.Squeezing(r=0.3, phi=0.4)
+        pq.Q(0) | pq.Displacement(r=0.5, phi=0.2)
+
+    state = (
+        pq.GaussianSimulator(d=1, connector=pq.JaxConnector())
+        .execute(program)
+        .state
+    )
+
+    assert np.isclose(
+        state.get_ladder_string_moment([0, 1]) - state.get_ladder_string_moment([1, 0]),
+        1.0,
+    )
+
+
 def test_GaussianState_get_parity_operator_expectation_value_on_vacuum():
     with pq.Program() as program:
         pq.Q() | pq.Vacuum()

--- a/tests/_simulators/gaussian/test_state.py
+++ b/tests/_simulators/gaussian/test_state.py
@@ -1513,7 +1513,9 @@ def test_get_ladder_string_moment_matches_xp_string_moment():
             pq.Q(i) | pq.Displacement(r=0.5 * (i + 1), phi=0.4 * i)
         pq.Q(all) | pq.Interferometer(U)
 
-    state = pq.GaussianSimulator(d=d, config=pq.Config(hbar=hbar)).execute(program).state
+    state = (
+        pq.GaussianSimulator(d=d, config=pq.Config(hbar=hbar)).execute(program).state
+    )
 
     # Linear map from xxpp quadratures to ladder operators.
     W = np.block(
@@ -1547,9 +1549,7 @@ def test_get_ladder_string_moment_jax_connector():
         pq.Q(0) | pq.Displacement(r=0.5, phi=0.2)
 
     state = (
-        pq.GaussianSimulator(d=1, connector=pq.JaxConnector())
-        .execute(program)
-        .state
+        pq.GaussianSimulator(d=1, connector=pq.JaxConnector()).execute(program).state
     )
 
     assert np.isclose(


### PR DESCRIPTION
Add a method to compute moments of ordered products of ladder (creation/annihilation) operators, mirroring get_xp_string_moment but in the complex (a, a-dagger) representation used by complex_displacement.

This spares users from manually rewriting ladder-operator products as quadratures, which is error-prone for higher-order moments. The shared extended-Isserlis (Wick) recursion is extracted from get_xp_string_moment into a private _string_moment helper reused by both methods; the ladder version assembles its first/second-order moments from complex_displacement and the complex correlation blocks (_C, _G) together with the canonical commutation relation [a_i, a_jdag] = delta_ij.

Resolves #524 