### PR TITLE
fix(sampling): Losses in `get_particle_detection_probability`

### DIFF
--- a/piquasso/_simulators/sampling/probabilities.py
+++ b/piquasso/_simulators/sampling/probabilities.py
@@ -1,0 +1,179 @@
+#
+# Copyright 2021-2026 Budapest Quantum Computing Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .utils import calculate_inner_product, calculate_lossy_density_matrix_element
+
+
+def get_ideal_particle_number_probability(
+    occupation_number,
+    postselections,
+    interferometer,
+    occupation_numbers,
+    coefficients,
+    connector,
+):
+    np = connector.np
+    fallback_np = connector.fallback_np
+
+    output_number_of_particles = fallback_np.sum(occupation_number) + sum(
+        postselections.values()
+    )
+
+    sum_ = 0.0
+
+    total_number_of_modes = len(interferometer)
+
+    postselected_modes = tuple(postselections.keys())
+    active_modes = tuple(
+        [i for i in range(total_number_of_modes) if i not in postselected_modes]
+    )
+    postselected_photons = tuple(postselections.values())
+
+    full_occupation_number = fallback_np.zeros(total_number_of_modes, dtype=int)
+
+    full_occupation_number[active_modes,] = occupation_number
+    full_occupation_number[postselected_modes,] = postselected_photons
+
+    for index, input_occupation_number in enumerate(occupation_numbers):
+        if output_number_of_particles != fallback_np.sum(input_occupation_number):
+            continue
+
+        inner_product = calculate_inner_product(
+            interferometer=interferometer,
+            input=input_occupation_number,
+            output=full_occupation_number,
+            connector=connector,
+        )
+        coefficient = coefficients[index]
+
+        sum_ += coefficient * inner_product
+
+    return np.abs(sum_) ** 2
+
+
+def get_lossy_particle_number_probability(
+    occupation_number,
+    postselections,
+    transmission_matrix,
+    occupation_numbers,
+    coefficients,
+    connector,
+):
+    np = connector.np
+    fallback_np = connector.fallback_np
+
+    total_number_of_modes = len(transmission_matrix)
+
+    postselected_modes = tuple(postselections.keys())
+    active_modes = tuple(
+        mode for mode in range(total_number_of_modes) if mode not in postselected_modes
+    )
+    postselected_photons = tuple(postselections.values())
+
+    full_occupation_number = fallback_np.zeros(
+        total_number_of_modes,
+        dtype=int,
+    )
+
+    full_occupation_number[active_modes,] = occupation_number
+    full_occupation_number[postselected_modes,] = postselected_photons
+
+    output_number_of_particles = int(fallback_np.sum(full_occupation_number))
+
+    loss_channel_matrix = _build_loss_channel_matrix(
+        transmission_matrix=transmission_matrix,
+        connector=connector,
+    )
+
+    probability = 0.0 + 0.0j
+
+    for left_index, input_left in enumerate(occupation_numbers):
+        input_left_number = int(fallback_np.sum(input_left))
+
+        if input_left_number < output_number_of_particles:
+            continue
+
+        left_coefficient = coefficients[left_index]
+
+        for right_index, input_right in enumerate(occupation_numbers):
+            input_right_number = int(fallback_np.sum(input_right))
+
+            if input_right_number < output_number_of_particles:
+                continue
+
+            # For a diagonal output probability, the number of lost photons
+            # must be the same on ket and bra sides.
+            if input_left_number != input_right_number:
+                continue
+
+            right_coefficient = coefficients[right_index]
+
+            matrix_element = calculate_lossy_density_matrix_element(
+                input_left=input_left,
+                input_right=input_right,
+                output_left=full_occupation_number,
+                output_right=full_occupation_number,
+                loss_channel_matrix=loss_channel_matrix,
+                connector=connector,
+            )
+
+            probability += (
+                left_coefficient * np.conj(right_coefficient) * matrix_element
+            )
+
+    return np.real_if_close(probability)
+
+
+def _build_loss_channel_matrix(transmission_matrix, connector):
+    """Build A_Phi for a lossy Fock-state channel."""
+    fallback_np = connector.fallback_np
+
+    T = fallback_np.asarray(transmission_matrix, dtype=complex)
+
+    d = T.shape[0]
+
+    zero = fallback_np.zeros((d, d), dtype=complex)
+    identity = fallback_np.identity(d, dtype=complex)
+
+    T_dagger = T.conj().T
+
+    return fallback_np.block(
+        [
+            [
+                zero,
+                T_dagger,
+                identity - T_dagger @ T,
+                zero,
+            ],
+            [
+                T.conj(),
+                zero,
+                zero,
+                zero,
+            ],
+            [
+                identity - T.T @ T.conj(),
+                zero,
+                zero,
+                T.T,
+            ],
+            [
+                zero,
+                zero,
+                T,
+                zero,
+            ],
+        ]
+    )

--- a/piquasso/_simulators/sampling/state.py
+++ b/piquasso/_simulators/sampling/state.py
@@ -21,6 +21,10 @@ import numpy as np
 from piquasso._math.fock import cutoff_fock_space_dim, get_fock_space_basis
 from piquasso._math.linalg import is_unitary
 
+from piquasso._simulators.sampling.probabilities import (
+    get_ideal_particle_number_probability,
+    get_lossy_particle_number_probability,
+)
 from piquasso.api.config import Config
 from piquasso.api.state import State
 from piquasso.api.exceptions import (
@@ -30,7 +34,7 @@ from piquasso.api.exceptions import (
 )
 from piquasso.api.connector import BaseConnector
 
-from .utils import calculate_state_vector, calculate_inner_product
+from .utils import calculate_state_vector
 from .marginal import get_marginal_probabilities
 
 if TYPE_CHECKING:
@@ -116,7 +120,11 @@ class SamplingState(State):
         self._coefficients: List = []
 
         self.interferometer = np.diag(np.ones(d, dtype=self._config.complex_dtype))
-        """The interferometer matrix corresponding to the circuit."""
+        """
+        The interferometer matrix corresponding to the circuit. When the state is
+        lossy, this matrix represents the transmission matrix of the lossy
+        interferometer.
+        """
 
         self.is_lossy = False
         """Returns `True` if the state is lossy, otherwise `False`."""
@@ -224,41 +232,24 @@ class SamplingState(State):
                 f"postselected."
             )
 
-        np = self._connector.np
-        fallback_np = self._connector.fallback_np
-
-        output_number_of_particles = fallback_np.sum(occupation_number) + sum(
-            self._postselections.values()
-        )
-
-        sum_ = 0.0
-
-        postselected_modes = self._get_postselected_modes()
-        active_modes = self._get_active_modes()
-        postselected_photons = self._get_postselected_photons()
-
-        for index, input_occupation_number in enumerate(self._occupation_numbers):
-            if output_number_of_particles != fallback_np.sum(input_occupation_number):
-                continue
-
-            full_occupation_number = fallback_np.zeros(
-                self.total_number_of_modes, dtype=int
-            )
-
-            full_occupation_number[active_modes,] = occupation_number
-            full_occupation_number[postselected_modes,] = postselected_photons
-
-            inner_product = calculate_inner_product(
-                interferometer=self.interferometer,
-                input=input_occupation_number,
-                output=full_occupation_number,
+        if self.is_lossy:
+            return get_lossy_particle_number_probability(
+                occupation_number=occupation_number,
+                postselections=self._postselections,
+                transmission_matrix=self.interferometer,
+                occupation_numbers=self._occupation_numbers,
+                coefficients=self._coefficients,
                 connector=self._connector,
             )
-            coefficient = self._coefficients[index]
 
-            sum_ += coefficient * inner_product
-
-        return np.abs(sum_) ** 2
+        return get_ideal_particle_number_probability(
+            occupation_number=occupation_number,
+            postselections=self._postselections,
+            interferometer=self.interferometer,
+            occupation_numbers=self._occupation_numbers,
+            coefficients=self._coefficients,
+            connector=self._connector,
+        )
 
     @property
     def state_vector(self):

--- a/piquasso/_simulators/sampling/utils.py
+++ b/piquasso/_simulators/sampling/utils.py
@@ -143,6 +143,64 @@ def calculate_inner_product(interferometer, input, output, connector):
     )
 
 
+def calculate_lossy_density_matrix_element(
+    input_left,
+    input_right,
+    output_left,
+    output_right,
+    loss_channel_matrix,
+    connector,
+):
+    """
+    Calculates the element of the lossy density matrix for the given input and output
+    states.
+
+    Source: https://arxiv.org/abs/2412.17742
+    """
+    # TODO: There might be a more efficient way to compute this, especially in certain
+    # cases, e.g., when the input and output states are the same, or for uniform losses.
+    fallback_np = connector.fallback_np
+
+    input_left = fallback_np.asarray(input_left, dtype=int)
+    input_right = fallback_np.asarray(input_right, dtype=int)
+    output_left = fallback_np.asarray(output_left, dtype=int)
+    output_right = fallback_np.asarray(output_right, dtype=int)
+
+    lost_left = int(fallback_np.sum(input_left) - fallback_np.sum(output_left))
+    lost_right = int(fallback_np.sum(input_right) - fallback_np.sum(output_right))
+
+    if lost_left < 0 or lost_right < 0:
+        return 0.0
+
+    if lost_left != lost_right:
+        return 0.0
+
+    repeated_occupation_number = fallback_np.concatenate(
+        [
+            input_left,
+            output_left,
+            input_right,
+            output_right,
+        ]
+    )
+
+    # NOTE: This can also be a hafnian, but that is not yet supported with JaxConnector
+    hafnian = connector.loop_hafnian(
+        loss_channel_matrix,
+        fallback_np.zeros(loss_channel_matrix.shape[0], dtype=complex),
+        repeated_occupation_number,
+    )
+
+    denominator = fallback_np.sqrt(
+        fallback_np.prod(factorial(input_left))
+        * fallback_np.prod(factorial(input_right))
+        * fallback_np.prod(factorial(output_left))
+        * fallback_np.prod(factorial(output_right))
+    )
+
+    return hafnian / denominator
+
+
 def generate_samples(
     input,
     shots,

--- a/tests/_simulators/sampling/test_state.py
+++ b/tests/_simulators/sampling/test_state.py
@@ -18,6 +18,8 @@ import pytest
 
 import piquasso as pq
 
+from scipy.special import comb
+
 
 def test_state_vector(generate_unitary_matrix):
     input_state = np.array([2, 1, 3, 1, 1], dtype=int)
@@ -63,6 +65,337 @@ def test_validate_not_normalized():
         pq.api.exceptions.InvalidState, match="The state is not normalized."
     ):
         result.state.validate()
+
+
+class TestGetParticleDetectionProbability:
+    def test_get_particle_detection_probability_simple(self):
+        input_state = np.array([1, 1], dtype=int)
+
+        unitary = np.array([[1, 0], [0, 1]], dtype=complex)
+
+        program = pq.Program(
+            instructions=[
+                pq.NumberState(input_state),
+                pq.Interferometer(unitary),
+            ]
+        )
+
+        simulator = pq.SamplingSimulator(d=len(unitary), config=pq.Config(cutoff=3))
+
+        result = simulator.execute(program)
+
+        state = result.state
+
+        occupation_number = np.array([1, 1], dtype=int)
+
+        probability = state.get_particle_detection_probability(occupation_number)
+
+        assert np.isclose(probability, 1.0)
+
+    def test_get_particle_detection_probability_beamsplitter(self):
+        input_state = np.array([1, 1], dtype=int)
+
+        theta = np.pi / 5
+
+        program = pq.Program(
+            instructions=[
+                pq.NumberState(input_state),
+                pq.Beamsplitter(theta=theta).on_modes(0, 1),
+            ]
+        )
+
+        simulator = pq.SamplingSimulator(d=len(input_state), config=pq.Config(cutoff=3))
+
+        result = simulator.execute(program)
+
+        state = result.state
+
+        occupation_number = np.array([2, 0], dtype=int)
+
+        probability = state.get_particle_detection_probability(occupation_number)
+
+        assert np.isclose(probability, np.sin(2 * theta) ** 2 / 2)
+
+    def test_get_particle_detection_probability_uniform_lossy(self):
+        input_state = np.array([1, 1], dtype=int)
+
+        theta = np.pi / 5
+
+        transmissivity = 0.5
+
+        program = pq.Program(
+            instructions=[
+                pq.NumberState(input_state),
+                pq.Beamsplitter(theta=theta).on_modes(0, 1),
+                pq.UniformLoss(transmissivity=transmissivity).on_modes(0, 1),
+            ]
+        )
+
+        simulator = pq.SamplingSimulator(d=len(input_state), config=pq.Config(cutoff=3))
+
+        result = simulator.execute(program)
+
+        state = result.state
+
+        occupation_number = np.array([2, 0], dtype=int)
+
+        probability = state.get_particle_detection_probability(occupation_number)
+
+        expected_probability = transmissivity**4 * np.sin(2 * theta) ** 2 / 2
+
+        assert np.isclose(probability, expected_probability)
+
+    def test_get_particle_detection_probability_uniform_lossy_three_modes(self):
+        input_state = np.array([1, 1, 1], dtype=int)
+
+        theta_01 = np.pi / 5
+        theta_12 = np.pi / 7
+        transmissivity = 0.6
+
+        lossless_program = pq.Program(
+            instructions=[
+                pq.NumberState(input_state),
+                pq.Beamsplitter(theta=theta_01).on_modes(0, 1),
+                pq.Beamsplitter(theta=theta_12).on_modes(1, 2),
+            ]
+        )
+
+        lossy_program = pq.Program(
+            instructions=[
+                pq.NumberState(input_state),
+                pq.Beamsplitter(theta=theta_01).on_modes(0, 1),
+                pq.Beamsplitter(theta=theta_12).on_modes(1, 2),
+                pq.UniformLoss(transmissivity=transmissivity).on_modes(0, 1, 2),
+            ]
+        )
+
+        simulator = pq.SamplingSimulator(
+            d=len(input_state),
+            config=pq.Config(cutoff=4),
+        )
+
+        lossless_state = simulator.execute(lossless_program).state
+        lossy_state = simulator.execute(lossy_program).state
+
+        detected_occupation = np.array([1, 1, 0], dtype=int)
+
+        probability = lossy_state.get_particle_detection_probability(
+            detected_occupation
+        )
+
+        possible_no_loss_outputs = [
+            np.array([2, 1, 0], dtype=int),
+            np.array([1, 2, 0], dtype=int),
+            np.array([1, 1, 1], dtype=int),
+        ]
+
+        expected_probability = 0.0
+
+        def _uniform_loss_transition_probability(
+            no_loss_occupation_number,
+            detected_occupation_number,
+            transmissivity,
+        ):
+            probability = 1.0
+
+            survival_probability = transmissivity**2
+            loss_probability = 1.0 - survival_probability
+
+            for no_loss, detected in zip(
+                no_loss_occupation_number,
+                detected_occupation_number,
+            ):
+                no_loss = int(no_loss)
+                detected = int(detected)
+
+                if detected > no_loss:
+                    return 0.0
+
+                lost = no_loss - detected
+
+                probability *= (
+                    comb(no_loss, detected)
+                    * survival_probability**detected
+                    * loss_probability**lost
+                )
+
+            return probability
+
+        for no_loss_output in possible_no_loss_outputs:
+            loss_probability = _uniform_loss_transition_probability(
+                no_loss_occupation_number=no_loss_output,
+                detected_occupation_number=detected_occupation,
+                transmissivity=transmissivity,
+            )
+
+            ideal_probability = lossless_state.get_particle_detection_probability(
+                no_loss_output
+            )
+
+            expected_probability += loss_probability * ideal_probability
+
+        assert np.isclose(probability, expected_probability)
+
+    def test_postselection_simple(self):
+        input_state = np.array([1, 1], dtype=int)
+
+        theta = np.pi / 5
+
+        program = pq.Program(
+            instructions=[
+                pq.NumberState(input_state),
+                pq.Beamsplitter(theta=theta).on_modes(0, 1),
+                pq.PostSelectPhotons(photon_counts=[1]).on_modes(0),
+            ]
+        )
+
+        simulator = pq.SamplingSimulator(d=len(input_state), config=pq.Config(cutoff=3))
+
+        result = simulator.execute(program)
+
+        state = result.state
+
+        occupation_number = np.array([1], dtype=int)
+
+        probability = state.get_particle_detection_probability(occupation_number)
+
+        assert np.isclose(probability, np.cos(2 * theta) ** 2)
+
+    def test_postselection_with_uniform_loss(self):
+        input_state = np.array([1, 1], dtype=int)
+
+        theta = np.pi / 5
+        transmissivity = 0.6
+
+        program = pq.Program(
+            instructions=[
+                pq.NumberState(input_state),
+                pq.Beamsplitter(theta=theta).on_modes(0, 1),
+                pq.UniformLoss(transmissivity=transmissivity).on_modes(0, 1),
+                pq.PostSelectPhotons(photon_counts=[1]).on_modes(0),
+            ]
+        )
+
+        simulator = pq.SamplingSimulator(
+            d=len(input_state),
+            config=pq.Config(cutoff=3),
+        )
+
+        result = simulator.execute(program)
+
+        state = result.state
+
+        occupation_number = np.array([0], dtype=int)
+
+        probability = state.get_particle_detection_probability(occupation_number)
+
+        survival_probability = transmissivity**2
+
+        expected_probability = survival_probability * (1.0 - survival_probability)
+
+        assert np.isclose(probability, expected_probability)
+
+    def test_postselection_with_nonuniform_loss(self):
+        input_state = np.array([1, 1], dtype=int)
+
+        theta = np.pi / 5
+
+        transmissivity_0 = 0.6
+        transmissivity_1 = 0.8
+
+        program = pq.Program(
+            instructions=[
+                pq.NumberState(input_state),
+                pq.Beamsplitter(theta=theta).on_modes(0, 1),
+                pq.UniformLoss(transmissivity=transmissivity_0).on_modes(0),
+                pq.UniformLoss(transmissivity=transmissivity_1).on_modes(1),
+                pq.PostSelectPhotons(photon_counts=[1]).on_modes(0),
+            ]
+        )
+
+        simulator = pq.SamplingSimulator(
+            d=len(input_state),
+            config=pq.Config(cutoff=3),
+        )
+
+        result = simulator.execute(program)
+
+        state = result.state
+
+        occupation_number = np.array([0], dtype=int)
+
+        probability = state.get_particle_detection_probability(occupation_number)
+
+        survival_probability_0 = transmissivity_0**2
+        survival_probability_1 = transmissivity_1**2
+
+        expected_probability = (
+            survival_probability_0
+            * (1.0 - survival_probability_1)
+            * np.cos(2 * theta) ** 2
+            + survival_probability_0
+            * (1.0 - survival_probability_0)
+            * np.sin(2 * theta) ** 2
+        )
+
+        assert np.isclose(probability, expected_probability)
+
+    def test_postselection_with_nonuniform_loss_multiple_input_number_states(self):
+        theta = np.pi / 5
+
+        transmissivity_0 = 0.6
+        transmissivity_1 = 0.8
+
+        coefficient_11 = np.sqrt(0.3)
+        coefficient_20 = np.sqrt(0.5)
+
+        program = pq.Program(
+            instructions=[
+                coefficient_11 * pq.NumberState([1, 1]),
+                coefficient_20 * pq.NumberState([2, 0]),
+                pq.Beamsplitter(theta=theta).on_modes(0, 1),
+                pq.UniformLoss(transmissivity=transmissivity_0).on_modes(0),
+                pq.UniformLoss(transmissivity=transmissivity_1).on_modes(1),
+                pq.PostSelectPhotons(photon_counts=[1]).on_modes(0),
+            ]
+        )
+
+        simulator = pq.SamplingSimulator(
+            d=2,
+            config=pq.Config(cutoff=3),
+        )
+
+        result = simulator.execute(program)
+
+        state = result.state
+
+        occupation_number = np.array([0], dtype=int)
+
+        probability = state.get_particle_detection_probability(occupation_number)
+
+        survival_probability_0 = transmissivity_0**2
+        survival_probability_1 = transmissivity_1**2
+
+        output_amplitude_11 = coefficient_11 * np.cos(
+            2 * theta
+        ) + coefficient_20 * np.sin(2 * theta) / np.sqrt(2)
+
+        output_amplitude_20 = (
+            -coefficient_11 * np.sin(2 * theta) / np.sqrt(2)
+            + coefficient_20 * np.cos(theta) ** 2
+        )
+
+        expected_probability = (
+            survival_probability_0
+            * (1.0 - survival_probability_1)
+            * np.abs(output_amplitude_11) ** 2
+            + 2
+            * survival_probability_0
+            * (1.0 - survival_probability_0)
+            * np.abs(output_amplitude_20) ** 2
+        )
+
+        assert np.isclose(probability, expected_probability)
 
 
 class TestMarginalProbabilities:


### PR DESCRIPTION
The handling of losses were not handled properly for `get_particle_detection_probability`. This has been resolved in this patch by computing the particle detection probabilities provided by techniques from https://arxiv.org/abs/2412.17742.