### PR TITLE
feat(sampling): Marginal probabilities

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -13,5 +13,6 @@ ignore:
   - piquasso/_simulators/connectors/_utils.py
   - piquasso/_simulators/connectors/numpy_/interferometer.py
   - piquasso/_simulators/connectors/numpy_/connections.py
+  - piquasso/_simulators/sampling/marginal.py
   - piquasso/fermionic/_utils.py
   - piquasso/fermionic/fock/_utils.py

--- a/piquasso/_simulators/sampling/marginal.py
+++ b/piquasso/_simulators/sampling/marginal.py
@@ -1,0 +1,341 @@
+#
+# Copyright 2021-2026 Budapest Quantum Computing Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+r"""Exact marginal probabilities for ideal Fock-state Boson Sampling.
+
+This module computes marginal output probabilities for a selected subset of
+modes, optionally together with a fixed postselection pattern. The implemented
+method is based on the low-rank marginal generating function.
+
+Let ``T`` denote the union of the postselected modes and the marginal modes,
+and let ``k = len(T)``. For each occupied input mode ``a`` with occupation
+``r_a``, define
+
+    V[a, j] = conjugate(U[T[j], a])
+
+and
+
+    f_a(z) = sum_j V[a, j] z_j.
+
+The central polynomial is
+
+    P(z, w) =
+        prod_a L_{r_a}(-f_a(z) conjugate(f_a(w))),
+
+where ``L_r`` is the Laguerre polynomial. If
+
+    P(z, w) = sum_{alpha, beta} P_{alpha, beta} z^alpha w^beta,
+
+then the scaled diagonal coefficients
+
+    b_alpha = alpha! P_{alpha, alpha}
+
+are the coefficients of the low-rank permanent polynomial
+
+    G(c) =
+        1 / r! * Per((I + V diag(c) V^dagger)_{r,r}).
+
+The probability of observing a pattern ``y`` on the selected modes is obtained
+from the binomial transform
+
+    Pr(Y = y) =
+        sum_{alpha >= y, |alpha| <= n}
+            b_alpha
+            prod_j binom(alpha_j, y_j) (-1)^(alpha_j - y_j).
+
+The implementation computes the coefficients ``b_alpha`` by multiplying the
+Laguerre factors in a bihomogeneous block representation. Since every factor
+has equal total degree in the ``z`` variables and in the ``w`` variables, all
+intermediate products satisfy
+
+    P_{alpha, beta} = 0 whenever |alpha| != |beta|.
+
+Thus the coefficient table decomposes into blocks
+
+    P_d = (P_{alpha, beta})_{|alpha| = |beta| = d},
+
+which avoids storing the full rectangular coefficient array.
+
+If postselected modes are supplied, the returned values are joint probabilities
+with the postselection event. Conditional postselected probabilities can be
+obtained by normalizing the returned values by their sum.
+
+For ``k`` selected modes and ``n`` photons, the block storage size is
+
+    sum_{d=0}^n binom(d + k - 1, k - 1)^2.
+
+For collision-free input and fixed ``k``, the sequential dynamic program has
+time scaling O(n^(2k)) and memory scaling O(n^(2k-1)).
+
+NOTE: This implementation might be improved by a sparse polynomial multiplication
+algorithm, which could perhaps reduce the time and memory requirements of this method;
+see https://arxiv.org/abs/0901.4323.
+"""
+
+from typing import Dict, Tuple, Sequence
+
+import numpy as np
+import numba as nb
+
+from scipy.special import factorial
+
+from piquasso._math.combinatorics import comb
+from piquasso._math.fock import get_fock_space_basis, cutoff_fock_space_dim_array
+from piquasso._math.indices import get_index_in_fock_subspace
+
+
+def get_marginal_probabilities(
+    input_photons: np.ndarray,
+    interferometer: np.ndarray,
+    postselected_modes: Tuple[int, ...],
+    postselected_photons: Tuple[int, ...],
+    marginal_modes: Tuple[int, ...],
+) -> Dict[Tuple[int, ...], float]:
+    r"""Calculates the marginal probabilities in a Boson Sampling experiment.
+
+    Args:
+        input_photons: The input photon numbers in each mode.
+        interferometer: The unitary matrix describing the interferometer.
+        postselected_modes: The modes on which a postselection is already performed.
+        postselected_photons: The photon numbers corresponding to the postselection.
+        marginal_modes: The modes for which the marginal probabilities are calculated.
+
+    Returns:
+        Dict[Tuple[int, ...], float]: The marginal probabilities of the state.
+    """
+    all_modes = np.asarray(postselected_modes + marginal_modes, dtype=np.int64)
+    k_total = len(all_modes)
+    k_marginal = len(marginal_modes)
+
+    n = np.sum(input_photons)
+    n_post = np.sum(postselected_photons)
+
+    compositions = get_fock_space_basis(k_total, n + 1)
+
+    diagonal_coefficients = _get_diagonal_coefficients(
+        input_photons=input_photons,
+        interferometer=interferometer,
+        all_modes=all_modes,
+        compositions=compositions,
+    )
+
+    outcomes = get_fock_space_basis(k_marginal, n - n_post + 1)
+
+    num_postselected_modes = len(postselected_modes)
+
+    outcomes_with_postselection = np.zeros((len(outcomes), k_total), dtype=np.int64)
+    if num_postselected_modes:
+        outcomes_with_postselection[:, :num_postselected_modes] = np.asarray(
+            postselected_photons, dtype=np.int64
+        )
+    outcomes_with_postselection[:, num_postselected_modes:] = outcomes
+    probabilities = _probabilities_from_diagonal_coefficients(
+        diagonal_coefficients, compositions, outcomes_with_postselection
+    )
+
+    probabilities /= np.sum(probabilities)
+
+    ret = {tuple(outcome): probabilities[i].real for i, outcome in enumerate(outcomes)}
+
+    return ret
+
+
+def _get_diagonal_coefficients(
+    input_photons: np.ndarray,
+    interferometer: np.ndarray,
+    all_modes: np.ndarray,
+    compositions: np.ndarray,
+) -> np.ndarray:
+    n = np.sum(input_photons)
+    k = len(all_modes)
+
+    occupied_input_modes = np.nonzero(input_photons)[0]
+    occupations = input_photons[occupied_input_modes]
+
+    V = interferometer[np.ix_(all_modes, occupied_input_modes)].T.conj()
+
+    indices = cutoff_fock_space_dim_array(np.arange(n + 2), k)
+
+    bihomogeneous_blocks = nb.typed.List(
+        [
+            np.zeros((indices[i + 1] - indices[i],) * 2, dtype=interferometer.dtype)
+            for i in range(n + 1)
+        ]
+    )
+    bihomogeneous_blocks[0][0, 0] = 1.0
+
+    factorials = factorial(np.arange(n + 1))
+
+    processed_degree = 0
+
+    for a, occupation in enumerate(occupations):
+        new_blocks = nb.typed.List(
+            [np.zeros_like(bihomogeneous_blocks[i]) for i in range(n + 1)]
+        )
+
+        coeffs = _linear_form_power_coefficients(
+            row=V[a],
+            compositions=compositions[: indices[occupation + 1]],
+            factorials=factorials,
+        )
+
+        for i in range(processed_degree + 1):
+            source_block = bihomogeneous_blocks[i]
+            source_comps = compositions[indices[i] : indices[i + 1]]
+
+            for j in range(occupation + 1):
+                add_comps = compositions[indices[j] : indices[j + 1]]
+                add_block = coeffs[indices[j] : indices[j + 1]]
+
+                _add_bihomogeneous_product_term(
+                    source_block,
+                    add_block,
+                    source_comps,
+                    add_comps,
+                    weight=comb(occupation, j) / factorials[j],
+                    out_block=new_blocks[i + j],
+                )
+
+        bihomogeneous_blocks = new_blocks
+        processed_degree = processed_degree + occupation
+
+    return _extract_diagonal_coefficients_from_bihomogeneous_blocks(
+        bihomogeneous_blocks, compositions, indices, factorials
+    )
+
+
+@nb.njit(cache=True)
+def _extract_diagonal_coefficients_from_bihomogeneous_blocks(
+    bihomogeneous_blocks: Sequence[np.ndarray],
+    compositions: np.ndarray,
+    indices: np.ndarray,
+    factorials: np.ndarray,
+) -> np.ndarray:
+    n = len(factorials) - 1
+
+    diagonal_coefficients = np.zeros(len(compositions), dtype=np.float64)
+
+    offsets = np.zeros(n + 2, dtype=np.int64)
+    for i in range(n + 1):
+        offsets[i + 1] = offsets[i] + len(compositions[indices[i] : indices[i + 1]])
+
+    for i in range(n + 1):
+        block = bihomogeneous_blocks[i]
+        diag = np.diag(block)
+        comps_i = compositions[indices[i] : indices[i + 1]]
+        start = offsets[i]
+
+        for j in range(len(comps_i)):
+            alpha_fact = 1.0
+            for value in comps_i[j]:
+                alpha_fact *= factorials[int(value)]
+            diagonal_coefficients[start + j] = (alpha_fact * diag[j]).real
+
+    return diagonal_coefficients
+
+
+@nb.njit(cache=True)
+def _linear_form_power_coefficients(row, compositions, factorials):
+    coeffs = np.zeros(len(compositions), dtype=np.complex128)
+
+    for i, gamma in enumerate(compositions):
+        degree = 0
+        for x in gamma:
+            degree += int(x)
+
+        multinomial = factorials[degree]
+        monomial = 1.0 + 0.0j
+
+        for j, exponent in enumerate(gamma):
+            exponent = int(exponent)
+            multinomial /= factorials[exponent]
+            if exponent != 0:
+                monomial *= row[j] ** exponent
+
+        coeffs[i] = multinomial * monomial
+
+    return coeffs
+
+
+@nb.njit(cache=True)
+def _add_bihomogeneous_product_term(
+    source_block: np.ndarray,
+    add_block: np.ndarray,
+    source_comps: np.ndarray,
+    add_comps: np.ndarray,
+    weight: float,
+    out_block: np.ndarray,
+) -> None:
+    source_size = source_block.shape[0]
+    add_size = add_block.shape[0]
+
+    for i in range(source_size):
+        for j in range(source_size):
+            base = source_block[i, j]
+            if base == 0.0:
+                continue
+
+            for gz in range(add_size):
+                row = get_index_in_fock_subspace(source_comps[i] + add_comps[gz])
+                cz = add_block[gz]
+
+                for gw in range(add_size):
+                    col = get_index_in_fock_subspace(source_comps[j] + add_comps[gw])
+                    cw = np.conjugate(add_block[gw])
+
+                    out_block[row, col] += weight * base * cz * cw
+
+
+@nb.njit(cache=True)
+def _probabilities_from_diagonal_coefficients(
+    diagonals: np.ndarray,
+    compositions: np.ndarray,
+    outcomes: np.ndarray,
+) -> np.ndarray:
+    num_outcomes = outcomes.shape[0]
+    num_alpha = compositions.shape[0]
+    k = compositions.shape[1]
+
+    probs = np.zeros(num_outcomes, dtype=np.complex128)
+
+    for y_index in range(num_outcomes):
+        total = 0.0 + 0.0j
+
+        for a_index in range(num_alpha):
+            alpha = compositions[a_index]
+
+            ok = True
+            sign_power = 0
+            factor = 1.0
+
+            for j in range(k):
+                aj = int(alpha[j])
+                yj = int(outcomes[y_index, j])
+
+                if aj < yj:
+                    ok = False
+                    break
+
+                sign_power += aj - yj
+                factor *= comb(aj, yj)
+
+            if ok:
+                if sign_power % 2 == 1:
+                    factor = -factor
+                total += diagonals[a_index] * factor
+
+        probs[y_index] = total
+
+    return probs

--- a/piquasso/_simulators/sampling/state.py
+++ b/piquasso/_simulators/sampling/state.py
@@ -31,6 +31,7 @@ from piquasso.api.exceptions import (
 from piquasso.api.connector import BaseConnector
 
 from .utils import calculate_state_vector, calculate_inner_product
+from .marginal import get_marginal_probabilities
 
 if TYPE_CHECKING:
     import piquasso
@@ -443,6 +444,42 @@ class SamplingState(State):
 
         raise NotImplementedCalculation(
             "Purity calculation is not implemented for lossy states."
+        )
+
+    def get_marginal_probabilities(
+        self, modes: Tuple[int, ...]
+    ) -> Dict[Tuple[int, ...], float]:
+        """Returns the marginal probabilities of the state.
+
+        Returns:
+            Dict[Tuple[int, ...], float]: The marginal probabilities of the state.
+        """
+
+        if self.is_lossy:
+            raise NotImplementedCalculation(
+                "Marginal probability calculation is not implemented for lossy states."
+            )
+
+        if len(self._occupation_numbers) > 1:
+            raise NotImplementedCalculation(
+                "Marginal probability calculation is not implemented for states with "
+                "multiple input occupation numbers."
+            )
+
+        postselected_modes = self._get_postselected_modes()
+        postselected_photons = self._get_postselected_photons()
+
+        if set(modes).intersection(set(postselected_modes)):
+            raise PiquassoException(
+                "Marginal probabilities cannot be calculated for postselected modes."
+            )
+
+        return get_marginal_probabilities(
+            self._occupation_numbers[0],
+            self.interferometer,
+            postselected_modes,
+            postselected_photons,
+            marginal_modes=tuple(modes),
         )
 
     def __eq__(self, other: object) -> bool:

--- a/tests/_simulators/sampling/test_state.py
+++ b/tests/_simulators/sampling/test_state.py
@@ -63,3 +63,309 @@ def test_validate_not_normalized():
         pq.api.exceptions.InvalidState, match="The state is not normalized."
     ):
         result.state.validate()
+
+
+class TestMarginalProbabilities:
+    def test_marginal_probabilities_simple(self):
+        input_state = np.array([1, 1], dtype=int)
+
+        unitary = np.array([[1, 0], [0, 1]], dtype=complex)
+
+        program = pq.Program(
+            instructions=[
+                pq.NumberState(input_state),
+                pq.Interferometer(unitary),
+            ]
+        )
+
+        simulator = pq.SamplingSimulator(d=len(unitary), config=pq.Config(cutoff=3))
+
+        result = simulator.execute(program)
+
+        state = result.state
+
+        modes = [0]
+
+        probabilities = state.get_marginal_probabilities(modes)
+
+        expected = {(0,): 0.0, (1,): 1.0, (2,): 0.0}
+        assert set(probabilities) == set(expected)
+
+        for outcome, expected_value in expected.items():
+            assert np.isclose(probabilities[outcome], expected_value)
+
+    def test_marginal_probabilities_simple_beamsplitter(self):
+        input_state = np.array([1, 1], dtype=int)
+
+        theta = np.pi / 5
+
+        program = pq.Program(
+            instructions=[
+                pq.NumberState(input_state),
+                pq.Beamsplitter(theta=theta).on_modes(0, 1),
+            ]
+        )
+
+        simulator = pq.SamplingSimulator(d=2, config=pq.Config(cutoff=3))
+
+        result = simulator.execute(program)
+
+        state = result.state
+
+        modes = [0]
+
+        probabilities = state.get_marginal_probabilities(modes)
+
+        expected_probabilities = {
+            (0,): np.sin(2 * theta) ** 2 / 2,
+            (1,): np.cos(2 * theta) ** 2,
+            (2,): np.sin(2 * theta) ** 2 / 2,
+        }
+
+        for outcome, expected in expected_probabilities.items():
+            assert np.isclose(probabilities[outcome], expected)
+
+    def test_marginal_probabilities_3_modes(self):
+        input_state = np.array([1, 1, 0], dtype=int)
+
+        alpha = np.pi / 5
+        beta = np.pi / 4
+
+        program = pq.Program(
+            instructions=[
+                pq.NumberState(input_state),
+                pq.Beamsplitter(theta=alpha).on_modes(0, 1),
+                pq.Beamsplitter(theta=beta).on_modes(1, 2),
+            ]
+        )
+
+        simulator = pq.SamplingSimulator(d=3, config=pq.Config(cutoff=3))
+
+        result = simulator.execute(program)
+
+        state = result.state
+
+        modes = [1]
+
+        probabilities = state.get_marginal_probabilities(modes)
+
+        sin_2alpha_sq = np.sin(2 * alpha) ** 2
+        cos_2alpha_sq = np.cos(2 * alpha) ** 2
+
+        sin_beta_sq = np.sin(beta) ** 2
+        cos_beta_sq = np.cos(beta) ** 2
+
+        p0 = (
+            0.5 * sin_2alpha_sq
+            + sin_beta_sq * cos_2alpha_sq
+            + 0.5 * sin_2alpha_sq * sin_beta_sq**2
+        )
+
+        p1 = cos_beta_sq * cos_2alpha_sq + sin_2alpha_sq * cos_beta_sq * sin_beta_sq
+
+        p2 = 0.5 * sin_2alpha_sq * cos_beta_sq**2
+
+        for outcome, expected in {(0,): p0, (1,): p1, (2,): p2}.items():
+            assert np.isclose(probabilities[outcome], expected)
+
+    def test_marginal_probabilities_4_modes_selected_2_modes(self):
+        input_state = np.array([1, 1, 0, 0], dtype=int)
+
+        alpha = np.pi / 5
+        beta = np.pi / 4
+        gamma = np.pi / 7
+
+        program = pq.Program(
+            instructions=[
+                pq.NumberState(input_state),
+                pq.Beamsplitter(theta=alpha).on_modes(0, 1),
+                pq.Beamsplitter(theta=beta).on_modes(1, 2),
+                pq.Beamsplitter(theta=gamma).on_modes(2, 3),
+            ]
+        )
+
+        simulator = pq.SamplingSimulator(d=4, config=pq.Config(cutoff=3))
+
+        result = simulator.execute(program)
+
+        state = result.state
+
+        modes = [1, 3]
+
+        probabilities = state.get_marginal_probabilities(modes)
+
+        S = np.sin(2 * alpha) ** 2
+        C = np.cos(2 * alpha) ** 2
+
+        sin_beta_sq = np.sin(beta) ** 2
+        cos_beta_sq = np.cos(beta) ** 2
+
+        sin_gamma_sq = np.sin(gamma) ** 2
+        cos_gamma_sq = np.cos(gamma) ** 2
+
+        expected = np.zeros((3, 3))
+
+        expected[0, 0] = (
+            0.5 * S
+            + sin_beta_sq * cos_gamma_sq * C
+            + 0.5 * S * sin_beta_sq**2 * cos_gamma_sq**2
+        )
+
+        expected[0, 1] = (
+            sin_beta_sq * sin_gamma_sq * C
+            + S * sin_beta_sq**2 * cos_gamma_sq * sin_gamma_sq
+        )
+
+        expected[0, 2] = 0.5 * S * sin_beta_sq**2 * sin_gamma_sq**2
+
+        expected[1, 0] = cos_beta_sq * C + S * cos_beta_sq * sin_beta_sq * cos_gamma_sq
+
+        expected[1, 1] = S * cos_beta_sq * sin_beta_sq * sin_gamma_sq
+
+        expected[2, 0] = 0.5 * S * cos_beta_sq**2
+
+        for outcome, probability in probabilities.items():
+            assert np.isclose(probability, expected[outcome])
+
+    def test_marginal_probabilities_4_modes_postselected(self):
+        input_state = np.array([1, 1, 0, 0], dtype=int)
+
+        alpha = np.pi / 5
+        beta = np.pi / 4
+        gamma = np.pi / 7
+
+        program = pq.Program(
+            instructions=[
+                pq.NumberState(input_state),
+                pq.Beamsplitter(theta=alpha).on_modes(0, 1),
+                pq.Beamsplitter(theta=beta).on_modes(1, 2),
+                pq.Beamsplitter(theta=gamma).on_modes(2, 3),
+                pq.PostSelectPhotons(photon_counts=[1]).on_modes(0),
+            ]
+        )
+
+        simulator = pq.SamplingSimulator(d=4, config=pq.Config(cutoff=3))
+
+        result = simulator.execute(program)
+
+        state = result.state
+
+        modes = [1]
+
+        probabilities = state.get_marginal_probabilities(modes)
+
+        expected = {
+            (0,): np.sin(beta) ** 2,
+            (1,): np.cos(beta) ** 2,
+        }
+
+        for outcome, probability in probabilities.items():
+            assert np.isclose(probability, expected[outcome])
+
+    @pytest.mark.monkey
+    def test_marginal_probabilities_sum_to_1_for_random(self, generate_unitary_matrix):
+        input_state = np.array([2, 1, 3, 1, 1], dtype=int)
+
+        unitary = generate_unitary_matrix(5)
+
+        program = pq.Program(
+            instructions=[
+                pq.NumberState(input_state),
+                pq.Interferometer(unitary),
+            ]
+        )
+
+        simulator = pq.SamplingSimulator(d=len(unitary), config=pq.Config(cutoff=9))
+
+        result = simulator.execute(program)
+
+        state = result.state
+
+        modes = [0, 1, 2]
+
+        probabilities = state.get_marginal_probabilities(modes)
+
+        assert np.isclose(np.sum(list(probabilities.values())), 1.0)
+
+    def test_lossy_state_marginal_probabilities_raises_NotImplementedCalculation(self):
+        input_state = np.array([1, 1], dtype=int)
+
+        program = pq.Program(
+            instructions=[
+                pq.NumberState(input_state),
+                pq.UniformLoss(transmissivity=0.5).on_modes(0, 1),
+            ]
+        )
+
+        simulator = pq.SamplingSimulator(d=2, config=pq.Config(cutoff=3))
+
+        result = simulator.execute(program)
+
+        state = result.state
+
+        modes = [0]
+
+        with pytest.raises(
+            pq.api.exceptions.NotImplementedCalculation,
+            match=(
+                "Marginal probability calculation is not implemented for lossy states."
+            ),
+        ):
+            _ = state.get_marginal_probabilities(modes)
+
+    def test_multiple_occupation_numbers_raises_NotImplementedCalculation(self):
+        unitary = np.array([[1, 0], [0, 1]], dtype=complex)
+
+        program = pq.Program(
+            instructions=[
+                (
+                    pq.NumberState([0, 2]) * np.sqrt(0.5)
+                    + pq.NumberState([2, 0]) * np.sqrt(0.5)
+                ),
+                pq.Interferometer(unitary),
+            ]
+        )
+
+        simulator = pq.SamplingSimulator(d=len(unitary), config=pq.Config(cutoff=3))
+
+        result = simulator.execute(program)
+
+        state = result.state
+
+        modes = [0]
+
+        with pytest.raises(
+            pq.api.exceptions.NotImplementedCalculation,
+            match=(
+                "Marginal probability calculation is not implemented for states with "
+                "multiple input occupation numbers."
+            ),
+        ):
+            _ = state.get_marginal_probabilities(modes)
+
+    def test_postselecting_on_same_mode_raises_PiquassoException(self):
+        input_state = np.array([1, 1, 0], dtype=int)
+
+        program = pq.Program(
+            instructions=[
+                pq.NumberState(input_state),
+                pq.Beamsplitter5050().on_modes(0, 1),
+                pq.PostSelectPhotons(photon_counts=[1]).on_modes(0),
+            ]
+        )
+
+        simulator = pq.SamplingSimulator(d=3, config=pq.Config(cutoff=3))
+
+        result = simulator.execute(program)
+
+        state = result.state
+
+        modes = [0]
+
+        with pytest.raises(
+            pq.api.exceptions.PiquassoException,
+            match=(
+                "Marginal probabilities cannot be calculated for postselected modes."
+            ),
+        ):
+            _ = state.get_marginal_probabilities(modes)


### PR DESCRIPTION
An algorithm for computing the marginal particle detection probabilities is added. This is required for sampling from the marginal distribution in Boson Sampling, see
https://github.com/Budapest-Quantum-Computing-Group/piquasso/issues/499.