### PR TITLE
feat(gaussian): Recursive `density_matrix` in JAX

### DIFF
--- a/piquasso/_math/hermite.py
+++ b/piquasso/_math/hermite.py
@@ -134,7 +134,7 @@ def _entry_raising_bra(
 
 
 @nb.njit(cache=True)
-def density_matrix_from_a_b_c(
+def density_matrix_from_gaussian(
     A: np.ndarray,
     b: np.ndarray,
     c: complex,

--- a/piquasso/_math/jax/hermite.py
+++ b/piquasso/_math/jax/hermite.py
@@ -1,0 +1,186 @@
+#
+# Copyright 2021-2026 Budapest Quantum Computing Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Translation of `piquasso._math.hermite` to JAX.
+"""
+
+import numpy as np
+
+import jax
+import jax.numpy as jnp
+
+import numba as nb
+
+from piquasso._math.indices import get_index_in_fock_space
+
+
+@nb.njit(cache=True)
+def _precompute_lowered_indices(basis: np.ndarray) -> np.ndarray:
+    # NOTE: This part of the code is not JAX-compatible, but it is only run once, so it
+    # is not a performance bottleneck. The differentiability is not violated.
+    cardinality, d = basis.shape
+
+    lowered_indices = np.zeros(shape=(cardinality, d), dtype=np.int32)
+
+    for index in range(cardinality):
+        occupation_numbers = basis[index]
+
+        for mode in range(d):
+            if occupation_numbers[mode] == 0:
+                continue
+
+            lowered = occupation_numbers.copy()
+            lowered[mode] -= 1
+
+            lowered_indices[index, mode] = get_index_in_fock_space(lowered)
+
+    return lowered_indices
+
+
+def _first_nonzero_mode(occupation_numbers):
+    return jnp.argmax(occupation_numbers > 0)
+
+
+def _entry_raising_ket(row, col, basis, lowered_indices, A, b, density_matrix):
+    d = basis.shape[1]
+    real_dtype = jnp.real(A).dtype
+
+    ket = basis[col]
+    bra = basis[row]
+
+    pivot = _first_nonzero_mode(ket)
+
+    col_lowered = lowered_indices[col, pivot]
+
+    value = b[pivot] * density_matrix[row, col_lowered]
+
+    def ket_body(mode, value):
+        occupation = basis[col_lowered, mode]
+        lowered_col = lowered_indices[col_lowered, mode]
+
+        return value + (
+            jnp.sqrt(occupation.astype(real_dtype))
+            * A[pivot, mode]
+            * density_matrix[row, lowered_col]
+        )
+
+    value = jax.lax.fori_loop(0, d, ket_body, value)
+
+    def bra_body(mode, value):
+        occupation = bra[mode]
+        lowered_row = lowered_indices[row, mode]
+
+        return value + (
+            jnp.sqrt(occupation.astype(real_dtype))
+            * A[pivot, d + mode]
+            * density_matrix[lowered_row, col_lowered]
+        )
+
+    value = jax.lax.fori_loop(0, d, bra_body, value)
+
+    return value / jnp.sqrt(ket[pivot].astype(real_dtype))
+
+
+def _entry_raising_bra(row, basis, lowered_indices, A, b, density_matrix):
+    d = basis.shape[1]
+    real_dtype = jnp.real(A).dtype
+
+    bra = basis[row]
+
+    pivot = _first_nonzero_mode(bra)
+
+    row_lowered = lowered_indices[row, pivot]
+
+    value = b[d + pivot] * density_matrix[row_lowered, 0]
+
+    def bra_body(mode, value):
+        occupation = basis[row_lowered, mode]
+        lowered_row = lowered_indices[row_lowered, mode]
+
+        return value + (
+            jnp.sqrt(occupation.astype(real_dtype))
+            * A[d + pivot, d + mode]
+            * density_matrix[lowered_row, 0]
+        )
+
+    value = jax.lax.fori_loop(0, d, bra_body, value)
+
+    return value / jnp.sqrt(bra[pivot].astype(real_dtype))
+
+
+@jax.jit
+def _density_matrix_from_gaussian_core(A, b, c, basis, lowered_indices):
+    cardinality = basis.shape[0]
+
+    dtype = A.dtype
+
+    density_matrix = jnp.zeros(
+        shape=(cardinality, cardinality),
+        dtype=dtype,
+    )
+    density_matrix = density_matrix.at[0, 0].set(c)
+
+    def row_body(row, density_matrix):
+        def col_body(col, density_matrix):
+            value = jax.lax.cond(
+                col > 0,
+                lambda _: _entry_raising_ket(
+                    row,
+                    col,
+                    basis,
+                    lowered_indices,
+                    A,
+                    b,
+                    density_matrix,
+                ),
+                lambda _: jax.lax.cond(
+                    row > 0,
+                    lambda __: _entry_raising_bra(
+                        row,
+                        basis,
+                        lowered_indices,
+                        A,
+                        b,
+                        density_matrix,
+                    ),
+                    lambda __: density_matrix[0, 0],
+                    operand=None,
+                ),
+                operand=None,
+            )
+
+            return density_matrix.at[row, col].set(value)
+
+        return jax.lax.fori_loop(0, cardinality, col_body, density_matrix)
+
+    return jax.lax.fori_loop(0, cardinality, row_body, density_matrix)
+
+
+def density_matrix_from_gaussian(
+    A: jnp.ndarray,
+    b: jnp.ndarray,
+    c: complex,
+    basis: np.ndarray,
+) -> jnp.ndarray:
+    lowered_indices = jnp.asarray(_precompute_lowered_indices(basis))
+
+    return _density_matrix_from_gaussian_core(
+        jnp.asarray(A),
+        jnp.asarray(b),
+        jnp.asarray(c),
+        jnp.asarray(basis),
+        lowered_indices,
+    )

--- a/piquasso/_simulators/connectors/connector.py
+++ b/piquasso/_simulators/connectors/connector.py
@@ -123,7 +123,7 @@ class BuiltinConnector(BaseConnector):
 
         return subspace_representations
 
-    def density_matrix_from_representation(self, A, b, c, basis):
+    def density_matrix_from_gaussian(self, A, b, c, basis):
         """Builds the density matrix element by element from the loop hafnian.
 
         Each element is ``c * loop_hafnian(A, b) / sqrt(ket! * bra!)`` reduced on

--- a/piquasso/_simulators/connectors/jax_/connector.py
+++ b/piquasso/_simulators/connectors/jax_/connector.py
@@ -17,7 +17,9 @@ import numpy as np
 
 from functools import partial
 from typing import Any
-from ..connector import BuiltinConnector
+from ..connector import BuiltinConnector, instancemethod
+
+from piquasso._math.jax.hermite import density_matrix_from_gaussian
 
 
 class JaxConnector(BuiltinConnector):
@@ -71,6 +73,8 @@ class JaxConnector(BuiltinConnector):
     # don't work together, when the condition depends on a tracer. Therefore,
     # conditionals must be disabled in this case
     allow_conditionals = False
+
+    density_matrix_from_gaussian = instancemethod(density_matrix_from_gaussian)
 
     def __init__(self):
         try:

--- a/piquasso/_simulators/connectors/numpy_/connector.py
+++ b/piquasso/_simulators/connectors/numpy_/connector.py
@@ -26,7 +26,7 @@ from piquasso._math.hafnian import (
     loop_hafnian_with_reduction,
     loop_hafnian_with_reduction_batch,
 )
-from piquasso._math.hermite import density_matrix_from_a_b_c
+from piquasso._math.hermite import density_matrix_from_gaussian
 
 from ..connector import BuiltinConnector, instancemethod
 
@@ -61,7 +61,7 @@ class NumpyConnector(BuiltinConnector):
     calculate_interferometer_on_fermionic_fock_space = instancemethod(
         calculate_interferometer_on_fermionic_fock_space
     )
-    density_matrix_from_representation = instancemethod(density_matrix_from_a_b_c)
+    density_matrix_from_gaussian = instancemethod(density_matrix_from_gaussian)
 
     def sqrtm(self, matrix):
         return scipy.linalg.sqrtm(matrix).astype(np.complex128)

--- a/piquasso/_simulators/fock/pure/simulator.py
+++ b/piquasso/_simulators/fock/pure/simulator.py
@@ -148,7 +148,7 @@ class PureFockSimulator(BuiltinSimulator):
 
     _default_connector_class = NumpyConnector
 
-    _extra_builtin_connectors = [TensorflowConnector, JaxConnector]
+    _extra_builtin_connectors = [TensorflowConnector, JaxConnector]  # type: ignore
 
     _measurement_classes_allowed_mid_circuit = (
         measurements.ParticleNumberMeasurement,

--- a/piquasso/_simulators/gaussian/probabilities.py
+++ b/piquasso/_simulators/gaussian/probabilities.py
@@ -48,7 +48,7 @@ class DensityMatrixCalculation(abc.ABC):
         )
 
     def get_density_matrix(self, occupation_numbers: np.ndarray) -> np.ndarray:
-        return self.connector.density_matrix_from_representation(
+        return self.connector.density_matrix_from_gaussian(
             self._A, self._b, self._normalization, occupation_numbers
         )
 

--- a/piquasso/api/connector.py
+++ b/piquasso/api/connector.py
@@ -275,7 +275,7 @@ class BaseConnector(abc.ABC):
         """
 
     @abc.abstractmethod
-    def density_matrix_from_representation(self, A, b, c, basis):
+    def density_matrix_from_gaussian(self, A, b, c, basis):
         """Builds a Gaussian density matrix from its :math:`(A, b, c)` triple.
 
         Args:

--- a/tests/_simulators/gaussian/test_density_matrix.py
+++ b/tests/_simulators/gaussian/test_density_matrix.py
@@ -16,9 +16,17 @@
 import pytest
 import numpy as np
 
+from scipy.linalg import block_diag
 from scipy.special import factorial
 
 import piquasso as pq
+
+import jax
+
+
+for_all_connectors = pytest.mark.parametrize(
+    "connector", [pq.NumpyConnector(), pq.JaxConnector()]
+)
 
 
 def _example_program(d, displaced):
@@ -74,7 +82,8 @@ def test_density_matrix_agrees_across_connectors(d, displaced):
     )
 
 
-def test_thermal_density_matrix_matches_analytic():
+@for_all_connectors
+def test_thermal_density_matrix_matches_analytic(connector):
     """The thermal state has the closed-form diagonal density matrix."""
     mean_photon_number = 0.5
     cutoff = 8
@@ -83,7 +92,7 @@ def test_thermal_density_matrix_matches_analytic():
         pq.Q(0) | pq.Thermal([mean_photon_number])
 
     state = (
-        pq.GaussianSimulator(d=1, config=pq.Config(cutoff=cutoff))
+        pq.GaussianSimulator(d=1, config=pq.Config(cutoff=cutoff), connector=connector)
         .execute(program)
         .state
     )
@@ -97,7 +106,8 @@ def test_thermal_density_matrix_matches_analytic():
     assert np.allclose(density_matrix - np.diag(np.diag(density_matrix)), 0.0)
 
 
-def test_squeezed_vacuum_density_matrix_matches_analytic():
+@for_all_connectors
+def test_squeezed_vacuum_density_matrix_matches_analytic(connector):
     """Single-mode squeezed vacuum has only even-photon amplitudes."""
     r = 0.5
     cutoff = 8
@@ -107,7 +117,7 @@ def test_squeezed_vacuum_density_matrix_matches_analytic():
         pq.Q(0) | pq.Squeezing(r=r)
 
     state = (
-        pq.GaussianSimulator(d=1, config=pq.Config(cutoff=cutoff))
+        pq.GaussianSimulator(d=1, config=pq.Config(cutoff=cutoff), connector=connector)
         .execute(program)
         .state
     )
@@ -125,7 +135,8 @@ def test_squeezed_vacuum_density_matrix_matches_analytic():
     assert np.allclose(state.density_matrix, expected)
 
 
-def test_coherent_density_matrix_matches_analytic():
+@for_all_connectors
+def test_coherent_density_matrix_matches_analytic(connector):
     """Coherent state: :math:`\\rho_{mn} = e^{-|\\alpha|^2} \\alpha^m
     \\bar{\\alpha}^n / \\sqrt{m! n!}`."""
     cutoff = 10
@@ -135,7 +146,7 @@ def test_coherent_density_matrix_matches_analytic():
         pq.Q(0) | pq.Displacement(r=0.7, phi=0.4)
 
     state = (
-        pq.GaussianSimulator(d=1, config=pq.Config(cutoff=cutoff))
+        pq.GaussianSimulator(d=1, config=pq.Config(cutoff=cutoff), connector=connector)
         .execute(program)
         .state
     )
@@ -148,30 +159,99 @@ def test_coherent_density_matrix_matches_analytic():
     assert np.allclose(state.density_matrix, expected)
 
 
-def test_density_matrix_is_hermitian():
+@for_all_connectors
+def test_density_matrix_is_hermitian(connector):
     with pq.Program() as program:
         pq.Q(all) | pq.Vacuum()
         pq.Q(0) | pq.Squeezing(r=0.5) | pq.Displacement(r=0.3, phi=0.7)
         pq.Q(1) | pq.Displacement(r=0.2)
         pq.Q(0, 1) | pq.Beamsplitter(theta=0.9, phi=0.4)
 
-    state = pq.GaussianSimulator(d=2, config=pq.Config(cutoff=6)).execute(program).state
+    state = (
+        pq.GaussianSimulator(d=2, config=pq.Config(cutoff=6), connector=connector)
+        .execute(program)
+        .state
+    )
 
     density_matrix = state.density_matrix
 
     assert np.allclose(density_matrix, density_matrix.conj().T)
 
 
-def test_density_matrix_diagonal_matches_fock_probabilities():
+@for_all_connectors
+def test_density_matrix_diagonal_matches_fock_probabilities(connector):
     with pq.Program() as program:
         pq.Q(all) | pq.Vacuum()
         pq.Q(0) | pq.Squeezing(r=0.5)
         pq.Q(1) | pq.Squeezing(r=0.3, phi=0.8)
         pq.Q(0, 1) | pq.Beamsplitter(theta=0.6, phi=0.2)
 
-    state = pq.GaussianSimulator(d=2, config=pq.Config(cutoff=6)).execute(program).state
+    state = (
+        pq.GaussianSimulator(d=2, config=pq.Config(cutoff=6), connector=connector)
+        .execute(program)
+        .state
+    )
 
     assert np.allclose(
         np.diag(state.density_matrix).real,
         state.fock_probabilities,
     )
+
+
+@for_all_connectors
+def test_density_matrix_Thermal_Interferometer(generate_unitary_matrix, connector):
+    d = 3
+
+    preparation = pq.Program([pq.Thermal([0.1, 0.2, 0.3])])
+
+    U = generate_unitary_matrix(d)
+
+    with pq.Program() as program:
+        pq.Q() | preparation
+        pq.Q() | pq.Interferometer(U)
+
+    simulator = pq.GaussianSimulator(
+        d=d, config=pq.Config(cutoff=2), connector=connector
+    )
+
+    initial_state = simulator.execute(preparation).state
+    final_state = simulator.execute(program).state
+
+    fock_space_unitary = block_diag(np.array([1.0]), U)
+
+    assert np.allclose(
+        final_state.density_matrix,
+        fock_space_unitary @ initial_state.density_matrix @ fock_space_unitary.conj().T,
+    )
+
+
+def test_density_matrix_differentiability():
+    connector = pq.JaxConnector()
+
+    def func(r):
+        with pq.Program() as program:
+            pq.Q() | pq.Vacuum()
+            pq.Q(0) | pq.Squeezing(r=r, phi=np.pi / 3)
+
+        simulator = pq.GaussianSimulator(
+            d=1, config=pq.Config(cutoff=3), connector=connector
+        )
+
+        state = simulator.execute(program).state
+
+        return state.density_matrix[2, 2].real
+
+    grad_func = jax.grad(func)
+
+    r = 0.1
+
+    expected_value = np.tanh(r) ** 2 / (2 * np.cosh(r))
+    expected_derivative = np.tanh(r) / np.cosh(r) ** 3 - np.tanh(r) ** 3 / (
+        2 * np.cosh(r)
+    )
+
+    actual_value = func(r)
+    actual_derivative = grad_func(r)
+
+    assert np.isclose(actual_value, expected_value)
+    assert np.isclose(actual_derivative, expected_derivative)

--- a/tests/_simulators/gaussian/test_state.py
+++ b/tests/_simulators/gaussian/test_state.py
@@ -18,7 +18,7 @@ import numpy as np
 
 import jax
 
-from scipy.linalg import polar, coshm, sinhm, block_diag
+from scipy.linalg import polar, coshm, sinhm
 from scipy.special import factorial2
 
 import piquasso as pq
@@ -1034,30 +1034,6 @@ def test_GaussianState_purify_on_3_modes():
     assert purification.is_pure()
     assert purification.d == 2 * mixed_state.d
     assert purification.reduced(modes=(0, 1, 2)) == mixed_state
-
-
-def test_density_matrix_Thermal_Interferometer(generate_unitary_matrix):
-    d = 3
-
-    preparation = pq.Program([pq.Thermal([0.1, 0.2, 0.3])])
-
-    U = generate_unitary_matrix(d)
-
-    with pq.Program() as program:
-        pq.Q() | preparation
-        pq.Q() | pq.Interferometer(U)
-
-    simulator = pq.GaussianSimulator(d=d, config=pq.Config(cutoff=2))
-
-    initial_state = simulator.execute(preparation).state
-    final_state = simulator.execute(program).state
-
-    fock_space_unitary = block_diag(np.array([1.0]), U)
-
-    assert np.allclose(
-        final_state.density_matrix,
-        fock_space_unitary @ initial_state.density_matrix @ fock_space_unitary.conj().T,
-    )
 
 
 def test_get_purity_Thermal_Interferometer(generate_unitary_matrix):


### PR DESCRIPTION
A JAX-compatible implementation of the multidimensional Hermite recurrence for constructing Gaussian density matrices in the Fock basis. The implementation is really just a direct translation of `piquasso/_math/hermite.py`.

The implementation precomputes lowered Fock-space indices and evaluates the recurrence using JAX primitives, making density matrix generation differentiable with respect to Gaussian parameters.

The functions/methods named `density_matrix_from_a_b_c` and `density_matrix_from_representation˙ got renamed to `density_matrix_from_gaussian` for clarity, and the density matrix-related tests got collected to `test_density_matrix.py`.