### PR TITLE
feat(sampling): Support for uniformly lossy marginal sampling

### DIFF
--- a/piquasso/_simulators/sampling/simulation_steps.py
+++ b/piquasso/_simulators/sampling/simulation_steps.py
@@ -253,9 +253,13 @@ def particle_number_measurement(
 
     marginal_sampling = set(modes) != set(range(state.d))
 
+    singular_values = np.linalg.svd(state.interferometer, compute_uv=False)
+
+    is_ideal_or_uniform_lossy = np.all(np.isclose(singular_values, singular_values[0]))
+
     if (
         marginal_sampling
-        and not state.is_lossy
+        and is_ideal_or_uniform_lossy
         and is_direct_marginal_sampling_cheaper(
             k=len(modes) + len(postselected_modes),
             d=state.total_number_of_modes,
@@ -283,16 +287,13 @@ def particle_number_measurement(
             binned_samples=binned_samples,
         )
 
-    interferometer_svd = np.linalg.svd(state.interferometer)
-    singular_values = interferometer_svd[1]
-
     if not state.is_lossy:
         partial_generate_samples = partial(
             generate_samples,
             interferometer=state.interferometer,
             reject_condition=lambda: False,
         )
-    elif np.all(np.isclose(singular_values, singular_values[0])):
+    elif is_ideal_or_uniform_lossy:
         uniform_transmission_probability = singular_values[0] ** 2
 
         partial_generate_samples = partial(
@@ -301,6 +302,7 @@ def particle_number_measurement(
             reject_condition=lambda: rng.uniform() > uniform_transmission_probability,
         )
     else:
+        interferometer_svd = np.linalg.svd(state.interferometer)
         partial_generate_samples = partial(
             generate_lossy_samples,
             interferometer_svd=interferometer_svd,

--- a/piquasso/_simulators/sampling/state.py
+++ b/piquasso/_simulators/sampling/state.py
@@ -151,6 +151,14 @@ class SamplingState(State):
     def _is_postselected(self) -> bool:
         return self._postselections != {}
 
+    def _is_uniformly_lossy(self) -> bool:
+        if not self.is_lossy:
+            return False
+
+        singular_values = np.linalg.svd(self.interferometer, compute_uv=False)
+
+        return all(np.isclose(singular_values, singular_values[0]))
+
     def _get_postselected_modes(self) -> Tuple[int, ...]:
         return tuple(self._postselections.keys())
 
@@ -452,9 +460,12 @@ class SamplingState(State):
             Dict[Tuple[int, ...], float]: The marginal probabilities of the state.
         """
 
-        if self.is_lossy:
+        is_uniformly_lossy = self._is_uniformly_lossy()
+
+        if self.is_lossy and not is_uniformly_lossy:
             raise NotImplementedCalculation(
-                "Marginal probability calculation is not implemented for lossy states."
+                "Marginal probability calculation is not implemented for non-uniformly "
+                "lossy states."
             )
 
         if len(self._occupation_numbers) > 1:

--- a/tests/_simulators/sampling/test_measurements.py
+++ b/tests/_simulators/sampling/test_measurements.py
@@ -955,6 +955,56 @@ class TestMarginalBosonSampling:
         for sample in result.samples:
             assert tuple(sample) == (2, 1)
 
+    def test_uniformly_lossy_marginal_sampling(self):
+        input_state = np.array([1, 1, 1, 0, 0], dtype=int)
+        d = len(input_state)
+
+        transmissivity = 0.5
+
+        permutation = np.zeros((d, d), dtype=complex)
+
+        permutation[2, 0] = 1.0
+        permutation[4, 1] = 1.0
+        permutation[0, 2] = 1.0
+        permutation[1, 3] = 1.0
+        permutation[3, 4] = 1.0
+
+        lossy_interferometer = transmissivity * permutation
+
+        program = pq.Program(
+            instructions=[
+                pq.NumberState(input_state),
+                pq.LossyInterferometer(lossy_interferometer),
+                pq.ParticleNumberMeasurement().on_modes(0, 2),
+            ]
+        )
+
+        simulator = pq.SamplingSimulator(d=d, config=pq.Config(seed_sequence=42))
+
+        shots = 100
+        result = simulator.execute(program, shots=shots)
+
+        assert len(result.samples) == shots
+
+        for sample in result.samples:
+            assert len(sample) == 2
+
+            assert sample[0] in (
+                0,
+                1,
+            ), "Output mode 0 receives the photon from input mode 2."
+
+            assert sample[1] in (
+                0,
+                1,
+            ), "Output mode 2 receives the photon from input mode 0."
+
+            assert sum(sample) in (
+                0,
+                1,
+                2,
+            ), "The measured modes can contain at most those two routed photons."
+
     def test_lossy_marginal_sampling(self):
         input_state = np.array([1, 1, 1, 0, 0], dtype=int)
         d = len(input_state)

--- a/tests/_simulators/sampling/test_state.py
+++ b/tests/_simulators/sampling/test_state.py
@@ -622,13 +622,81 @@ class TestMarginalProbabilities:
 
         assert np.isclose(np.sum(list(probabilities.values())), 1.0)
 
-    def test_lossy_state_marginal_probabilities_raises_NotImplementedCalculation(self):
-        input_state = np.array([1, 1], dtype=int)
+    def test_uniform_lossy_state_marginal_probabilities_trivial(self):
+        input_state = np.array([1, 0], dtype=int)
+
+        transmissivity = 0.5
+        survival_probability = transmissivity**2
 
         program = pq.Program(
             instructions=[
                 pq.NumberState(input_state),
-                pq.UniformLoss(transmissivity=0.5).on_modes(0, 1),
+                pq.UniformLoss(transmissivity=transmissivity).on_modes(0, 1),
+            ]
+        )
+
+        simulator = pq.SamplingSimulator(d=2, config=pq.Config(cutoff=2))
+
+        result = simulator.execute(program)
+
+        probabilities = result.state.get_marginal_probabilities(modes=[0])
+
+        expected = {
+            (0,): 1.0 - survival_probability,
+            (1,): survival_probability,
+        }
+
+        assert set(probabilities) == set(expected)
+
+        for outcome, expected_probability in expected.items():
+            assert np.isclose(probabilities[outcome], expected_probability)
+
+        assert np.isclose(sum(probabilities.values()), 1.0)
+
+    def test_uniform_lossy_state_marginal_probabilities_trivial_multiphoton(self):
+        input_state = np.array([2, 1, 0], dtype=int)
+
+        transmissivity = 0.5
+        survival_probability = transmissivity**2
+
+        program = pq.Program(
+            instructions=[
+                pq.NumberState(input_state),
+                pq.UniformLoss(transmissivity=transmissivity).on_modes(0, 1, 2),
+            ]
+        )
+
+        simulator = pq.SamplingSimulator(d=3, config=pq.Config(cutoff=4))
+
+        result = simulator.execute(program)
+
+        probabilities = result.state.get_marginal_probabilities(modes=[0, 1])
+
+        expected = {
+            (0, 0): (1.0 - survival_probability) ** 3,
+            (0, 1): (1.0 - survival_probability) ** 2 * survival_probability,
+            (1, 0): 2 * survival_probability * (1.0 - survival_probability) ** 2,
+            (1, 1): 2 * survival_probability**2 * (1.0 - survival_probability),
+            (2, 0): survival_probability**2 * (1.0 - survival_probability),
+            (2, 1): survival_probability**3,
+        }
+
+        for outcome, expected_probability in expected.items():
+            assert np.isclose(probabilities[outcome], expected_probability)
+
+        assert np.isclose(sum(probabilities.values()), 1.0)
+
+    def test_uniform_lossy_state_marginal_probabilities_with_beamsplitter(self):
+        input_state = np.array([1, 1], dtype=int)
+
+        transmissivity = 0.5
+        survival_probability = transmissivity**2
+
+        program = pq.Program(
+            instructions=[
+                pq.NumberState(input_state),
+                pq.Beamsplitter(theta=np.pi / 4, phi=0.0).on_modes(0, 1),
+                pq.UniformLoss(transmissivity=transmissivity).on_modes(0, 1),
             ]
         )
 
@@ -636,17 +704,45 @@ class TestMarginalProbabilities:
 
         result = simulator.execute(program)
 
-        state = result.state
+        probabilities = result.state.get_marginal_probabilities(modes=[0])
 
-        modes = [0]
+        expected = {
+            (0,): 0.5 + 0.5 * (1.0 - survival_probability) ** 2,
+            (1,): 0.5 * 2.0 * survival_probability * (1.0 - survival_probability),
+            (2,): 0.5 * survival_probability**2,
+        }
+
+        for outcome, expected_probability in expected.items():
+            assert np.isclose(probabilities[outcome], expected_probability)
+
+        assert np.isclose(sum(probabilities.values()), 1.0)
+
+    def test_non_uniformly_lossy_state_raises_NotImplementedCalculation(
+        self,
+    ):
+        input_state = np.array([1, 1], dtype=int)
+
+        lossy_interferometer = np.diag([0.5, 0.25])
+
+        program = pq.Program(
+            instructions=[
+                pq.NumberState(input_state),
+                pq.LossyInterferometer(lossy_interferometer),
+            ]
+        )
+
+        simulator = pq.SamplingSimulator(d=2, config=pq.Config(cutoff=3))
+
+        result = simulator.execute(program)
 
         with pytest.raises(
             pq.api.exceptions.NotImplementedCalculation,
             match=(
-                "Marginal probability calculation is not implemented for lossy states."
+                "Marginal probability calculation is not implemented for non-uniformly "
+                "lossy states."
             ),
         ):
-            _ = state.get_marginal_probabilities(modes)
+            _ = result.state.get_marginal_probabilities(modes=[0])
 
     def test_multiple_occupation_numbers_raises_NotImplementedCalculation(self):
         unitary = np.array([[1, 0], [0, 1]], dtype=complex)


### PR DESCRIPTION
The logic really doesn't have to be modified to enable uniformly lossy states in marginal sampling, so it is not very difficult to support this.