### PR TITLE
fix(passive): Unify marginal probability naming

### DIFF
--- a/piquasso/_simulators/passive/marginal.py
+++ b/piquasso/_simulators/passive/marginal.py
@@ -107,7 +107,7 @@ from piquasso._math.fock import (
 from piquasso._math.indices import get_index_in_fock_space, get_index_in_fock_subspace
 
 
-def get_marginal_probabilities(
+def get_marginal_fock_probabilities(
     input_photons: np.ndarray,
     interferometer: np.ndarray,
     postselected_modes: Tuple[int, ...],

--- a/piquasso/_simulators/passive/state.py
+++ b/piquasso/_simulators/passive/state.py
@@ -37,7 +37,7 @@ from piquasso.api.exceptions import (
 from piquasso.api.connector import BaseConnector
 
 from .utils import calculate_state_vector
-from .marginal import get_marginal_probabilities
+from .marginal import get_marginal_fock_probabilities
 
 if TYPE_CHECKING:
     import piquasso
@@ -534,7 +534,7 @@ class PassiveState(State):
             "distinguishable states."
         )
 
-    def get_marginal_probabilities(
+    def get_marginal_fock_probabilities(
         self, modes: Tuple[int, ...]
     ) -> Dict[Tuple[int, ...], float]:
         """Returns the marginal probabilities of the state.
@@ -575,7 +575,7 @@ class PassiveState(State):
                 "Marginal probabilities cannot be calculated for postselected modes."
             )
 
-        return get_marginal_probabilities(
+        return get_marginal_fock_probabilities(
             self._occupation_numbers[0],
             self.interferometer,
             postselected_modes,

--- a/tests/_simulators/passive/test_measurements.py
+++ b/tests/_simulators/passive/test_measurements.py
@@ -1083,7 +1083,7 @@ class TestMarginalBosonSampling:
             )
         )
 
-        analytic_probabilities = analytic_result.state.get_marginal_probabilities(
+        analytic_probabilities = analytic_result.state.get_marginal_fock_probabilities(
             modes=(1, 2),
         )
 

--- a/tests/_simulators/passive/test_state.py
+++ b/tests/_simulators/passive/test_state.py
@@ -1083,7 +1083,7 @@ class TestMarginalProbabilities:
 
         modes = [0]
 
-        probabilities = state.get_marginal_probabilities(modes)
+        probabilities = state.get_marginal_fock_probabilities(modes)
 
         expected = {(0,): 0.0, (1,): 1.0, (2,): 0.0}
         assert set(probabilities) == set(expected)
@@ -1111,7 +1111,7 @@ class TestMarginalProbabilities:
 
         modes = [0]
 
-        probabilities = state.get_marginal_probabilities(modes)
+        probabilities = state.get_marginal_fock_probabilities(modes)
 
         expected_probabilities = {
             (0,): np.sin(2 * theta) ** 2 / 2,
@@ -1144,7 +1144,7 @@ class TestMarginalProbabilities:
 
         modes = [1]
 
-        probabilities = state.get_marginal_probabilities(modes)
+        probabilities = state.get_marginal_fock_probabilities(modes)
 
         sin_2alpha_sq = np.sin(2 * alpha) ** 2
         cos_2alpha_sq = np.cos(2 * alpha) ** 2
@@ -1189,7 +1189,7 @@ class TestMarginalProbabilities:
 
         modes = [1, 3]
 
-        probabilities = state.get_marginal_probabilities(modes)
+        probabilities = state.get_marginal_fock_probabilities(modes)
 
         S = np.sin(2 * alpha) ** 2
         C = np.cos(2 * alpha) ** 2
@@ -1249,7 +1249,7 @@ class TestMarginalProbabilities:
 
         modes = [1]
 
-        probabilities = state.get_marginal_probabilities(modes)
+        probabilities = state.get_marginal_fock_probabilities(modes)
 
         postselection_probability = np.cos(2 * alpha) ** 2
 
@@ -1282,7 +1282,7 @@ class TestMarginalProbabilities:
 
         modes = [0, 1, 2]
 
-        probabilities = state.get_marginal_probabilities(modes)
+        probabilities = state.get_marginal_fock_probabilities(modes)
 
         assert np.isclose(np.sum(list(probabilities.values())), 1.0)
 
@@ -1303,7 +1303,7 @@ class TestMarginalProbabilities:
 
         result = simulator.execute(program)
 
-        probabilities = result.state.get_marginal_probabilities(modes=[0])
+        probabilities = result.state.get_marginal_fock_probabilities(modes=[0])
 
         expected = {
             (0,): 1.0 - survival_probability,
@@ -1334,7 +1334,7 @@ class TestMarginalProbabilities:
 
         result = simulator.execute(program)
 
-        probabilities = result.state.get_marginal_probabilities(modes=[0, 1])
+        probabilities = result.state.get_marginal_fock_probabilities(modes=[0, 1])
 
         expected = {
             (0, 0): (1.0 - survival_probability) ** 3,
@@ -1368,7 +1368,7 @@ class TestMarginalProbabilities:
 
         result = simulator.execute(program)
 
-        probabilities = result.state.get_marginal_probabilities(modes=[0])
+        probabilities = result.state.get_marginal_fock_probabilities(modes=[0])
 
         expected = {
             (0,): 0.5 + 0.5 * (1.0 - survival_probability) ** 2,
@@ -1406,7 +1406,7 @@ class TestMarginalProbabilities:
                 "lossy states."
             ),
         ):
-            _ = result.state.get_marginal_probabilities(modes=[0])
+            _ = result.state.get_marginal_fock_probabilities(modes=[0])
 
     def test_multiple_occupation_numbers_raises_NotImplementedCalculation(self):
         unitary = np.array([[1, 0], [0, 1]], dtype=complex)
@@ -1436,7 +1436,7 @@ class TestMarginalProbabilities:
                 "multiple input occupation numbers."
             ),
         ):
-            _ = state.get_marginal_probabilities(modes)
+            _ = state.get_marginal_fock_probabilities(modes)
 
     def test_postselecting_on_same_mode_raises_PiquassoException(self):
         input_state = np.array([1, 1, 0], dtype=int)
@@ -1463,4 +1463,4 @@ class TestMarginalProbabilities:
                 "Marginal probabilities cannot be calculated for postselected modes."
             ),
         ):
-            _ = state.get_marginal_probabilities(modes)
+            _ = state.get_marginal_fock_probabilities(modes)


### PR DESCRIPTION
In other simulators, `PassiveState.get_marginal_probabilities` is called `get_marginal_fock_probabilities`. Therefore, this is unified in this patch so that every such method is called
`get_marginal_fock_probabilities`.