### PR TITLE
fix: infer sampling cutoff from prepared states

### DIFF
--- a/piquasso/_simulators/sampling/simulation_steps.py
+++ b/piquasso/_simulators/sampling/simulation_steps.py
@@ -28,6 +28,7 @@ from piquasso.api.exceptions import InvalidState, NotImplementedCalculation
 from piquasso.api.branch import Branch
 from piquasso.api.instruction import Instruction
 
+from piquasso._math.validations import validate_occupation_numbers
 from piquasso._simulators.fock.pure.simulation_steps import (
     imperfect_post_select_photons as pure_fock_imperfect_post_select_photons,
 )
@@ -50,9 +51,39 @@ def create(state: SamplingState, instruction: Instruction, shots: int) -> List[B
     modes = instruction.modes
 
     for i in range(len(state._occupation_numbers)):
-        state._occupation_numbers[i][modes,] += 1
+        occupation_numbers = state._occupation_numbers[i].copy()
+        occupation_numbers[modes,] += 1
+        _validate_or_infer_cutoff(state, occupation_numbers, instruction)
+        state._occupation_numbers[i] = occupation_numbers
 
     return [Branch(state=state)]
+
+
+def _validate_or_infer_cutoff(
+    state: SamplingState,
+    occupation_numbers: np.ndarray,
+    instruction: Instruction,
+) -> None:
+    occupation_numbers_tuple = tuple(int(number) for number in occupation_numbers)
+
+    if state._config.validate and len(occupation_numbers) != state.d:
+        raise InvalidState(
+            f"The occupation numbers '{occupation_numbers_tuple}' are not "
+            f"well-defined on '{state.d}' modes: instruction={instruction}"
+        )
+
+    if state._config._cutoff_was_explicit:
+        if state._config.validate:
+            validate_occupation_numbers(
+                occupation_numbers_tuple,
+                state.d,
+                state._config.cutoff,
+                context=f" Instruction: {instruction}.",
+            )
+        return
+
+    required_cutoff = int(np.sum(occupation_numbers)) + 1
+    state._config.cutoff = max(state._config.cutoff, required_cutoff)
 
 
 def state_vector(
@@ -64,13 +95,11 @@ def state_vector(
         occupation_numbers = instruction._get_all_params(state._connector)[
             "occupation_numbers"
         ]
-        if state._config.validate and len(occupation_numbers) != state.d:
-            raise InvalidState(
-                f"The occupation numbers '{occupation_numbers}' are not well-defined "
-                f"on '{state.d}' modes: instruction={instruction}"
-            )
+        occupation_numbers = np.rint(occupation_numbers).astype(int)
 
-        state._occupation_numbers.append(np.rint(occupation_numbers).astype(int))
+        _validate_or_infer_cutoff(state, occupation_numbers, instruction)
+
+        state._occupation_numbers.append(occupation_numbers)
         state._coefficients.append(coefficient)
 
     elif "fock_amplitude_map" in instruction._get_all_params(state._connector):
@@ -78,14 +107,11 @@ def state_vector(
             state._connector
         )["fock_amplitude_map"].items():
 
-            if state._config.validate and len(occupation_numbers) != state.d:
-                raise InvalidState(
-                    f"The occupation numbers '{occupation_numbers}' "
-                    f"are not well-defined "
-                    f"on '{state.d}' modes: instruction={instruction}"
-                )
+            occupation_numbers = np.rint(occupation_numbers).astype(int)
 
-            state._occupation_numbers.append(np.rint(occupation_numbers).astype(int))
+            _validate_or_infer_cutoff(state, occupation_numbers, instruction)
+
+            state._occupation_numbers.append(occupation_numbers)
             state._coefficients.append(coefficient * amplitude)
 
     return [Branch(state=state)]

--- a/piquasso/api/config.py
+++ b/piquasso/api/config.py
@@ -26,7 +26,11 @@ from piquasso.core import _mixins
 class Config(_mixins.CodeMixin):
     """The configuration for the simulation.
 
-    :ivar cutoff: The Fock space cutoff. Defaults to `4`.
+    :ivar cutoff:
+        The Fock space cutoff. Defaults to `4`. When omitted, the
+        :class:`~piquasso._simulators.sampling.simulator.SamplingSimulator`
+        may increase its execution-local copy to fit the prepared state. An
+        explicitly supplied cutoff is kept as a strict limit.
     :ivar dtype:
         The underlying datatype of the simulation. Possible values: `np.float32` and
         `np.float64`. Defaults to `np.float64`.
@@ -60,7 +64,7 @@ class Config(_mixins.CodeMixin):
     def __init__(
         self,
         *,
-        cutoff: int = 4,
+        cutoff: Optional[int] = None,
         dtype: type = np.float64,
         measurement_cutoff: int = 5,
         hbar: float = 2.0,
@@ -78,7 +82,8 @@ class Config(_mixins.CodeMixin):
         self.cache_size = cache_size
         self.hbar = hbar
         self.use_torontonian = use_torontonian
-        self.cutoff = cutoff
+        self._cutoff_was_explicit = cutoff is not None
+        self.cutoff = 4 if cutoff is None else cutoff
         self.measurement_cutoff = measurement_cutoff
         self.dtype = np.float64 if dtype is float else dtype
         self.validate = validate
@@ -93,6 +98,7 @@ class Config(_mixins.CodeMixin):
             and self.cache_size == other.cache_size
             and self.hbar == other.hbar
             and self.use_torontonian == other.use_torontonian
+            and self._cutoff_was_explicit == other._cutoff_was_explicit
             and self.cutoff == other.cutoff
             and self.measurement_cutoff == other.measurement_cutoff
             and self.dtype == other.dtype
@@ -113,7 +119,7 @@ class Config(_mixins.CodeMixin):
             non_default_params["hbar"] = self.hbar
         if self.use_torontonian != default_config.use_torontonian:
             non_default_params["use_torontonian"] = self.use_torontonian
-        if self.cutoff != default_config.cutoff:
+        if self._cutoff_was_explicit:
             non_default_params["cutoff"] = self.cutoff
         if self.measurement_cutoff != default_config.measurement_cutoff:
             non_default_params["measurement_cutoff"] = self.measurement_cutoff

--- a/piquasso/api/config.py
+++ b/piquasso/api/config.py
@@ -27,10 +27,12 @@ class Config(_mixins.CodeMixin):
     """The configuration for the simulation.
 
     :ivar cutoff:
-        The Fock space cutoff. Defaults to `4`. When omitted, the
-        :class:`~piquasso._simulators.sampling.simulator.SamplingSimulator`
-        may increase its execution-local copy to fit the prepared state. An
-        explicitly supplied cutoff is kept as a strict limit.
+        The Fock space cutoff/truncation. Defaults to `None`, which means the cutoff
+        is inferred from the program whenever possible, for example for simulations
+        with a fixed particle number. If no cutoff can be inferred, a default value
+        of `4` is used. An explicitly specified cutoff is always respected, and is
+        useful when automatic inference is not possible, such as when computing the
+        density matrix of a Gaussian state.
     :ivar dtype:
         The underlying datatype of the simulation. Possible values: `np.float32` and
         `np.float64`. Defaults to `np.float64`.

--- a/tests/_simulators/sampling/test_measurements.py
+++ b/tests/_simulators/sampling/test_measurements.py
@@ -575,6 +575,17 @@ def test_PostSelectPhotons_state_vector_with_more_photons():
         assert np.isclose(state_vector_map[index], coeff)
 
 
+def test_PostSelectPhotons_infers_cutoff_for_state_vector():
+    with pq.Program() as program:
+        pq.Q() | pq.StateVector([0, 1, 0, 1, 1, 1])
+        pq.Q(4, 5) | pq.PostSelectPhotons(photon_counts=[1, 1])
+
+    state = pq.SamplingSimulator(d=6).execute(program, shots=100).state
+
+    assert state._config.cutoff == 3
+    assert len(state.state_vector) > 0
+
+
 @pytest.mark.monkey
 def test_PostSelectPhotons_state_vector_with_more_photons_random():
     photon_counts = [2, 2]

--- a/tests/_simulators/sampling/test_preparations.py
+++ b/tests/_simulators/sampling/test_preparations.py
@@ -50,6 +50,57 @@ def test_initial_state_raises_InvalidState_for_occupation_numbers_of_differing_l
     )
 
 
+def test_cutoff_is_inferred_from_state_vector():
+    with pq.Program() as program:
+        pq.Q() | pq.StateVector([2, 1, 1, 0, 1])
+
+    state = pq.SamplingSimulator(d=5).execute(program).state
+
+    assert state._config.cutoff == 6
+    assert len(state.state_vector) > 0
+
+
+def test_cutoff_is_inferred_when_validation_is_disabled():
+    with pq.Program() as program:
+        pq.Q() | pq.StateVector([2, 1, 1, 0, 1])
+
+    simulator = pq.SamplingSimulator(d=5, config=pq.Config(validate=False))
+    state = simulator.execute(program).state
+
+    assert state._config.cutoff == 6
+    assert len(state.state_vector) > 0
+
+
+def test_explicit_cutoff_is_not_inferred_when_validation_is_disabled():
+    with pq.Program() as program:
+        pq.Q() | pq.StateVector([2, 1, 1, 0, 1])
+
+    simulator = pq.SamplingSimulator(
+        d=5,
+        config=pq.Config(cutoff=4, validate=False),
+    )
+    state = simulator.execute(program).state
+
+    assert state._config.cutoff == 4
+
+
+def test_explicit_cutoff_is_validated_against_state_vector():
+    with pq.Program() as program:
+        pq.Q() | pq.StateVector([2, 1, 1, 0, 1])
+
+    simulator = pq.SamplingSimulator(d=5, config=pq.Config(cutoff=4))
+
+    with pytest.raises(pq.api.exceptions.InvalidState) as error:
+        simulator.execute(program)
+
+    assert error.value.args[0] == (
+        "The occupation numbers '(2, 1, 1, 0, 1)' require a cutoff of at least "
+        "'6', but the provided cutoff is '4'. "
+        "Instruction: StateVector(occupation_numbers=(2, 1, 1, 0, 1), "
+        "coefficient=1.0, modes=(0, 1, 2, 3, 4))."
+    )
+
+
 def test_interferometer_init():
     with pq.Program() as program:
         pass
@@ -453,3 +504,15 @@ def test_Create_on_multiple_modes():
     assert len(state._occupation_numbers) == 1
     assert np.allclose(state._occupation_numbers[0], np.array([1, 0, 1, 0]))
     assert np.allclose(state._coefficients[0], 1.0)
+
+
+def test_cutoff_is_inferred_from_Create_instructions():
+    with pq.Program() as program:
+        pq.Q() | pq.Vacuum()
+        for _ in range(5):
+            pq.Q(0) | pq.Create()
+
+    state = pq.SamplingSimulator(d=1).execute(program).state
+
+    assert state._config.cutoff == 6
+    assert np.allclose(state._occupation_numbers[0], np.array([5]))

--- a/tests/api/test_config.py
+++ b/tests/api/test_config.py
@@ -82,6 +82,15 @@ def test_as_code_validate():
     assert no_validate_config._as_code() == "pq.Config(validate=False)"
 
 
+def test_as_code_preserves_explicit_default_cutoff():
+    default = pq.Config()
+    explicit_default_cutoff = pq.Config(cutoff=4)
+
+    assert default != explicit_default_cutoff
+    assert default._as_code() == "pq.Config()"
+    assert explicit_default_cutoff._as_code() == "pq.Config(cutoff=4)"
+
+
 def test_as_code_use_dask():
     default = pq.Config()
     conf_dont_use_dask = pq.Config(use_dask=False)


### PR DESCRIPTION
## Summary

- distinguish an omitted Fock cutoff from an explicitly supplied cutoff
- infer the execution-local cutoff for sampling `StateVector` and `Create` preparations
- keep explicit cutoffs strict and raise `InvalidState` with the required value
- cover the original `PostSelectPhotons` reproduction, disabled validation, explicit defaults, and repeated creation

## Why

Validating every sampling preparation against the default cutoff would make previously valid programs require `Config(cutoff=...)`. Instead, this follows the approach described in the review discussion on #593: sampling infers a sufficient cutoff when the user omitted it, while an explicit cutoff remains a deliberate constraint.

The simulator's configuration is copied into each state, so inference is local to one execution and does not mutate the reusable simulator configuration.

## Checks

- `pytest --skip-tensorflow --import-mode=append tests/api tests/_simulators/sampling -q` (188 passed)
- focused regression suite (66 passed)
- `mypy piquasso` (passed)
- `black --check .` (282 files unchanged)
- `flake8` (passed)
- broader optional-stack run reached 322 passed / 16 skipped before stalling in an unrelated Matplotlib backend test; stopped after 4m32s
- `git diff --check` (passed)

Closes #472.

## AI disclosure

I used an LLM as a collaborative tool for repository triage, test drafting, and reviewing compatibility risks. I verified the maintainer discussion, reproduced the failure, implemented and reviewed the change locally, and ran the checks listed above.
