### PR TITLE
docs: Facelifting documentation

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -1,33 +1,436 @@
-body[data-theme="dark"] div.nbinput.container div.input_area, .highlight {
-    border-color: #232d48!important;
+:root {
+    --pq-red: #e46363;
+    --pq-red-strong: #d95555;
+    --pq-red-bright: #f47f6f;
+    --pq-red-soft: rgba(228, 99, 99, 0.12);
+    --pq-heading-color: var(--pq-red-strong);
+    --pq-heading-font: "Eurostile", "Bank Gothic", "Avenir Next", "Segoe UI", system-ui, sans-serif;
+    --pq-border-dark: #232d48;
+    --pq-radius-sm: 0.45rem;
+    --pq-radius-md: 0.75rem;
+    --pq-radius-lg: 1.1rem;
+    --pq-shadow-sm: 0 0.35rem 1rem rgba(30, 40, 68, 0.08);
+    --pq-shadow-md: 0 0.9rem 2.2rem rgba(30, 40, 68, 0.14);
+    --pq-card-border: rgba(228, 99, 99, 0.24);
+    --pq-card-background: linear-gradient(145deg, rgba(228, 99, 99, 0.12), rgba(228, 99, 99, 0.03) 46%), var(--color-background-secondary);
+    --pq-card-shadow: 0 0.55rem 1.45rem rgba(30, 40, 68, 0.12), 0 0 0 1px rgba(228, 99, 99, 0.05);
+    --pq-card-shadow-hover: 0 0.9rem 2rem rgba(30, 40, 68, 0.18), 0 0 0 1px rgba(228, 99, 99, 0.1);
+    --pq-transition: 160ms ease;
 }
 
-div.nbinput.container div.input_area, .highlight {
-    background: var(--color-code-background)!important;
-    color: var(--color-content-foreground)!important;
+body[data-theme="dark"] {
+    --pq-heading-color: var(--pq-red-bright);
+    --pq-shadow-sm: 0 0.45rem 1.3rem rgba(0, 0, 0, 0.18);
+    --pq-shadow-md: 0 1rem 2.6rem rgba(0, 0, 0, 0.25);
+    --pq-card-border: rgba(228, 99, 99, 0.3);
+    --pq-card-background: linear-gradient(145deg, rgba(228, 99, 99, 0.17), rgba(228, 99, 99, 0.04) 48%), var(--color-background-secondary);
+    --pq-card-shadow: 0 0.65rem 1.6rem rgba(0, 0, 0, 0.3), 0 0 0 1px rgba(228, 99, 99, 0.08);
+    --pq-card-shadow-hover: 0 1rem 2.2rem rgba(0, 0, 0, 0.38), 0 0 0 1px rgba(228, 99, 99, 0.14);
 }
 
-div.nbinput.container div.input_area {
-    padding: .5rem!important;
-    /* border-radius: 0.5rem!important; */
-    box-shadow: 0 0 7px 2px rgba(0,0,0,.1);
+body {
+    text-rendering: optimizeLegibility;
 }
 
-.sd-card-title {
-    font-size: 1.4em;
+.article-container {
+    max-width: 84rem;
+}
+
+.content {
+    line-height: 1.68;
+}
+
+.content p,
+.content li {
+    font-size: 1rem;
+}
+
+.content a {
+    text-underline-offset: 0.18em;
+}
+
+.content a:hover {
+    text-decoration-thickness: 0.12em;
+}
+
+/* Headings */
+.content h1,
+.content h2,
+.content h3 {
+    font-family: var(--pq-heading-font);
+    letter-spacing: -0.025em;
+}
+
+.content h1 {
+    width: fit-content;
+    max-width: min(100%, 58rem);
+    margin: 0 auto 1.6rem;
+    padding: 0.15rem 0.75rem 0.1rem;
+    position: relative;
+    isolation: isolate;
+    color: var(--pq-heading-color);
+    font-size: clamp(1.95rem, 4.2vw, 3.35rem);
+    font-weight: 820;
+    line-height: 1.05;
+    letter-spacing: -0.055em;
     text-align: center;
+    text-wrap: balance;
 }
 
-.sd-card-text {
-    font-size: 0.8em;
-    text-align: center;
+.content h1::before {
+    position: absolute;
+    left: 50%;
+    bottom: -0.35rem;
+    z-index: -1;
+    width: min(24rem, 76vw);
+    height: 1.1rem;
+    border-radius: 999px;
+    background: radial-gradient(ellipse at center, var(--pq-red-soft) 0%, transparent 72%);
+    content: "";
+    filter: blur(0.12rem);
+    transform: translateX(-50%);
+}
+
+.content h1::after {
+    display: block;
+    width: min(8.5rem, 42%);
+    height: 0.22rem;
+    margin: 1.05rem auto 0;
+    border-radius: 999px;
+    background: linear-gradient(90deg, transparent 0%, rgba(228, 99, 99, 0.55) 18%, var(--pq-red) 50%, rgba(228, 99, 99, 0.55) 82%, transparent 100%);
+    box-shadow: 0 0.45rem 1.4rem rgba(228, 99, 99, 0.22);
+    content: "";
+}
+
+.content h1 .headerlink {
+    position: absolute;
+    top: 50%;
+    left: 100%;
+    margin-left: 0.55rem;
+    color: var(--color-brand-content);
+    font-size: 0.42em;
+    opacity: 0;
+    text-decoration: none;
+    transform: translateY(-47%);
+    transition: opacity var(--pq-transition), transform var(--pq-transition);
+}
+
+.content h1:hover .headerlink,
+.content h1 .headerlink:focus-visible {
+    opacity: 0.7;
+    transform: translateY(-47%) scale(1.04);
+}
+
+.content h2 {
+    margin-top: 2.8rem;
+    padding-bottom: 0.35rem;
+    border-bottom: 1px solid transparent;
+    color: var(--color-foreground-primary);
+    font-weight: 780;
+}
+
+.content h2::after {
+    display: block;
+    width: 4.5rem;
+    height: 0.14rem;
+    margin-top: 0.35rem;
+    border-radius: 999px;
+    background: linear-gradient(90deg, var(--pq-heading-color), transparent);
+    content: "";
+}
+
+.content h3 {
+    margin-top: 2rem;
+    color: var(--pq-heading-color);
+    font-weight: 720;
+}
+
+body[data-theme="light"] .content h1 {
+    color: var(--pq-red-strong);
+    text-shadow: 0 0.12rem 0.8rem rgba(228, 99, 99, 0.12);
+}
+
+body[data-theme="dark"] .content h1 {
+    color: var(--pq-red-bright);
+    text-shadow: 0 0.12rem 0.2rem rgba(0, 0, 0, 0.28), 0 0 1.25rem rgba(228, 99, 99, 0.12);
 }
 
 .mission-statement {
-    font-size: 1.3em;
+    max-width: 52rem;
+    margin: 0 auto 1.25rem;
+    padding: 0.85rem 1.25rem;
+    border: 1px solid rgba(228, 99, 99, 0.22);
+    border-radius: var(--pq-radius-lg);
+    background:
+        linear-gradient(145deg, rgba(228, 99, 99, 0.08), transparent 58%),
+        var(--color-background-secondary);
+    color: var(--color-foreground-primary);
+    font-size: clamp(1.12rem, 1.55vw, 1.35rem);
+    font-weight: 620;
+    line-height: 1.55;
+    text-align: center;
+    box-shadow: var(--pq-shadow-sm);
+}
+
+.mission-statement p {
+    margin: 0;
+}
+
+body[data-theme="dark"] .mission-statement {
+    border-color: rgba(228, 99, 99, 0.28);
+    background:
+        linear-gradient(145deg, rgba(228, 99, 99, 0.12), transparent 60%),
+        var(--color-background-secondary);
+}
+
+.landing-intro {
+    max-width: 54rem;
+    margin: 0 auto 2.8rem;
+    color: var(--color-foreground-secondary);
+    font-size: clamp(0.98rem, 1.15vw, 1.08rem);
+    line-height: 1.7;
     text-align: center;
 }
 
-h1 {
-    text-align: center;
+.landing-intro p {
+    margin: 0;
+}
+
+/* Sidebar and table of contents */
+.sidebar-brand {
+    padding-top: 1.15rem;
+    padding-bottom: 1rem;
+}
+
+.sidebar-brand img {
+    max-width: min(12rem, 82%);
+}
+
+.sidebar-search-container,
+.sidebar-tree .reference,
+.toc-tree .reference {
+    border-radius: var(--pq-radius-sm);
+}
+
+.sidebar-tree .reference:hover,
+.toc-tree .reference:hover {
+    background: var(--color-background-hover);
+}
+
+.sidebar-tree .current-page > .reference,
+.toc-tree .current > .reference {
+    color: var(--color-brand-content);
+    font-weight: 650;
+}
+
+.toc-drawer {
+    font-size: 0.92rem;
+}
+
+/* Sphinx Design cards */
+.sd-card {
+    height: 100%;
+    overflow: hidden;
+    border: 1px solid var(--pq-card-border);
+    border-radius: 1rem;
+    background: var(--pq-card-background);
+    box-shadow: var(--pq-card-shadow);
+    transition: transform var(--pq-transition), border-color var(--pq-transition), box-shadow var(--pq-transition), background-color var(--pq-transition);
+}
+
+.sd-container-fluid .sd-row {
+    row-gap: 1rem;
+}
+
+.sd-card:hover,
+.sd-card:focus-within {
+    border-color: var(--color-brand-content);
+    box-shadow: var(--pq-card-shadow-hover);
+    transform: translateY(-2px);
+}
+
+.sd-card-body {
+    padding: 1.1rem 1.15rem;
+}
+
+.sd-card-title {
+    margin-bottom: 0.35rem;
+    color: var(--color-foreground-primary);
+    font-size: 1.15rem;
+    font-weight: 700;
+    line-height: 1.25;
+    text-align: left;
+}
+
+.sd-card-text {
+    color: var(--color-foreground-secondary);
+    font-size: 0.92rem;
+    line-height: 1.55;
+    text-align: left;
+}
+
+.sd-card-footer {
+    border-top: 1px solid var(--color-background-border);
+    background: transparent;
+}
+
+.sd-btn,
+.sd-card .sd-btn {
+    border-radius: 999px;
+    font-weight: 650;
+}
+
+/* Code, console blocks, and notebooks */
+code.literal,
+code.xref,
+a code {
+    border: 1px solid var(--color-background-border);
+    border-radius: 0.35rem;
+    padding: 0.08rem 0.28rem;
+    background: var(--color-code-background);
+    color: var(--color-foreground-primary);
+    font-size: 0.88em;
+}
+
+.highlight,
+div.highlight,
+div.nbinput.container div.input_area,
+div.nboutput.container div.output_area {
+    border: 1px solid var(--color-background-border) !important;
+    border-radius: var(--pq-radius-md) !important;
+    background: var(--color-code-background) !important;
+    color: var(--color-foreground-primary) !important;
+    box-shadow: var(--pq-shadow-sm);
+}
+
+.highlight pre,
+div.nbinput.container div.input_area pre,
+div.nboutput.container div.output_area pre {
+    padding: 1rem !important;
+    line-height: 1.55;
+}
+
+div.nbinput.container,
+div.nboutput.container {
+    margin: 1.15rem 0;
+}
+
+div.nbinput.container div.prompt,
+div.nboutput.container div.prompt {
+    opacity: 0.55;
+}
+
+.copybtn {
+    border-radius: 999px;
+}
+
+/* Python object reference blocks */
+dl.py.class,
+dl.py.function,
+dl.py.method,
+dl.py.attribute {
+    margin: 1.25rem 0;
+    padding: 1rem 1.15rem;
+    border: 1px solid var(--color-background-border);
+    border-radius: var(--pq-radius-lg);
+    background: var(--color-background-secondary);
+    box-shadow: var(--pq-shadow-sm);
+}
+
+dl.py dt.sig {
+    overflow-x: auto;
+    border-radius: var(--pq-radius-sm);
+    background: var(--color-code-background);
+}
+
+.sig-name,
+.sig-prename {
+    font-weight: 700;
+}
+
+/* Admonitions */
+.admonition,
+div.admonition {
+    overflow: hidden;
+    border: 1px solid var(--color-background-border);
+    border-left: 0.28rem solid var(--color-brand-content);
+    border-radius: var(--pq-radius-lg);
+    box-shadow: var(--pq-shadow-sm);
+}
+
+.admonition-title {
+    font-weight: 750;
+}
+
+/* Tables */
+table.docutils,
+.table-wrapper table {
+    overflow: hidden;
+    border-collapse: separate;
+    border-spacing: 0;
+    border: 1px solid var(--color-background-border);
+    border-radius: var(--pq-radius-md);
+    box-shadow: var(--pq-shadow-sm);
+}
+
+table.docutils thead,
+.table-wrapper table thead {
+    background: var(--color-background-secondary);
+}
+
+table.docutils th,
+table.docutils td,
+.table-wrapper table th,
+.table-wrapper table td {
+    padding: 0.72rem 0.85rem;
+}
+
+/* Footnotes, bibliography, and focus states */
+.footnote,
+.citation {
+    color: var(--color-foreground-secondary);
+    font-size: 0.93rem;
+}
+
+:focus-visible {
+    outline: 0.16rem solid var(--color-brand-content);
+    outline-offset: 0.16rem;
+}
+
+/* Dark-theme borders */
+body[data-theme="dark"] .sd-card,
+body[data-theme="dark"] .highlight,
+body[data-theme="dark"] div.highlight,
+body[data-theme="dark"] div.nbinput.container div.input_area,
+body[data-theme="dark"] div.nboutput.container div.output_area,
+body[data-theme="dark"] dl.py.class,
+body[data-theme="dark"] dl.py.function,
+body[data-theme="dark"] dl.py.method,
+body[data-theme="dark"] dl.py.attribute,
+body[data-theme="dark"] .admonition,
+body[data-theme="dark"] table.docutils,
+body[data-theme="dark"] .table-wrapper table {
+    border-color: var(--pq-border-dark) !important;
+}
+
+body[data-theme="dark"] .sd-card {
+    border-color: var(--pq-card-border) !important;
+}
+
+@media (max-width: 67rem) {
+    .article-container {
+        max-width: 100%;
+    }
+
+    .content h1 {
+        width: auto;
+        max-width: 100%;
+        font-size: clamp(1.85rem, 7.5vw, 2.65rem);
+    }
+
+    .content h1 .headerlink {
+        left: auto;
+        right: -0.15rem;
+        margin-left: 0;
+    }
 }

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -1,10 +1,14 @@
 API reference
 =============
 
-The API reference of Piquasso.
+.. container:: mission-statement
+
+   Explore the public building blocks of Piquasso, from programs and simulators
+   to states, connectors, and exceptions.
 
 .. toctree::
    :maxdepth: 1
+   :hidden:
 
    program
    simulator
@@ -17,3 +21,93 @@ The API reference of Piquasso.
    exceptions
    computer
    connector
+
+Core workflow
+-------------
+
+.. grid:: 1 1 2 3
+   :gutter: 2
+
+   .. grid-item-card:: Program
+      :link: program
+      :link-type: doc
+
+      Define and compose photonic quantum programs.
+
+   .. grid-item-card:: Simulator
+      :link: simulator
+      :link-type: doc
+
+      Execute programs using the available simulation backends.
+
+   .. grid-item-card:: Config
+      :link: config
+      :link-type: doc
+
+      Configure numerical precision, cutoffs, validation, and execution options.
+
+Quantum objects
+---------------
+
+.. grid:: 1 1 2 3
+   :gutter: 2
+
+   .. grid-item-card:: Mode
+      :link: mode
+      :link-type: doc
+
+      Address individual modes and mode registers.
+
+   .. grid-item-card:: State
+      :link: state
+      :link-type: doc
+
+      Inspect the quantum states produced by simulations.
+
+   .. grid-item-card:: Instruction
+      :link: instruction
+      :link-type: doc
+
+      Apply gates, preparations, measurements, and channels.
+
+Execution results
+-----------------
+
+.. grid:: 1 1 2 3
+   :gutter: 2
+
+   .. grid-item-card:: Result
+      :link: result
+      :link-type: doc
+
+      Access samples, states, and metadata returned by simulator runs.
+
+   .. grid-item-card:: Branch
+      :link: branch
+      :link-type: doc
+
+      Work with conditional execution branches and measurement outcomes.
+
+   .. grid-item-card:: Exceptions
+      :link: exceptions
+      :link-type: doc
+
+      Understand the errors raised by Piquasso.
+
+Advanced components
+-------------------
+
+.. grid:: 1 1 2 3
+   :gutter: 2
+
+   .. grid-item-card:: Computer
+      :link: computer
+      :link-type: doc
+
+      Use lower-level execution interfaces.
+
+   .. grid-item-card:: Connector
+      :link: connector
+      :link-type: doc
+
+      Connect Piquasso to numerical backends and autodiff frameworks.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,7 +19,7 @@ sys.path.insert(0, os.path.abspath(".."))
 # -- Project information -----------------------------------------------------
 
 project = "Piquasso"
-copyright = "2021-2025, Budapest Quantum Computing Group"
+copyright = "2021-2026, Budapest Quantum Computing Group"
 author = "Budapest Quantum Computing Group"
 
 
@@ -86,9 +86,13 @@ html_theme = "furo"
 html_static_path = ["_static"]
 html_favicon = "_static/favicon.png"
 
+html_title = "Piquasso documentation"
+html_short_title = "Piquasso"
+
 pq_color = {
     "pq-grey": "#656565",
-    "pq-smokey-white": "#f4f4f4",
+    "pq-smokey-white": "#f7f8fb",
+    "pq-paper": "#ffffff",
     "pq-blue-shade1": "#1e2844",
     "pq-blue-shade2": "#273250",
     "pq-blue-shade3": "#2f3b5a",
@@ -97,28 +101,51 @@ pq_color = {
     "pq-font-color-shade2": "#b2bac8",
     "pq-font-color-shade3": "#8995a8",
     "pq-font-color-shade4": "#717c8e",
+    "pq-ink": "#202842",
+    "pq-ink-muted": "#4f5d75",
     "pq-color-red": "#e46363",
-    "pq-color-border": "#232d48",
-    "pq-color-border-dark": "#1a243e",
+    "pq-color-red-light": "#f07676",
+    "pq-color-border": "#dfe4ee",
+    "pq-color-border-dark": "#232d48",
 }
 
 html_theme_options = {
     "sidebar_hide_name": True,
     "light_logo": "logo_light.svg",
     "dark_logo": "logo_main.svg",
+    "light_css_variables": {
+        "color-background-primary": pq_color["pq-paper"],
+        "color-background-secondary": pq_color["pq-smokey-white"],
+        "color-background-hover": "#eef1f7",
+        "color-background-border": pq_color["pq-color-border"],
+        "color-code-background": "#f2f4f9",
+        "color-foreground-primary": pq_color["pq-ink"],
+        "color-foreground-secondary": pq_color["pq-ink-muted"],
+        "color-sidebar-link-text--top-level": pq_color["pq-ink"],
+        "color-brand-primary": pq_color["pq-color-red"],
+        "color-brand-content": pq_color["pq-color-red"],
+        "color-link": pq_color["pq-color-red"],
+        "color-link--hover": pq_color["pq-blue-shade4"],
+        "color-admonition-title--note": pq_color["pq-color-red"],
+        "color-admonition-background": "#fff4f4",
+        "color-admonition-title-background--note": "#ffe5e5",
+    },
     "dark_css_variables": {
         "color-background-primary": pq_color["pq-blue-shade1"],
         "color-background-secondary": pq_color["pq-blue-shade2"],
+        "color-background-hover": pq_color["pq-blue-shade3"],
+        "color-background-border": pq_color["pq-color-border-dark"],
         "color-code-background": pq_color["pq-blue-shade3"],
         "color-foreground-primary": pq_color["pq-font-color-shade1"],
         "color-foreground-secondary": pq_color["pq-font-color-shade2"],
         "color-sidebar-link-text--top-level": pq_color["pq-font-color-shade1"],
-        "color-brand-primary": pq_color["pq-font-color-shade4"],
-        "color-brand-content": pq_color["pq-color-red"],
-        "color-admonition-title--note": pq_color["pq-color-red"],
+        "color-brand-primary": pq_color["pq-color-red-light"],
+        "color-brand-content": pq_color["pq-color-red-light"],
+        "color-link": pq_color["pq-color-red-light"],
+        "color-link--hover": pq_color["pq-font-color-shade1"],
+        "color-admonition-title--note": pq_color["pq-color-red-light"],
         "color-admonition-background": pq_color["pq-blue-shade3"],
         "color-admonition-title-background--note": pq_color["pq-blue-shade2"],
-        "color-background-hover": pq_color["pq-blue-shade3"],
     },
 }
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,106 +11,141 @@
 
 .. container:: mission-statement
 
-   Piquasso is an open source Python package, which allows you to simulate a photonic
-   quantum computer.
+   Piquasso is an open-source Python package for simulating photonic quantum
+   computers.
 
-|
 
-.. grid:: 4
+.. container:: landing-intro
 
-   .. grid-item-card::  Installation
+   Build photonic programs from preparations, gates, measurements, and channels,
+   then execute them with task-specific high-performance simulators. Piquasso supports
+   Gaussian, Fock-space, and Boson Sampling-based workflows, from small examples to
+   adaptive and differentiable simulations.
+
+Get started
+===========
+
+.. grid:: 1 1 2 2
+   :gutter: 2
+
+   .. grid-item-card:: Installation
       :link: installation
       :link-type: doc
-      :class-title: cardclass
 
-      Instructions on the installation of the Piquasso package.
+      Install Piquasso and verify your local setup.
 
-   .. grid-item-card::  Tutorials
+   .. grid-item-card:: Tutorials
       :link: tutorials/index
       :link-type: doc
 
-      Basic tutorials for using Piquasso.
+      Learn the basic program structure through guided examples.
 
-   .. grid-item-card::  Simulators
+   .. grid-item-card:: Simulators
       :link: simulators/index
       :link-type: doc
 
-      The built-in simulators in Piquasso.
+      Choose the simulator that matches your circuit and representation.
 
-   .. grid-item-card::  API reference
+   .. grid-item-card:: API reference
       :link: api/index
       :link-type: doc
 
-      API reference for Piquasso.
+      Browse the public classes, functions, and configuration options.
 
+Explore Piquasso
+================
 
-|
+.. grid:: 1 1 2 2
+   :gutter: 2
+
+   .. grid-item-card:: Instructions
+      :link: instructions/index
+      :link-type: doc
+
+      Use preparations, gates, measurements, channels, and adaptive execution.
+
+   .. grid-item-card:: States
+      :link: states/index
+      :link-type: doc
+
+      Inspect the state representations returned by the simulators.
+
+   .. grid-item-card:: Connectors
+      :link: advanced/connectors
+      :link-type: doc
+
+      Use alternative numerical backends, including JAX-based workflows.
+
+   .. grid-item-card:: Advanced topics
+      :link: advanced/decompositions
+      :link-type: doc
+
+      Learn about decompositions and specialized simulation workflows.
 
 Code example
 ============
 
-.. code-block::
+The example below prepares a Gaussian state, applies a displacement and a
+beamsplitter, then performs a homodyne measurement.
+
+.. code-block:: python
 
    import numpy as np
    import piquasso as pq
 
-   # Program definition
    with pq.Program() as program:
-      # Prepare a Gaussian vacuum state
       pq.Q() | pq.Vacuum()
-
-      # Displace the state on mode 0
       pq.Q(0) | pq.Displacement(r=np.sqrt(2), phi=np.pi / 4)
-
-      # Use a beamsplitter gate on modes 0, 1
       pq.Q(0, 1) | pq.Beamsplitter(theta=np.pi / 3, phi=np.pi / 2)
-
-      # Measurement on mode 0
       pq.Q(0) | pq.HomodyneMeasurement(phi=0)
 
-   # Creating the Gaussian simulator
    simulator = pq.GaussianSimulator(d=3)
-
-   # Apply the program with 10 shots
    result = simulator.execute(program, shots=10)
+
+   print(result.samples)
 
 
 How to cite us
 ==============
 
-If you are doing research using Piquasso, please cite us as follows:
+If you use Piquasso in your research, please cite:
 
-.. code-block::
+.. code-block:: text
 
-   @article{Kolarovszki_2025,
-      title={Piquasso: A Photonic Quantum Computer Simulation Software Platform},
-      volume={9},
-      ISSN={2521-327X},
-      url={http://dx.doi.org/10.22331/q-2025-04-15-1708},
-      DOI={10.22331/q-2025-04-15-1708},
-      journal={Quantum},
-      publisher={Verein zur Forderung des Open Access Publizierens in den Quantenwissenschaften},
-      author={
-         Kolarovszki, Zoltán
-         and Rybotycki, Tomasz
-         and Rakyta, Péter
-         and Kaposi, Ágoston
-         and Poór, Boldizsár
-         and Jóczik, Szabolcs
-         and Nagy, Dániel T. R.
-         and Varga, Henrik
-         and El-Safty, Kareem H.
-         and Morse, Gregory
-         and Oszmaniec, Michał
-         and Kozsik, Tamás
-         and Zimborás, Zoltán
-      },
-      year={2025},
-      month=apr,
-      pages={1708}
-   }
+   Piquasso: A Photonic Quantum Computer Simulation Software Platform,
+   Quantum 9, 1708 (2025).
 
+.. dropdown:: BibTeX entry
 
+   .. code-block:: bibtex
+
+      @article{Kolarovszki_2025,
+         title={Piquasso: A Photonic Quantum Computer Simulation Software Platform},
+         volume={9},
+         ISSN={2521-327X},
+         url={http://dx.doi.org/10.22331/q-2025-04-15-1708},
+         DOI={10.22331/q-2025-04-15-1708},
+         journal={Quantum},
+         publisher={Verein zur Forderung des Open Access Publizierens in den Quantenwissenschaften},
+         author={
+            Kolarovszki, Zoltán
+            and Rybotycki, Tomasz
+            and Rakyta, Péter
+            and Kaposi, Ágoston
+            and Poór, Boldizsár
+            and Jóczik, Szabolcs
+            and Nagy, Dániel T. R.
+            and Varga, Henrik
+            and El-Safty, Kareem H.
+            and Morse, Gregory
+            and Oszmaniec, Michał
+            and Kozsik, Tamás
+            and Zimborás, Zoltán
+         },
+         year={2025},
+         month=apr,
+         pages={1708}
+      }
 
 .. toctree::
    :hidden:
@@ -118,7 +153,6 @@ If you are doing research using Piquasso, please cite us as follows:
 
    installation
    tutorials/index
-
 
 .. toctree::
    :hidden:
@@ -144,3 +178,56 @@ If you are doing research using Piquasso, please cite us as follows:
    :caption: Experimental
 
    experimental/fermionic
+
+
+Notable features
+================
+
+Piquasso is designed for concise examples, adaptive photonic programs, and
+research workflows that need performance, differentiability, or realistic
+imperfections.
+
+.. grid:: 1 1 2 3
+   :gutter: 2
+
+   .. grid-item-card:: Task-specific simulators
+      :link: simulators/index
+      :link-type: doc
+
+      Choose Gaussian, Fock-space, or Boson Sampling simulators depending on the
+      circuit and the representation you need.
+
+   .. grid-item-card:: Adaptive execution
+      :link: instructions/index
+      :link-type: doc
+
+      Use mid-circuit measurements, postselection, and conditional instructions
+      to build adaptive photonic programs.
+
+   .. grid-item-card:: Runtime-resolved parameters
+      :link: instructions/index
+      :link-type: doc
+
+      Let instruction parameters depend on previous measurement outcomes using
+      Python callables or expression strings.
+
+   .. grid-item-card:: Losses and imperfections
+      :link: instructions/channels
+      :link-type: doc
+
+      Model non-unitary effects such as photon loss and other realistic
+      imperfections through channel instructions.
+
+   .. grid-item-card:: Differentiable workflows
+      :link: advanced/cvqnn
+      :link-type: doc
+
+      Build optimization workflows for trainable photonic circuits and quantum
+      neural-network-style simulations.
+
+   .. grid-item-card:: JAX, GPU, and performance
+      :link: advanced/connectors
+      :link-type: doc
+
+      Use connector-based workflows and optimized backends for demanding
+      simulations and accelerator-ready execution.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,25 +1,38 @@
 Installation
 ============
 
-One could easily install Piquasso with the following command:
+Install Piquasso from PyPI with:
 
 .. code-block:: bash
 
    pip install piquasso
 
-For a basic example, check out :doc:`tutorials/getting-started`.
+For a first example, see :doc:`tutorials/getting-started`.
 
-One can also use Piquasso along with TensorFlow, see, e.g.,
-:doc:`tutorials/cvqnn-with-tensorflow`. To install Piquasso with TensorFlow, just enter
+Optional dependencies
+---------------------
+
+TensorFlow support
+^^^^^^^^^^^^^^^^^^
+
+Piquasso can also be used with TensorFlow, for example in continuous-variable
+quantum neural network workflows. See :doc:`tutorials/cvqnn-with-tensorflow`
+for a tutorial.
+
+To install Piquasso with TensorFlow support, run:
 
 .. code-block:: bash
 
-   pip install piquasso[tensorflow]
+   pip install "piquasso[tensorflow]"
 
+JAX support
+^^^^^^^^^^^
 
-Similarly, Piquasso admits a JAX support, as described in :doc:`tutorials/jax-example`
-To install Piquasso with JAX is done by
+Piquasso also supports JAX-based workflows, as described in
+:doc:`tutorials/jax-example`.
+
+To install Piquasso with JAX support, run:
 
 .. code-block:: bash
 
-   pip install piquasso[jax]
+   pip install "piquasso[jax]"

--- a/docs/instructions/index.rst
+++ b/docs/instructions/index.rst
@@ -1,7 +1,10 @@
 Instructions
 ============
 
-The built-in :class:`~piquasso.api.instruction.Instruction` classes in Piquasso.
+Instructions are the operations placed inside a :class:`~piquasso.api.program.Program`.
+They describe how selected modes are prepared, transformed, measured, or affected
+by noise. In most examples, an instruction is attached to one or more modes with
+the ``pq.Q(...) | instruction`` syntax.
 
 .. toctree::
    :maxdepth: 3
@@ -12,29 +15,241 @@ The built-in :class:`~piquasso.api.instruction.Instruction` classes in Piquasso.
    measurements
    channels
 
+.. grid:: 1 1 2 2
+   :gutter: 2
 
-.. grid:: 3
-
-   .. grid-item-card::  Preparations
+   .. grid-item-card:: Preparations
       :link: preparations
       :link-type: doc
 
-      Instructions for state preparations.
+      Define the initial state or add state-vector components to the program.
 
-   .. grid-item-card::  Gates
+   .. grid-item-card:: Gates
       :link: gates
       :link-type: doc
 
-      Instructions for applying quantum gates.
+      Apply transformations such as displacements, squeezings, beamsplitters,
+      and interferometers.
 
-   .. grid-item-card::  Measurements
+   .. grid-item-card:: Measurements
       :link: measurements
       :link-type: doc
 
-      Instructions to carry out measurements.
+      Extract samples or measurement results from selected modes.
 
-   .. grid-item-card::  Channels
+   .. grid-item-card:: Channels
       :link: channels
       :link-type: doc
 
-      Instructions for applying quantum channels.
+      Model non-unitary effects such as loss and other noisy processes.
+
+How instructions are used
+-------------------------
+
+A program is built by applying instructions to modes. The instruction itself
+describes the operation, while ``pq.Q(...)`` selects the modes on which the
+operation acts.
+
+.. code-block:: python
+
+   import numpy as np
+   import piquasso as pq
+
+   with pq.Program() as program:
+      # Preparation
+      pq.Q() | pq.Vacuum()
+
+      # Gates
+      pq.Q(0) | pq.Displacement(r=0.2)
+      pq.Q(0, 1) | pq.Beamsplitter(theta=np.pi / 4)
+
+      # Measurement
+      pq.Q(all) | pq.ParticleNumberMeasurement()
+
+   simulator = pq.GaussianSimulator(d=2)
+   result = simulator.execute(program, shots=10)
+
+   print(result.samples)
+
+Instruction categories
+----------------------
+
+.. grid:: 1 1 2 2
+   :gutter: 2
+
+   .. grid-item-card:: Preparations usually come first
+
+      A preparation instruction initializes the simulated state before gates,
+      channels, or measurements are applied.
+
+   .. grid-item-card:: Gates transform the state
+
+      Gate instructions describe reversible transformations of the selected
+      modes. Many common optical operations are represented as gates.
+
+   .. grid-item-card:: Channels model noise
+
+      Channel instructions describe non-unitary effects, such as losses. Their
+      availability can depend on the chosen simulator.
+
+   .. grid-item-card:: Measurements usually come last
+
+      Measurement instructions produce classical information, such as samples.
+      When shots are requested, the result contains measurement samples.
+
+Simulator compatibility
+-----------------------
+
+Instructions are declarative: they describe the program to be executed. The
+chosen simulator determines which instructions can be evaluated efficiently and
+which state representation is used. For example, Gaussian circuits are naturally
+handled by Gaussian simulators, while many non-Gaussian operations require a
+Fock-space simulator. Boson Sampling-style programs are handled by the Sampling
+simulator.
+
+
+Dynamic and adaptive programs
+-----------------------------
+
+Piquasso programs do not have to be simple straight-line circuits. In supported
+simulators, measurements can appear before the end of the program, later
+instructions can be conditioned on previous measurement outcomes, and some
+instruction parameters can be resolved at runtime.
+
+.. grid:: 1 1 2 3
+   :gutter: 2
+
+   .. grid-item-card:: Mid-circuit measurements
+
+      Measure or postselect modes before the program ends, then continue the
+      simulation on the remaining modes.
+
+   .. grid-item-card:: Conditional execution
+
+      Attach a condition to an instruction with ``Instruction.when(...)`` so it
+      is applied only for selected measurement histories.
+
+   .. grid-item-card:: Runtime parameters
+
+      Use previous measurement outcomes to determine instruction parameters
+      during execution.
+
+Mid-circuit measurements
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Mid-circuit measurements are useful when a measurement result should affect the
+state before later instructions are applied. A common example is heralding: one
+mode is measured or postselected, and the unmeasured modes continue in the
+post-measurement state.
+
+.. code-block:: python
+
+   import numpy as np
+   import piquasso as pq
+
+   with pq.Program() as program:
+      pq.Q() | pq.Vacuum()
+
+      # Entangle modes 0 and 1.
+      pq.Q(0, 1) | pq.Squeezing2(r=np.log(1 + np.sqrt(2)))
+
+      # Herald on detecting exactly one photon in mode 1.
+      pq.Q(1) | pq.PostSelectPhotons((1,))
+
+      # Continue the program on the heralded state.
+      pq.Q(0, 2) | pq.Beamsplitter5050()
+
+   result = pq.PureFockSimulator(d=3).execute(program)
+
+Conditional instruction execution
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``Instruction.when(...)`` method makes an instruction conditional. The
+condition receives the previous measurement outcomes and decides whether the
+instruction should be applied in the current branch.
+
+.. code-block:: python
+
+   import numpy as np
+   import piquasso as pq
+
+   with pq.Program() as program:
+      pq.Q(0, 1, 2) | pq.StateVector((1, 0, 0))
+      pq.Q(0, 1) | pq.Beamsplitter(theta=np.pi / 4)
+
+      # Measure mode 0 before the end of the program.
+      pq.Q(0) | pq.ParticleNumberMeasurement()
+
+      # If the last detected value was 0, route the remaining photon.
+      pq.Q(1, 2) | pq.Beamsplitter(theta=np.pi / 2).when(
+         lambda outcomes: outcomes[-1] == 0
+      )
+
+      pq.Q(1, 2) | pq.ParticleNumberMeasurement()
+
+   result = pq.PureFockSimulator(d=3).execute(program, shots=20)
+
+Runtime-resolved parameters
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Instruction parameters can also depend on earlier measurement outcomes. This is
+useful for adaptive programs where a later gate is calibrated from information
+obtained during the same execution.
+
+.. code-block:: python
+
+   import numpy as np
+   import piquasso as pq
+
+   program = pq.Program(
+      instructions=[
+         pq.StateVector([0, 2]) * np.sqrt(1 / 3),
+         pq.StateVector([1, 1]) * np.sqrt(1 / 3),
+         pq.StateVector([2, 0]) * np.sqrt(1 / 3),
+         pq.ParticleNumberMeasurement().on_modes(1),
+         pq.Squeezing(r=lambda x: 0.1 * x[-1] ** 2).on_modes(0),
+      ]
+   )
+
+   result = pq.PureFockSimulator(d=2).execute(program, shots=10)
+
+Using an expression string:
+
+.. code-block:: python
+
+   import numpy as np
+   import piquasso as pq
+
+   program = pq.Program(
+      instructions=[
+         pq.StateVector([0, 2]) * np.sqrt(1 / 3),
+         pq.StateVector([1, 1]) * np.sqrt(1 / 3),
+         pq.StateVector([2, 0]) * np.sqrt(1 / 3),
+         pq.ParticleNumberMeasurement().on_modes(1),
+         pq.Squeezing(r="0.1 * x[-1] ** 2").on_modes(0),
+      ]
+   )
+
+   result = pq.PureFockSimulator(d=2).execute(program, shots=10)
+
+Program construction styles
+---------------------------
+
+Most examples use the context-manager style, but the same program can also be
+created from an explicit instruction list. This can be convenient when programs
+are generated by another tool or assembled dynamically.
+
+.. code-block:: python
+
+   import numpy as np
+   import piquasso as pq
+
+   program = pq.Program(
+      instructions=[
+         pq.Vacuum(),
+         pq.Squeezing(r=0.5).on_modes(0),
+         pq.Beamsplitter(theta=np.pi / 4).on_modes(0, 1),
+      ]
+   )
+
+   result = pq.GaussianSimulator(d=2).execute(program)

--- a/docs/simulators/index.rst
+++ b/docs/simulators/index.rst
@@ -1,8 +1,9 @@
 Simulators
 ==========
 
-The built-in simulators in Piquasso.
-
+Piquasso provides several built-in simulators for different photonic simulation
+tasks. The right choice depends on the representation you need, the instructions
+in your program, and whether you want finite-shot samples or the final state.
 
 .. toctree::
    :maxdepth: 3
@@ -13,25 +14,166 @@ The built-in simulators in Piquasso.
    fock
    sampling
 
+.. grid:: 1 1 2 3
+   :gutter: 2
 
-.. grid:: 3
-
-   .. grid-item-card::  Gaussian simulator
+   .. grid-item-card:: Gaussian simulator
       :link: gaussian
       :link-type: doc
-      :class-title: cardclass
 
-      Simulate Gaussian states, i.e., states characterized by first and second moments.
+      Efficiently simulate Gaussian states, Gaussian gates, Gaussian channels,
+      and compatible measurements.
 
-   .. grid-item-card::  Fock space-based simulators
+   .. grid-item-card:: Fock space-based simulators
       :link: fock
       :link-type: doc
 
-      Simulate generic photonic states using its coefficients in the Fock basis.
+      Simulate states in the truncated Fock basis, including non-Gaussian
+      operations such as Kerr-type gates.
 
-   .. grid-item-card::  Boson Sampling simulator
+   .. grid-item-card:: Boson Sampling simulator
       :link: sampling
       :link-type: doc
 
-      Simulate Boson Sampling, a scheme using interferometers and terminal particle
-      number detectors.
+      Sample from interferometer-based Boson Sampling circuits with terminal
+      particle number measurements.
+
+Choosing a simulator
+--------------------
+
+.. grid:: 1 1 2 2
+   :gutter: 2
+
+   .. grid-item-card:: GaussianSimulator
+      :link: gaussian
+      :link-type: doc
+
+      Use this for Gaussian circuits and efficient phase-space simulations based
+      on first and second moments.
+
+   .. grid-item-card:: PureFockSimulator
+      :link: fock
+      :link-type: doc
+
+      Use this for pure-state simulations in a truncated Fock basis, including
+      supported non-Gaussian operations.
+
+   .. grid-item-card:: FockSimulator
+      :link: fock
+      :link-type: doc
+
+      Use this when you need the more general Fock representation, for example
+      for mixed states or supported noisy operations.
+
+   .. grid-item-card:: SamplingSimulator
+      :link: sampling
+      :link-type: doc
+
+      Use this for Boson Sampling-style circuits with Fock-state inputs,
+      interferometers, losses, and particle number measurements.
+
+Quick examples
+--------------
+
+Gaussian simulation
+~~~~~~~~~~~~~~~~~~~
+
+Use the Gaussian simulator for circuits that can be represented in phase space.
+
+.. code-block:: python
+
+   import numpy as np
+   import piquasso as pq
+
+   with pq.Program() as program:
+      pq.Q() | pq.Vacuum()
+      pq.Q(0) | pq.Displacement(r=0.2)
+      pq.Q(0, 1) | pq.Beamsplitter(theta=np.pi / 4)
+      pq.Q(all) | pq.ParticleNumberMeasurement()
+
+   simulator = pq.GaussianSimulator(d=2)
+   result = simulator.execute(program, shots=10)
+
+   print(result.samples)
+
+Fock simulation
+~~~~~~~~~~~~~~~
+
+Use a Fock simulator when the circuit contains non-Gaussian operations. The
+``cutoff`` controls the size of the truncated Fock basis.
+
+.. code-block:: python
+
+   import numpy as np
+   import piquasso as pq
+
+   with pq.Program() as program:
+      pq.Q() | pq.Vacuum()
+      pq.Q(0) | pq.Displacement(r=0.4)
+      pq.Q(0) | pq.Kerr(xi=0.05)
+
+   simulator = pq.PureFockSimulator(
+      d=1,
+      config=pq.Config(cutoff=8),
+   )
+   result = simulator.execute(program)
+
+   print(result.state.fock_probabilities)
+
+Boson Sampling simulation
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use the Sampling simulator for particle-number input states followed by a
+linear optical circuit and terminal particle number measurements.
+
+.. code-block:: python
+
+   import numpy as np
+   import piquasso as pq
+
+   interferometer = np.array(
+      [
+         [1 / np.sqrt(2), 1 / np.sqrt(2)],
+         [1 / np.sqrt(2), -1 / np.sqrt(2)],
+      ]
+   )
+
+   with pq.Program() as program:
+      pq.Q() | pq.StateVector([1, 1])
+      pq.Q() | pq.Interferometer(interferometer)
+      pq.Q(all) | pq.ParticleNumberMeasurement()
+
+   simulator = pq.SamplingSimulator(d=2)
+   result = simulator.execute(program, shots=10)
+
+   print(result.samples)
+
+Automatic simulator selection with ``simulate``
+-----------------------------------------------
+
+For small examples and quick experiments, the top-level ``pq.simulate`` function
+can choose a compatible built-in simulator for the program.
+
+.. code-block:: python
+
+   import numpy as np
+   import piquasso as pq
+
+   with pq.Program() as program:
+      pq.Q() | pq.Vacuum()
+      pq.Q(0) | pq.Displacement(r=0.2)
+      pq.Q(0, 1) | pq.Beamsplitter(theta=np.pi / 4)
+      pq.Q(all) | pq.ParticleNumberMeasurement()
+
+   result = pq.simulate(
+      program,
+      number_of_modes=2,
+      shots=10,
+   )
+
+   print(result.samples)
+
+The function accepts the same common simulation options as explicit simulator
+usage, including ``config``, ``connector``, and ``shots``. Use an explicit
+simulator class when you want to document or control the exact representation
+used by the simulation.

--- a/docs/states/index.rst
+++ b/docs/states/index.rst
@@ -1,7 +1,11 @@
 States
 ======
 
-The built-in :class:`~piquasso.api.state.State` classes in Piquasso.
+Piquasso state classes represent the result of a simulation. In most workflows,
+you do not choose a state class directly. Instead, you choose a simulator, execute a
+program, and inspect the returned :class:`~piquasso.api.result.Result` (e.g.,
+``result.state`` when no measurements are performed, otherwise ``result.samples`` or
+``result.branches``).
 
 .. toctree::
    :maxdepth: 3
@@ -11,25 +15,133 @@ The built-in :class:`~piquasso.api.state.State` classes in Piquasso.
    fock
    sampling
 
+.. grid:: 1 1 2 3
+   :gutter: 2
 
-.. grid:: 3
-
-   .. grid-item-card::  GaussianState
+   .. grid-item-card:: GaussianState
       :link: gaussian
       :link-type: doc
-      :class-title: cardclass
 
-      Class to represent a Gaussian state.
+      Returned by Gaussian simulations. It represents Gaussian states through
+      phase-space data such as first and second moments.
 
-   .. grid-item-card::  FockState and PureFockState
+   .. grid-item-card:: FockState and PureFockState
       :link: fock
       :link-type: doc
 
-      Classes to represent a mixed or pure photonic states in the Fock basis.
+      Returned by Fock-space simulations. They represent mixed or pure photonic
+      states in a truncated Fock basis.
 
-   .. grid-item-card::  SamplingState
+   .. grid-item-card:: SamplingState
       :link: sampling
       :link-type: doc
 
-      Class to represent the state in a Boson Sampling expermiment before measurement.
+      Used by Boson Sampling simulations to represent the state before terminal
+      particle number measurements.
 
+How states are obtained
+-----------------------
+
+The state type follows from the simulator used to execute the program.
+
+.. grid:: 1 1 2 2
+   :gutter: 2
+
+   .. grid-item-card:: GaussianSimulator
+
+      Returns a :class:`~piquasso._simulators.gaussian.state.GaussianState`
+      when the program is executed without terminal sampling-only output.
+
+   .. grid-item-card:: PureFockSimulator
+
+      Returns a :class:`~piquasso._simulators.fock.pure.state.PureFockState`
+      represented by state-vector coefficients in the Fock basis.
+
+   .. grid-item-card:: FockSimulator
+
+      Returns a :class:`~piquasso._simulators.fock.general.state.FockState`
+      represented by a density matrix in the Fock basis.
+
+   .. grid-item-card:: SamplingSimulator
+
+      Uses a :class:`~piquasso._simulators.sampling.state.SamplingState` for
+      Boson Sampling-style circuits and produces particle-number samples.
+
+Basic usage
+-----------
+
+After executing a program without measurements, the final state can be accessed through
+``result.state``. For programs with measurements, inspect ``result.samples`` (finite shots)
+or ``result.branches`` (exact distribution with ``shots=None``).
+
+.. code-block:: python
+
+   import numpy as np
+   import piquasso as pq
+
+   with pq.Program() as program:
+      pq.Q() | pq.Vacuum()
+      pq.Q(0) | pq.Displacement(r=0.2)
+      pq.Q(0, 1) | pq.Beamsplitter(theta=np.pi / 4)
+
+   simulator = pq.GaussianSimulator(d=2)
+   result = simulator.execute(program)
+
+   state = result.state
+
+   print(type(state))
+   print(state.mean_photon_number())
+
+Fock-state example
+------------------
+
+For non-Gaussian circuits, use a Fock-space simulator. The state is represented
+in a truncated Fock basis, controlled by ``Config(cutoff=...)``.
+
+.. code-block:: python
+
+   import piquasso as pq
+
+   with pq.Program() as program:
+      pq.Q() | pq.Vacuum()
+      pq.Q(0) | pq.Displacement(r=0.4)
+      pq.Q(0) | pq.Kerr(xi=0.05)
+
+   simulator = pq.PureFockSimulator(
+      d=1,
+      config=pq.Config(cutoff=8),
+   )
+   result = simulator.execute(program)
+
+   state = result.state
+
+   print(type(state))
+   print(state.fock_probabilities)
+
+Sampling example
+----------------
+
+For Boson Sampling-style simulations, the main output is usually the collection
+of measurement samples.
+
+.. code-block:: python
+
+   import numpy as np
+   import piquasso as pq
+
+   interferometer = np.array(
+      [
+         [1 / np.sqrt(2), 1 / np.sqrt(2)],
+         [1 / np.sqrt(2), -1 / np.sqrt(2)],
+      ]
+   )
+
+   with pq.Program() as program:
+      pq.Q() | pq.StateVector([1, 1])
+      pq.Q() | pq.Interferometer(interferometer)
+      pq.Q(all) | pq.ParticleNumberMeasurement()
+
+   simulator = pq.SamplingSimulator(d=2)
+   result = simulator.execute(program, shots=10)
+
+   print(result.samples)

--- a/docs/tutorials/index.rst
+++ b/docs/tutorials/index.rst
@@ -1,77 +1,91 @@
 Tutorials
 =========
 
-This document contains the basic tutorials of Piquasso.
+These tutorials introduce the main workflows in Piquasso, from basic program
+construction to sampling, differentiable simulations, and application-oriented
+examples.
 
-.. grid:: 3
+First steps
+-----------
 
-   .. grid-item-card::  Getting started
+.. grid:: 1 1 2 2
+   :gutter: 2
+
+   .. grid-item-card:: Getting started
       :link: getting-started
       :link-type: doc
 
-      A basic usage example of Piquasso.
+      Build and execute a first Piquasso program.
 
-
-   .. grid-item-card::  Boson Sampling
-      :link: boson-sampling
-      :link-type: doc
-
-      Boson Sampling simulations using Piquasso.
-
-
-   .. grid-item-card::  Gaussian Boson Sampling
-      :link: gaussian-boson-sampling
-      :link-type: doc
-
-      Gaussian Boson Sampling simulations using Piquasso.
-
-
-.. grid:: 3
-
-    .. grid-item-card::  Modularity in Piquasso
+   .. grid-item-card:: Modularity in Piquasso
       :link: separating-programs
       :link-type: doc
 
-      Compose Piquasso programs and define custom gates with ease.
+      Compose programs, reuse circuit fragments, and define custom gates.
 
+Sampling experiments
+--------------------
 
-    .. grid-item-card::  Quantum Neural Network layers
+.. grid:: 1 1 2 2
+   :gutter: 2
+
+   .. grid-item-card:: Boson Sampling
+      :link: boson-sampling
+      :link-type: doc
+
+      Simulate Boson Sampling circuits with particle-number input states.
+
+   .. grid-item-card:: Gaussian Boson Sampling
+      :link: gaussian-boson-sampling
+      :link-type: doc
+
+      Simulate Gaussian Boson Sampling circuits and inspect the resulting
+      samples.
+
+Differentiable workflows
+------------------------
+
+.. grid:: 1 1 2 2
+   :gutter: 2
+
+   .. grid-item-card:: Quantum Neural Network layers
       :link: cvqnn-with-tensorflow
       :link-type: doc
 
-      Using the automatic differentiation capabilities of Piquasso with TensorFlow.
+      Use Piquasso with TensorFlow in a trainable continuous-variable workflow.
 
-
-    .. grid-item-card::  Using JAX with Piquasso
+   .. grid-item-card:: Using JAX with Piquasso
       :link: jax-example
       :link-type: doc
 
-      A simple state learning example using JAX and Piquasso.
+      Learn a simple state-learning example using JAX and Piquasso.
 
+Applications and benchmarking
+-----------------------------
 
-.. grid:: 3
+.. grid:: 1 1 2 2
+   :gutter: 2
 
-   .. grid-item-card::  Dense k-subgraph problem
+   .. grid-item-card:: Dense k-subgraph problem
       :link: dense-subgraph-gbs
       :link-type: doc
 
-      Solve dense k-subgraph problem with Gaussian Boson Sampling.
+      Use Gaussian Boson Sampling to study the dense k-subgraph problem.
 
-   .. grid-item-card::  Linear cross-entropy benchmarking
+   .. grid-item-card:: Linear cross-entropy benchmarking
       :link: lxeb
       :link-type: doc
 
-      A simple example of linear cross-entropy benchmarking with Piquasso.
-
+      Run a simple linear cross-entropy benchmarking example.
 
 .. toctree::
    :maxdepth: 3
    :hidden:
 
    getting-started
+   separating-programs
    boson-sampling
    gaussian-boson-sampling
-   separating-programs
    cvqnn-with-tensorflow
    jax-example
    dense-subgraph-gbs


### PR DESCRIPTION
This patch includes a major facelifting of the documentation with several visual and structural improvements.

The changes include a refreshed custom CSS theme, improved heading and card styling, more polished landing-page sections, and reorganized overview pages for tutorials, simulators, states, and instructions. The updated pages provide clearer navigation, more context for new users, and additional examples for simulator usage, state inspection, instruction categories, adaptive execution, mid-circuit measurements, conditional instructions, runtime-resolved parameters, and expression strings. The main index page now highlights notable Piquasso features.

### Acknowledgement

Parts of this documentation were improved with assistance from ChatGPT by OpenAI. All generated suggestions were reviewed, edited, and integrated by the author of this commit.