### PR TITLE
fix(sampling): Fix marginal sampling fallback path

### DIFF
--- a/piquasso/_simulators/sampling/simulation_steps.py
+++ b/piquasso/_simulators/sampling/simulation_steps.py
@@ -257,7 +257,7 @@ def particle_number_measurement(
         marginal_sampling
         and not state.is_lossy
         and is_direct_marginal_sampling_cheaper(
-            k=len(modes),
+            k=len(modes) + len(postselected_modes),
             d=state.total_number_of_modes,
             n=int(np.sum(initial_state)),
             shots=shots,

--- a/piquasso/_simulators/sampling/simulation_steps.py
+++ b/piquasso/_simulators/sampling/simulation_steps.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 from functools import partial
-from typing import Tuple, List
+from typing import Dict, Tuple, List
 
 import numpy as np
 
@@ -257,9 +257,10 @@ def particle_number_measurement(
         marginal_sampling
         and not state.is_lossy
         and is_direct_marginal_sampling_cheaper(
-            k=len(modes) + len(postselected_modes),
+            k=len(modes),
             d=state.total_number_of_modes,
             n=int(np.sum(initial_state)),
+            shots=shots,
         )
     ):
         original_modes = map_to_original_modes(modes, postselected_modes)
@@ -275,24 +276,12 @@ def particle_number_measurement(
 
         binned_samples = get_counts(samples)
 
-        branches = []
-
-        for outcome, multiplicity in binned_samples.items():
-            new_state = state.copy()
-            new_state._postselections = {
-                **new_state._postselections,
-                **{mode: x for mode, x in zip(modes, outcome)},
-            }
-
-            branches.append(
-                Branch(
-                    state=new_state,
-                    outcome=outcome,
-                    frequency=Fraction(multiplicity, shots),
-                )
-            )
-
-        return branches
+        return _create_branches_after_marginal_particle_number_measurement(
+            state=state,
+            instruction=instruction,
+            shots=shots,
+            binned_samples=binned_samples,
+        )
 
     interferometer_svd = np.linalg.svd(state.interferometer)
     singular_values = interferometer_svd[1]
@@ -328,15 +317,52 @@ def particle_number_measurement(
     binned_samples = get_counts(samples)
 
     if marginal_sampling:
-        binned_samples = {
-            tuple(outcome[mode] for mode in modes): multiplicity
-            for outcome, multiplicity in binned_samples.items()
-        }
+        projected_binned_samples: Dict[Tuple[int, ...], int] = {}
+
+        for outcome, multiplicity in binned_samples.items():
+            projected_outcome = tuple(outcome[mode] for mode in modes)
+            projected_binned_samples[projected_outcome] = (
+                projected_binned_samples.get(projected_outcome, 0) + multiplicity
+            )
+
+        binned_samples = projected_binned_samples
+
+        return _create_branches_after_marginal_particle_number_measurement(
+            state=state,
+            instruction=instruction,
+            shots=shots,
+            binned_samples=binned_samples,
+        )
 
     branches = [
         Branch(state=None, outcome=outcome, frequency=Fraction(multiplicity, shots))
         for outcome, multiplicity in binned_samples.items()
     ]
+
+    return branches
+
+
+def _create_branches_after_marginal_particle_number_measurement(
+    state: SamplingState, instruction: Instruction, shots: int, binned_samples: dict
+) -> List[Branch]:
+    modes = instruction.modes
+
+    branches = []
+
+    for outcome, multiplicity in binned_samples.items():
+        new_state = state.copy()
+        new_state._postselections = {
+            **new_state._postselections,
+            **{mode: x for mode, x in zip(modes, outcome)},
+        }
+
+        branches.append(
+            Branch(
+                state=new_state,
+                outcome=outcome,
+                frequency=Fraction(multiplicity, shots),
+            )
+        )
 
     return branches
 

--- a/piquasso/_simulators/sampling/utils.py
+++ b/piquasso/_simulators/sampling/utils.py
@@ -614,7 +614,7 @@ def is_direct_marginal_sampling_cheaper(k: int, d: int, n: int, shots: int) -> b
     discarding unmeasured modes. The decision is based on the size of the number of
     coefficients in the marginal sampling algorithm and the number of shots.
 
-    NOTE: Take this with a grain of salt, as it based on rough guesses and benchmarks
+    NOTE: Take this with a grain of salt, as it is based on rough guesses and benchmarks
     on my laptop, and the specific runtime may vary depending on the machine and the
     specific parameters.
     """

--- a/piquasso/_simulators/sampling/utils.py
+++ b/piquasso/_simulators/sampling/utils.py
@@ -608,26 +608,31 @@ def generate_marginal_samples(
     return samples
 
 
-def is_direct_marginal_sampling_cheaper(k: int, d: int, n: int) -> bool:
+def is_direct_marginal_sampling_cheaper(k: int, d: int, n: int, shots: int) -> bool:
     """
-    Estimate whether direct marginal sampling is cheaper than full sampling
-    followed by discarding unmeasured modes. The comparison is based on simple
-    cost estimates.
+    Estimate whether direct marginal sampling is cheaper than full sampling followed by
+    discarding unmeasured modes. The decision is based on the size of the number of
+    coefficients in the marginal sampling algorithm and the number of shots.
 
-    Direct marginal sampling is dominated by the cost of calculating the marginal
-    probabilities, which is roughly `n * k^2 * sum_{s=0}^n binom(s + k - 1, k - 1)^2`,
-    In the case of full sampling, the cost is roughly `n * 2^n + d * n^2`.
-
-    Here, k is the number of measured modes, d is the total number of modes, and
-    n is the total number of photons.
+    NOTE: Take this with a grain of salt, as it based on rough guesses and benchmarks
+    on my laptop, and the specific runtime may vary depending on the machine and the
+    specific parameters.
     """
+
     if k == d:
         return False
 
-    direct_marginal_cost = (
-        n * k**2 * sum(comb(degree + k - 1, k - 1) ** 2 for degree in range(n + 1))
+    number_of_coeffs_in_marginal_sampling_algorithm = sum(
+        comb(degree + k - 1, k - 1) ** 2 for degree in range(n + 1)
     )
 
-    full_sampling_cost = n * 2**n + d * n**2
+    if number_of_coeffs_in_marginal_sampling_algorithm <= 100_000:
+        return True
 
-    return direct_marginal_cost < full_sampling_cost
+    if number_of_coeffs_in_marginal_sampling_algorithm <= 500_000:
+        return shots >= 1_000
+
+    if number_of_coeffs_in_marginal_sampling_algorithm <= 4_000_000:
+        return shots >= 10_000
+
+    return False


### PR DESCRIPTION
The processing of the binned samples in the case of marginal sampling is faulty, because samples can of course coincide. The solution is to merge the equivalent samples.

The `is_direct_marginal_sampling_cheaper` function was also rewritten based on local benchmarks. The previous asymptotic cost estimate was not reliable enough for algorithm selection, because the runtime is strongly affected by constant factors, memory traffic, and amortization over the number of shots. The new heuristic is intentionally simple and not exact, but it matches the observed runtime regimes well.