### PR TITLE
feat: add `ImperfectParticleNumberMeasurement`

### DIFF
--- a/piquasso/__init__.py
+++ b/piquasso/__init__.py
@@ -100,6 +100,7 @@ from .instructions.gates import (
 
 from .instructions.measurements import (
     ParticleNumberMeasurement,
+    ImperfectParticleNumberMeasurement,
     ThresholdMeasurement,
     HomodyneMeasurement,
     HeterodyneMeasurement,
@@ -188,6 +189,7 @@ __all__ = [
     "Graph",
     # Measurements
     "ParticleNumberMeasurement",
+    "ImperfectParticleNumberMeasurement",
     "ThresholdMeasurement",
     "HomodyneMeasurement",
     "HeterodyneMeasurement",

--- a/piquasso/_simulators/fock/general/simulator.py
+++ b/piquasso/_simulators/fock/general/simulator.py
@@ -13,6 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from piquasso._simulators.simulation_steps import (
+    create_imperfect_particle_number_measurement,
+)
+
 from ...simulator import BuiltinSimulator
 from piquasso.instructions import preparations, gates, measurements, channels
 
@@ -93,7 +97,8 @@ class FockSimulator(BuiltinSimulator):
         :class:`~piquasso.instructions.gates.MomentumDisplacement`.
 
     Supported measurements:
-        :class:`~piquasso.instructions.measurements.ParticleNumberMeasurement`.
+        :class:`~piquasso.instructions.measurements.ParticleNumberMeasurement`,
+        :class:`~piquasso.instructions.measurements.ImperfectParticleNumberMeasurement`.
 
     Supported channels:
         :class:`~piquasso.instructions.channels.Attenuator`
@@ -122,6 +127,11 @@ class FockSimulator(BuiltinSimulator):
         gates.Squeezing2: linear,
         gates.GaussianTransform: linear,
         measurements.ParticleNumberMeasurement: particle_number_measurement,
+        measurements.ImperfectParticleNumberMeasurement: (
+            create_imperfect_particle_number_measurement(
+                particle_number_measurement_simulation_step=particle_number_measurement
+            )
+        ),
         channels.Attenuator: attenuator,
     }
 

--- a/piquasso/_simulators/fock/pure/simulator.py
+++ b/piquasso/_simulators/fock/pure/simulator.py
@@ -13,6 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from piquasso._simulators.simulation_steps import (
+    create_imperfect_particle_number_measurement,
+)
+
 from .state import PureFockState
 
 from .simulation_steps import (
@@ -109,7 +113,11 @@ class PureFockSimulator(BuiltinSimulator):
         :class:`~piquasso.instructions.gates.MomentumDisplacement`.
 
     Supported measurements:
-        :class:`~piquasso.instructions.measurements.ParticleNumberMeasurement`.
+        :class:`~piquasso.instructions.measurements.ParticleNumberMeasurement`,
+        :class:`~piquasso.instructions.measurements.ImperfectParticleNumberMeasurement`,
+        :class:`~piquasso.instructions.measurements.PostSelectPhotons`,
+        :class:`~piquasso.instructions.measurements.ImperfectPostSelectPhotons`,
+        :class:`~piquasso.instructions.measurements.HomodyneMeasurement`.
 
     Supported channels:
         :class:`~piquasso.instructions.channels.Attenuator`.
@@ -142,6 +150,11 @@ class PureFockSimulator(BuiltinSimulator):
         gates.Squeezing2: linear,
         gates.GaussianTransform: linear,
         measurements.ParticleNumberMeasurement: particle_number_measurement,
+        measurements.ImperfectParticleNumberMeasurement: (
+            create_imperfect_particle_number_measurement(
+                particle_number_measurement_simulation_step=particle_number_measurement
+            )
+        ),
         measurements.PostSelectPhotons: post_select_photons,
         measurements.ImperfectPostSelectPhotons: imperfect_post_select_photons,
         measurements.HomodyneMeasurement: homodyne_measurement,

--- a/piquasso/_simulators/gaussian/simulator.py
+++ b/piquasso/_simulators/gaussian/simulator.py
@@ -34,6 +34,10 @@ from .simulation_steps import (
     deterministic_gaussian_channel,
 )
 
+from ..simulation_steps import (
+    create_imperfect_particle_number_measurement,
+)
+
 
 class GaussianSimulator(BuiltinSimulator):
     """Performs photonic simulations using Gaussian representation.
@@ -93,6 +97,7 @@ class GaussianSimulator(BuiltinSimulator):
         :class:`~piquasso.instructions.measurements.HeterodyneMeasurement`,
         :class:`~piquasso.instructions.measurements.GeneraldyneMeasurement`,
         :class:`~piquasso.instructions.measurements.ParticleNumberMeasurement`,
+        :class:`~piquasso.instructions.measurements.ImperfectParticleNumberMeasurement`,
         :class:`~piquasso.instructions.measurements.ThresholdMeasurement`.
 
     Supported channels:
@@ -125,6 +130,11 @@ class GaussianSimulator(BuiltinSimulator):
         measurements.HeterodyneMeasurement: generaldyne_measurement,
         measurements.GeneraldyneMeasurement: generaldyne_measurement,
         measurements.ParticleNumberMeasurement: particle_number_measurement,
+        measurements.ImperfectParticleNumberMeasurement: (
+            create_imperfect_particle_number_measurement(
+                particle_number_measurement_simulation_step=particle_number_measurement
+            )
+        ),
         measurements.ThresholdMeasurement: threshold_measurement,
         channels.DeterministicGaussianChannel: deterministic_gaussian_channel,
         channels.Attenuator: deterministic_gaussian_channel,

--- a/piquasso/_simulators/passive/simulator.py
+++ b/piquasso/_simulators/passive/simulator.py
@@ -37,6 +37,10 @@ from .simulation_steps import (
     imperfect_post_select_photons,
 )
 
+from ..simulation_steps import (
+    create_imperfect_particle_number_measurement,
+)
+
 
 class PassiveSimulator(BuiltinSimulator):
     r"""A simulator dedicated for Boson Sampling (or related) simulations.
@@ -86,7 +90,10 @@ class PassiveSimulator(BuiltinSimulator):
         :class:`~piquasso.instructions.gates.Interferometer`.
 
     Supported measurements:
-        :class:`~piquasso.instructions.measurements.ParticleNumberMeasurement`.
+        :class:`~piquasso.instructions.measurements.ParticleNumberMeasurement`,
+        :class:`~piquasso.instructions.measurements.ImperfectParticleNumberMeasurement`,
+        :class:`~piquasso.instructions.measurements.PostSelectPhotons`,
+        :class:`~piquasso.instructions.measurements.ImperfectPostSelectPhotons`.
 
     Supported channels:
         :class:`~piquasso.instructions.channels.Loss`,
@@ -110,6 +117,11 @@ class PassiveSimulator(BuiltinSimulator):
         gates.Kerr: kerr,
         gates.CrossKerr: cross_kerr,
         measurements.ParticleNumberMeasurement: particle_number_measurement,
+        measurements.ImperfectParticleNumberMeasurement: (
+            create_imperfect_particle_number_measurement(
+                particle_number_measurement_simulation_step=particle_number_measurement
+            )
+        ),
         measurements.PostSelectPhotons: post_select_photons,
         measurements.ImperfectPostSelectPhotons: imperfect_post_select_photons,
         channels.Loss: loss,
@@ -123,7 +135,11 @@ class PassiveSimulator(BuiltinSimulator):
 
     _extra_builtin_connectors = [JaxConnector]
 
-    _measurement_classes_allowed_mid_circuit = (measurements.PostSelectPhotons,)
+    _measurement_classes_allowed_mid_circuit = (
+        measurements.PostSelectPhotons,
+        measurements.ParticleNumberMeasurement,
+        measurements.ImperfectParticleNumberMeasurement,
+    )
 
 
 class SamplingSimulator(PassiveSimulator):

--- a/piquasso/_simulators/simulation_steps.py
+++ b/piquasso/_simulators/simulation_steps.py
@@ -1,0 +1,128 @@
+#
+# Copyright 2021-2026 Budapest Quantum Computing Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Dict, Tuple, List, Callable
+
+import numpy as np
+
+from fractions import Fraction
+
+from piquasso.api.state import State
+from piquasso.api.branch import Branch
+from piquasso.api.instruction import Instruction
+from piquasso.api.exceptions import InvalidParameter
+
+
+def create_imperfect_particle_number_measurement(
+    particle_number_measurement_simulation_step: Callable,
+) -> Callable:
+    def imperfect_particle_number_measurement(
+        state: State, instruction: Instruction, shots: int
+    ) -> List[Branch]:
+        branches = particle_number_measurement_simulation_step(
+            state, instruction, shots
+        )
+
+        detector_efficiency_matrix: np.ndarray = np.asarray(
+            instruction.params["detector_efficiency_matrix"],
+            dtype=state._config.dtype,
+        )
+
+        rng = state._config.rng
+
+        detected_counts: Dict[Tuple[int, ...], int] = {}
+        imperfect_branches: List[Branch] = []
+
+        for branch in branches:
+            multiplicity = (branch.frequency * shots).numerator
+
+            detected_outcomes = _sample_detected_outcomes_for_branch(
+                actual_outcome=branch.outcome,
+                multiplicity=multiplicity,
+                detector_efficiency_matrix=detector_efficiency_matrix,
+                rng=rng,
+            )
+
+            for detected_outcome, detected_multiplicity in detected_outcomes.items():
+                if branch.state is None:
+                    detected_counts[detected_outcome] = (
+                        detected_counts.get(detected_outcome, 0) + detected_multiplicity
+                    )
+                else:
+                    imperfect_branches.append(
+                        Branch(
+                            state=branch.state.copy(),
+                            outcome=detected_outcome,
+                            frequency=Fraction(detected_multiplicity, shots),
+                        )
+                    )
+
+        imperfect_branches.extend(
+            Branch(
+                state=None,
+                outcome=outcome,
+                frequency=Fraction(multiplicity, shots),
+            )
+            for outcome, multiplicity in detected_counts.items()
+        )
+
+        return imperfect_branches
+
+    return imperfect_particle_number_measurement
+
+
+def _sample_detected_outcomes_for_branch(
+    actual_outcome: Tuple[int, ...],
+    multiplicity: int,
+    detector_efficiency_matrix: np.ndarray,
+    rng: np.random.Generator,
+) -> Dict[Tuple[int, ...], int]:
+    number_of_detectable_counts, number_of_actual_counts = (
+        detector_efficiency_matrix.shape
+    )
+
+    detected_counts = np.arange(number_of_detectable_counts)
+
+    detected_counts_by_mode = []
+
+    for actual_count in actual_outcome:
+        if actual_count >= number_of_actual_counts:
+            raise InvalidParameter(
+                f"The detector efficiency matrix has no value for photon count "
+                f"{actual_count}. Increase the number of columns."
+            )
+
+        probabilities = detector_efficiency_matrix[:, actual_count]
+        probabilities = probabilities / np.sum(probabilities)
+
+        detected_counts_by_mode.append(
+            rng.choice(
+                detected_counts,
+                size=multiplicity,
+                p=probabilities,
+            )
+        )
+
+    detected_outcomes = np.stack(detected_counts_by_mode, axis=1)
+    unique_outcomes, first_indices, counts = np.unique(
+        detected_outcomes, axis=0, return_index=True, return_counts=True
+    )
+
+    order = np.argsort(first_indices)
+
+    return {
+        tuple(int(value) for value in outcome): int(count)
+        for outcome, count in zip(unique_outcomes[order], counts[order])
+    }

--- a/piquasso/instructions/measurements.py
+++ b/piquasso/instructions/measurements.py
@@ -62,6 +62,87 @@ class ParticleNumberMeasurement(Measurement):
         super().__init__()
 
 
+class ImperfectParticleNumberMeasurement(Measurement):
+    r"""Imperfect particle number measurement.
+
+    Similar to :class:`ParticleNumberMeasurement`, but with a detector efficiency matrix
+    :math:`P` which describes the probability of detecting a certain number of photons
+    given the actual number of photons in the mode. The detector efficiency matrix
+    :math:`P` is defined elementwise as
+
+    .. math::
+
+        P_{n m} = p(\text{detected photon count } = n| \text{actual photon count } = m)
+
+    Example usage::
+
+        P = np.array(
+            [
+                [1.0, 0.1, 0.2],
+                [0.0, 0.9, 0.2],
+                [0.0, 0.0, 0.6],
+            ],
+        )
+
+        with pq.Program() as program:
+            pq.Q(all) | pq.StateVector([0, 1, 0]) * np.sqrt(0.2)
+            pq.Q(all) | pq.StateVector([1, 1, 0]) * np.sqrt(0.3)
+            pq.Q(all) | pq.StateVector([2, 1, 0]) * np.sqrt(0.5)
+
+            pq.Q(0) | pq.Phaseshifter(np.pi)
+
+            pq.Q(1, 2) | pq.Beamsplitter(np.pi / 8)
+            pq.Q(0, 1) | pq.Beamsplitter(1.1437)
+            pq.Q(1, 2) | pq.Beamsplitter(-np.pi / 8)
+
+            pq.Q(all) | pq.ImperfectParticleNumberMeasurement(
+                detector_efficiency_matrix=P,
+            )
+
+        simulator = pq.PureFockSimulator(d=3, config=pq.Config(cutoff=4))
+
+        state = simulator.execute(program).state
+
+    """
+
+    def __init__(self, detector_efficiency_matrix: "np.ndarray") -> None:
+        """
+        Args:
+            detector_efficiency_matrix (np.ndarray): Detector efficiency matrix.
+        """
+        super().__init__(
+            params=dict(
+                detector_efficiency_matrix=detector_efficiency_matrix,
+            )
+        )
+
+    def _validate(self, connector: BaseConnector) -> None:
+        detector_efficiency_matrix = self.params["detector_efficiency_matrix"]
+
+        if connector.is_abstract(detector_efficiency_matrix):
+            return
+
+        if detector_efficiency_matrix.ndim != 2:
+            raise ValueError(
+                "The detector efficiency matrix must be a two-dimensional array."
+            )
+
+        if np.any(detector_efficiency_matrix < 0.0):
+            raise ValueError(
+                "The detector efficiency matrix must contain non-negative "
+                "probabilities."
+            )
+
+        column_sums = np.sum(detector_efficiency_matrix, axis=0)
+
+        if not np.all(np.isclose(column_sums, 1.0)):
+            raise ValueError(
+                "Each column of the detector efficiency matrix must sum to 1. "
+                "Column m gives the probabilities of detected counts conditioned "
+                "on actual photon count m."
+            )
+
+
 class ThresholdMeasurement(Measurement):
     """Threshold measurement.
 
@@ -254,6 +335,16 @@ class PostSelectPhotons(Measurement):
 class ImperfectPostSelectPhotons(Measurement):
     r"""Post-selection on detected photon numbers.
 
+    Similar to :class:`PostSelectPhotons`, but with a detector efficiency matrix
+    :math:`P` which describes the probability of detecting a certain number of photons
+    given the actual number of photons in the mode. The detector efficiency matrix
+    :math:`P` is defined elementwise as
+
+    .. math::
+
+        P_{n m} = p(\text{detected photon count } = n| \text{actual photon count } = m)
+
+
     Example usage::
 
         P = np.array(
@@ -285,12 +376,6 @@ class ImperfectPostSelectPhotons(Measurement):
         state = simulator.execute(program).state
 
 
-    The detector efficiency matrix :math:`P` is defined elementwise as
-
-    .. math::
-
-        P_{n m} = p(\text{detected photon count } = n| \text{actual photon count } = m)
-
     Note:
         The resulting state is not normalized. To normalize it, use
         :meth:`~piquasso._simulators.fock.pure.state.PureFockState.normalize`. Moreover,
@@ -303,8 +388,7 @@ class ImperfectPostSelectPhotons(Measurement):
         photon_counts: Tuple[int, ...],
         detector_efficiency_matrix: "np.ndarray",
     ):
-        """_summary_
-
+        """
         Args:
             photon_counts (Tuple[int, ...]):
                 The desired photon numbers on the specified modes.

--- a/tests/_simulators/passive/test_measurements.py
+++ b/tests/_simulators/passive/test_measurements.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from fractions import Fraction
+
 import numpy as np
 import pytest
 
@@ -705,24 +707,26 @@ class TestMidCircuitMeasurements:
     """Test programs that contain mid-circuit measurements."""
 
     @pytest.mark.monkey
-    def test_ParticleNumberMeasurement_mid_circuit_not_allowed(self):
-        """
-        Test that an error is raised for mid-circuit measurements that are not allowed.
-        """
-        d = 3
+    def test_ParticleNumberMeasurement_mid_circuit_allowed(self):
+        interferometer_matrix = unitary_group.rvs(2)
 
-        interferometer_matrix = unitary_group.rvs(d)
         with pq.Program() as program:
-            pq.Q() | pq.NumberState([1, 1, 1, 0, 0])
+            pq.Q() | pq.NumberState([1, 1, 1])
             pq.Q(2) | pq.ParticleNumberMeasurement()
             pq.Q(all) | pq.Interferometer(interferometer_matrix)
 
-        simulator = pq.PassiveSimulator(d=5)
-        with pytest.raises(
-            pq.api.exceptions.InvalidSimulation,
-            match="not allowed as a mid-circuit measurement",
-        ):
-            simulator.execute(program, shots=1)
+        simulator = pq.PassiveSimulator(d=3)
+
+        result = simulator.execute(program, shots=1)
+
+        assert result.samples == [(1,)]
+
+        branches = result.branches
+
+        assert len(branches) == 1
+        assert branches[0].outcome == (1,)
+        assert branches[0].frequency == Fraction(1, 1)
+        assert branches[0].state is not None
 
     @pytest.mark.monkey
     def test_PostSelectPhotons_mid_circuit_allowed(self):
@@ -1335,3 +1339,222 @@ class TestDistinguishableNumberStateWithParticleNumberMeasurement:
         result = simulator.execute(program, shots=20)
 
         assert all(tuple(sample) == expected_sample for sample in result.samples)
+
+
+class TestImperfectParticleNumberMeasurement:
+    """Test programs that contain imperfect particle number measurements."""
+
+    def test_imperfect_measurement_with_uniform_loss_and_blind_detector(self):
+        input_state = np.array([1, 1, 1], dtype=int)
+
+        transmissivity = 0.5
+
+        detector_efficiency_matrix = np.array(
+            [
+                [1.0, 1.0],
+                [0.0, 0.0],
+            ]
+        )
+
+        with pq.Program() as program:
+            pq.Q() | pq.NumberState(input_state)
+            pq.Q() | pq.UniformLoss(transmissivity=transmissivity)
+            pq.Q() | pq.ImperfectParticleNumberMeasurement(
+                detector_efficiency_matrix=detector_efficiency_matrix,
+            )
+
+        simulator = pq.PassiveSimulator(d=3, config=pq.Config(seed_sequence=42))
+        result = simulator.execute(program, shots=100)
+
+        assert result.samples == [(0, 0, 0)] * 100
+
+    def test_identity_imperfect_measurement_matches_particle_number_measurement_with_uniform_loss(  # noqa: E501
+        self,
+    ):
+        input_state = np.array([1, 1, 1], dtype=int)
+
+        transmissivity = 0.5
+
+        detector_efficiency_matrix = np.identity(2)
+
+        with pq.Program() as ideal_program:
+            pq.Q() | pq.NumberState(input_state)
+            pq.Q() | pq.UniformLoss(transmissivity=transmissivity)
+            pq.Q() | pq.ParticleNumberMeasurement()
+
+        with pq.Program() as imperfect_program:
+            pq.Q() | pq.NumberState(input_state)
+            pq.Q() | pq.UniformLoss(transmissivity=transmissivity)
+            pq.Q() | pq.ImperfectParticleNumberMeasurement(
+                detector_efficiency_matrix=detector_efficiency_matrix,
+            )
+
+        ideal_simulator = pq.PassiveSimulator(
+            d=3,
+            config=pq.Config(seed_sequence=42),
+        )
+        imperfect_simulator = pq.PassiveSimulator(
+            d=3,
+            config=pq.Config(seed_sequence=42),
+        )
+
+        ideal_result = ideal_simulator.execute(ideal_program, shots=100)
+        imperfect_result = imperfect_simulator.execute(imperfect_program, shots=100)
+
+        assert imperfect_result.samples == ideal_result.samples
+
+    def test_imperfect_measurement_with_uniform_loss_and_perfect_detector_has_expected_samples(  # noqa: E501
+        self,
+    ):
+        input_state = np.array([1, 1, 1], dtype=int)
+
+        transmissivity = 0.0
+
+        detector_efficiency_matrix = np.identity(2)
+
+        with pq.Program() as program:
+            pq.Q() | pq.NumberState(input_state)
+            pq.Q() | pq.UniformLoss(transmissivity=transmissivity)
+            pq.Q() | pq.ImperfectParticleNumberMeasurement(
+                detector_efficiency_matrix=detector_efficiency_matrix,
+            )
+
+        simulator = pq.PassiveSimulator(d=3, config=pq.Config(seed_sequence=42))
+        result = simulator.execute(program, shots=100)
+
+        assert result.samples == [(0, 0, 0)] * 100
+
+    def test_imperfect_measurement_with_unit_transmissivity_and_blind_detector(
+        self,
+    ):
+        input_state = np.array([1, 1, 1], dtype=int)
+
+        transmissivity = 1.0
+
+        detector_efficiency_matrix = np.array(
+            [
+                [1.0, 1.0],
+                [0.0, 0.0],
+            ]
+        )
+
+        with pq.Program() as program:
+            pq.Q() | pq.NumberState(input_state)
+            pq.Q() | pq.UniformLoss(transmissivity=transmissivity)
+            pq.Q() | pq.ImperfectParticleNumberMeasurement(
+                detector_efficiency_matrix=detector_efficiency_matrix,
+            )
+
+        simulator = pq.PassiveSimulator(d=3, config=pq.Config(seed_sequence=42))
+        result = simulator.execute(program, shots=100)
+
+        assert result.samples == [(0, 0, 0)] * 100
+
+    def test_imperfect_measurement_with_unit_transmissivity_and_identity_detector(
+        self,
+    ):
+        input_state = np.array([1, 1, 1], dtype=int)
+
+        transmissivity = 1.0
+
+        detector_efficiency_matrix = np.identity(2)
+
+        with pq.Program() as program:
+            pq.Q() | pq.NumberState(input_state)
+            pq.Q() | pq.UniformLoss(transmissivity=transmissivity)
+            pq.Q() | pq.ImperfectParticleNumberMeasurement(
+                detector_efficiency_matrix=detector_efficiency_matrix,
+            )
+
+        simulator = pq.PassiveSimulator(d=3, config=pq.Config(seed_sequence=42))
+        result = simulator.execute(program, shots=100)
+
+        assert result.samples == [(1, 1, 1)] * 100
+
+    def test_marginal_imperfect_particle_number_measurement(self):
+        detector_efficiency_matrix = np.array(
+            [
+                [1.0, 1.0, 1.0],
+                [0.0, 0.0, 0.0],
+            ]
+        )
+
+        with pq.Program() as program:
+            pq.Q() | pq.NumberState([1, 1])
+            pq.Q(0, 1) | pq.Beamsplitter(np.pi / 4)
+
+            pq.Q(0) | pq.ImperfectParticleNumberMeasurement(
+                detector_efficiency_matrix=detector_efficiency_matrix,
+            )
+
+        simulator = pq.PassiveSimulator(d=2, config=pq.Config(seed_sequence=42))
+
+        result = simulator.execute(program, shots=100)
+
+        branches = result.branches
+
+        assert len(branches) == 2
+
+        assert {branch.outcome for branch in branches} == {(0,)}
+
+        assert all(branch.state is not None for branch in branches)
+
+        actual_postselected_counts = {
+            branch.state._postselections[0] for branch in branches
+        }
+
+        assert actual_postselected_counts == {0, 2}
+
+        assert sum(branch.frequency for branch in branches) == Fraction(1, 1)
+
+        assert result.samples == [(0,)] * 100
+
+    def test_marginal_imperfect_particle_number_measurement_less_trivial(
+        self,
+    ):
+        detector_efficiency_matrix = np.array(
+            [
+                [1.0, 1.0, 0.0],
+                [0.0, 0.0, 1.0],
+                [0.0, 0.0, 0.0],
+            ]
+        )
+
+        with pq.Program() as program:
+            pq.Q() | pq.NumberState([2, 0])
+            pq.Q(0, 1) | pq.Beamsplitter(np.pi / 4)
+
+            pq.Q(0) | pq.ImperfectParticleNumberMeasurement(
+                detector_efficiency_matrix=detector_efficiency_matrix,
+            )
+
+        simulator = pq.PassiveSimulator(d=2, config=pq.Config(seed_sequence=42))
+
+        result = simulator.execute(program, shots=100)
+
+        branches = result.branches
+
+        assert len(branches) == 3
+
+        assert {branch.outcome for branch in branches} == {(0,), (1,)}
+
+        assert all(branch.state is not None for branch in branches)
+
+        actual_postselected_counts = {
+            branch.state._postselections[0] for branch in branches
+        }
+
+        assert actual_postselected_counts == {0, 1, 2}
+
+        detected_outcomes_by_actual_count = {
+            branch.state._postselections[0]: branch.outcome for branch in branches
+        }
+
+        assert detected_outcomes_by_actual_count == {0: (0,), 1: (0,), 2: (1,)}
+
+        assert sum(branch.frequency for branch in branches) == Fraction(1, 1)
+
+        assert {tuple(int(value) for value in sample) for sample in result.samples} == {
+            (0,),
+            (1,),
+        }


### PR DESCRIPTION
Introduce `ImperfectParticleNumberMeasurement` with `detector_efficiency_matrix` based readout post-processing. Register the new measurement for `GaussianSimulator`, `FockSimulator`, `PureFockSimulator`, and `PassiveSimulator` through a shared simulation-step factory.

The implementation samples detected photon counts from the ideal `ParticleNumberMeasurement` branches, preserves post-measurement `Branch` states when present, and merges full-measurement outcomes when no branch state remains.

Also add `PassiveSimulator` coverage for blind detectors, identity detectors, uniform loss, and deterministic transmissivity edge cases.