### PR TITLE
fix(sampling): return unnormalized marginal probabilities

### DIFF
--- a/piquasso/_simulators/sampling/marginal.py
+++ b/piquasso/_simulators/sampling/marginal.py
@@ -145,8 +145,6 @@ def get_marginal_probabilities(
         diagonal_coefficients, compositions, outcomes_with_postselection
     )
 
-    probabilities /= np.sum(probabilities)
-
     ret = {tuple(outcome): probabilities[i].real for i, outcome in enumerate(outcomes)}
 
     return ret

--- a/piquasso/_simulators/sampling/state.py
+++ b/piquasso/_simulators/sampling/state.py
@@ -451,6 +451,12 @@ class SamplingState(State):
     ) -> Dict[Tuple[int, ...], float]:
         """Returns the marginal probabilities of the state.
 
+        .. note::
+
+            If the state is postselected, the marginal probabilities are not normalized,
+            and the sum of the marginal probabilities is equal to the probability of the
+            postselection.
+
         Returns:
             Dict[Tuple[int, ...], float]: The marginal probabilities of the state.
         """

--- a/tests/_simulators/sampling/test_state.py
+++ b/tests/_simulators/sampling/test_state.py
@@ -254,9 +254,11 @@ class TestMarginalProbabilities:
 
         probabilities = state.get_marginal_probabilities(modes)
 
+        postselection_probability = np.cos(2 * alpha) ** 2
+
         expected = {
-            (0,): np.sin(beta) ** 2,
-            (1,): np.cos(beta) ** 2,
+            (0,): postselection_probability * np.sin(beta) ** 2,
+            (1,): postselection_probability * np.cos(beta) ** 2,
         }
 
         for outcome, probability in probabilities.items():


### PR DESCRIPTION
Keep postselected marginal probabilities consistent with `get_particle_detection_probability` by returning joint probabilities that include the postselection event.

Previously, `get_marginal_probabilities` normalized over the requested marginal outcomes, effectively returning conditional probabilities after postselection.  This made its behavior inconsistent with other probability queries on postselected states.

Now the returned probabilities sum to the postselection probability instead of one.