### PR TITLE
refact!: Make `get_marginal_fock_probabilities` friendlier

### DIFF
--- a/piquasso/_simulators/fock/state.py
+++ b/piquasso/_simulators/fock/state.py
@@ -290,17 +290,20 @@ class BaseFockState(State, abc.ABC):
         )
         return np.abs(np.sum(geometric_mean)) ** 2
 
-    def get_marginal_fock_probabilities(self, modes: Tuple[int, ...]) -> np.ndarray:
+    def get_marginal_fock_probabilities(
+        self, modes: Tuple[int, ...]
+    ) -> Dict[Tuple[int, ...], float]:
         """Return the particle number probabilities on a given subsystem.
 
         Args:
             modes (tuple[int, ...]): The indices of the modes to keep.
 
         Returns:
-            numpy.ndarray: The marginal particle number detection probabilities.
+            Dict[Tuple[int, ...], float]: The marginal particle number detection
+                probabilities, mapping occupation number tuples to their probabilities.
         """
 
-        return self.reduced(modes).fock_probabilities
+        return self.reduced(modes).fock_probabilities_map
 
     @abc.abstractmethod
     def get_purity(self):

--- a/piquasso/_simulators/gaussian/state.py
+++ b/piquasso/_simulators/gaussian/state.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional, Tuple, List, Union
+from typing import Optional, Tuple, List, Union, Dict
 
 import numpy as np
 
@@ -1011,10 +1011,20 @@ class GaussianState(State):
             get_fock_space_basis(d=self.d, cutoff=self._config.cutoff)
         )
 
-    def get_marginal_fock_probabilities(self, modes: Tuple[int, ...]) -> np.ndarray:
+    @property
+    def fock_probabilities_map(self) -> Dict[Tuple[int, ...], float]:
+        fock_space_basis = get_fock_space_basis(d=self.d, cutoff=self._config.cutoff)
+
+        occupation_numbers = [tuple(x) for x in fock_space_basis]
+
+        return dict(zip(occupation_numbers, self.fock_probabilities))
+
+    def get_marginal_fock_probabilities(
+        self, modes: Tuple[int, ...]
+    ) -> Dict[Tuple[int, ...], float]:
         """Return the particle number probabilities on a given subsystem."""
 
-        return self.reduced(modes).fock_probabilities
+        return self.reduced(modes).fock_probabilities_map
 
     def get_xp_string_moment(self, string: List[int]) -> complex:
         r"""Moment corresponding to a product of quadrature operators (XP-string).

--- a/piquasso/_simulators/passive/state.py
+++ b/piquasso/_simulators/passive/state.py
@@ -487,16 +487,11 @@ class PassiveState(State):
 
     @property
     def fock_probabilities_map(self) -> Dict[Tuple[int, ...], float]:
-        probability_map: Dict[Tuple[int, ...], float] = {}
+        fock_space_basis = get_fock_space_basis(d=self.d, cutoff=self._config.cutoff)
 
-        space = get_fock_space_basis(d=self.d, cutoff=self._config.cutoff)
+        occupation_numbers = [tuple(x) for x in fock_space_basis]
 
-        state_vector = self.state_vector
-
-        for index, basis in enumerate(space):
-            probability_map[tuple(basis)] = self._np.abs(state_vector[index]) ** 2
-
-        return probability_map
+        return dict(zip(occupation_numbers, self.fock_probabilities))
 
     def to_pure_fock_state(
         self,

--- a/piquasso/fermionic/fock/state.py
+++ b/piquasso/fermionic/fock/state.py
@@ -87,7 +87,7 @@ class PureFockState(State):
     def fock_probabilities_map(self) -> dict:
         fock_space_basis = get_fock_space_basis(self.d, self._config.cutoff)
 
-        occupation_numbers = [tuple(x) for x in fock_space_basis.tolist()]
+        occupation_numbers = [tuple(x) for x in fock_space_basis]
 
         return dict(zip(occupation_numbers, self.fock_probabilities))
 

--- a/tests/_simulators/fock/general/test_state.py
+++ b/tests/_simulators/fock/general/test_state.py
@@ -135,10 +135,12 @@ def test_FockState_get_marginal_fock_probabilities():
     state = simulator.execute(program).state
 
     modes = (1,)
-    expected_probabilities = np.array([0.5, 0.25, 0.25, 0.0])
     actual_probabilities = state.get_marginal_fock_probabilities(modes)
 
-    assert np.allclose(actual_probabilities, expected_probabilities)
+    assert np.isclose(actual_probabilities[(0,)], 0.5)
+    assert np.isclose(actual_probabilities[(1,)], 0.25)
+    assert np.isclose(actual_probabilities[(2,)], 0.25)
+    assert np.isclose(actual_probabilities[(3,)], 0.0)
 
 
 def test_FockState_quadratures_mean_variance():

--- a/tests/_simulators/fock/pure/test_state.py
+++ b/tests/_simulators/fock/pure/test_state.py
@@ -142,10 +142,12 @@ def test_PureFockState_get_marginal_fock_probabilities():
     state = simulator.execute(program).state
 
     modes = (1,)
-    expected_probabilities = np.array([0.5, 0.25, 0.25, 0.0])
-    actual_probabilities = state.get_marginal_fock_probabilities(modes)
+    probabilities = state.get_marginal_fock_probabilities(modes)
 
-    assert np.allclose(actual_probabilities, expected_probabilities)
+    assert np.isclose(probabilities[(0,)], 0.5)
+    assert np.isclose(probabilities[(1,)], 0.25)
+    assert np.isclose(probabilities[(2,)], 0.25)
+    assert np.isclose(probabilities[(3,)], 0.0)
 
 
 def test_PureFockState_quadratures_mean_variance():

--- a/tests/_simulators/gaussian/test_state.py
+++ b/tests/_simulators/gaussian/test_state.py
@@ -374,10 +374,12 @@ def test_GaussianState_get_marginal_fock_probabilities():
     state.validate()
 
     modes = (0, 2)
-    expected_probabilities = state.reduced(modes).fock_probabilities
+    expected_probabilities = state.reduced(modes).fock_probabilities_map
     actual_probabilities = state.get_marginal_fock_probabilities(modes)
 
-    assert np.allclose(actual_probabilities, expected_probabilities)
+    for occupation, expected_probability in expected_probabilities.items():
+        actual_probability = actual_probabilities[occupation]
+        assert np.isclose(expected_probability, actual_probability)
 
 
 def test_vacuum_covariance_is_proportional_to_identity():


### PR DESCRIPTION
The problem is that `get_marginal_probabilites` returns a dict with occupation numbers as keys and probabilities as values in `PassiveSimulator`, but in other places, it just returns with the probabilities. This is problematice because a) it is inconsistent b) it is easier for the user if the occupation numbers are also returned.

Therefore, the dict solution is implemented in `GaussianState`, `FockState` and `PureFockState`.