### PR TITLE
chore: Update codecov settings

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,3 +1,14 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 5%
+
+    patch:
+      default:
+        informational: true
+
 ignore:
   - tests/**/*
   - piquasso/_math/hafnian/*

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,5 +30,5 @@ jobs:
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       with:
-        fail_ci_if_error: true
+        fail_ci_if_error: false
 


### PR DESCRIPTION
This patch relaxes Codecov handling by preventing upload issues from failing CI and making patch coverage informational.

This keeps coverage reporting available on pull requests while avoiding overly sensitive failures for small or branch-heavy changes.