### PR TITLE
feat(passive): Enable `shots=None`

### DIFF
--- a/piquasso/_simulators/passive/sampling.py
+++ b/piquasso/_simulators/passive/sampling.py
@@ -794,9 +794,9 @@ def map_to_original_modes(modes, postselected_modes):
 
 
 def generate_marginal_samples(
-    initial_state, interferometer, modes, shots, rng, postselect_data
+    input, interferometer, modes, shots, config, postselect_data
 ):
-    n = sum(initial_state)
+    n = sum(input)
     k = len(modes)
 
     postselect_modes = postselect_data[0]
@@ -805,7 +805,7 @@ def generate_marginal_samples(
     all_modes = np.array(postselect_modes + modes)
 
     binomial_moments = get_binomial_moments(
-        input_photons=initial_state,
+        input_photons=input,
         interferometer=interferometer,
         all_modes=all_modes,
         compositions=get_fock_space_basis(len(all_modes), n + 1),
@@ -832,7 +832,7 @@ def generate_marginal_samples(
         particles = np.concatenate([postselect_photons, np.zeros(k, dtype=int)])
 
         for mode_idx in range(k):
-            threshold = rng.random()
+            threshold = config.rng.random()
 
             cumulative_probability = 0.0
 

--- a/piquasso/_simulators/passive/simulation_steps.py
+++ b/piquasso/_simulators/passive/simulation_steps.py
@@ -284,6 +284,34 @@ def particle_number_measurement(
 
     marginal_sampling = set(modes) != set(range(state.d))
 
+    common_kwargs = dict(
+        input=initial_state,
+        interferometer=state.interferometer,
+        shots=shots,
+        config=config,
+        postselect_data=postselect_data,
+    )
+
+    if shots is None:
+        if marginal_sampling:
+            probabilities = state.get_marginal_fock_probabilities(modes=modes)
+
+            return [
+                Branch(
+                    state=state._copy_with_postselection(modes, outcome),
+                    outcome=outcome,
+                    frequency=probability,
+                )
+                for outcome, probability in probabilities.items()
+            ]
+
+        probabilities = state.fock_probabilities_map
+
+        return [
+            Branch(state=None, outcome=outcome, frequency=probability)
+            for outcome, probability in probabilities.items()
+        ]
+
     singular_values = np.linalg.svd(state.interferometer, compute_uv=False)
 
     is_ideal_or_uniform_lossy = np.all(np.isclose(singular_values, singular_values[0]))
@@ -300,14 +328,7 @@ def particle_number_measurement(
     ):
         original_modes = map_to_original_modes(modes, postselected_modes)
 
-        samples = generate_marginal_samples(
-            initial_state=initial_state,
-            interferometer=state.interferometer,
-            modes=original_modes,
-            shots=shots,
-            rng=rng,
-            postselect_data=postselect_data,
-        )
+        samples = generate_marginal_samples(**common_kwargs, modes=original_modes)
 
         binned_samples = get_counts(samples)
 
@@ -317,14 +338,6 @@ def particle_number_measurement(
             shots=shots,
             binned_samples=binned_samples,
         )
-
-    common_kwargs = dict(
-        input=initial_state,
-        interferometer=state.interferometer,
-        shots=shots,
-        config=config,
-        postselect_data=postselect_data,
-    )
 
     if not state.is_lossy and not state.is_nonuniformly_partially_distinguishable:
         samples = generate_samples(
@@ -395,10 +408,7 @@ def _create_branches_after_marginal_particle_number_measurement(
 
     for outcome, multiplicity in binned_samples.items():
         new_state = state.copy()
-        new_state._postselections = {
-            **new_state._postselections,
-            **{mode: x for mode, x in zip(modes, outcome)},
-        }
+        new_state._set_postselection(modes, outcome)
 
         branches.append(
             Branch(

--- a/piquasso/_simulators/passive/simulator.py
+++ b/piquasso/_simulators/passive/simulator.py
@@ -141,6 +141,12 @@ class PassiveSimulator(BuiltinSimulator):
         measurements.ImperfectParticleNumberMeasurement,
     )
 
+    _measurement_classes_allowed_with_shots_none = (
+        measurements.PostSelectPhotons,
+        measurements.ParticleNumberMeasurement,
+        measurements.ImperfectParticleNumberMeasurement,
+    )
+
 
 class SamplingSimulator(PassiveSimulator):
     """Deprecated alias for :class:`PassiveSimulator`."""

--- a/piquasso/_simulators/passive/state.py
+++ b/piquasso/_simulators/passive/state.py
@@ -16,9 +16,14 @@
 
 from functools import partial
 from typing import Dict, Optional, List, Tuple, Union, TYPE_CHECKING
+from typing_extensions import Self
 import numpy as np
 
-from piquasso._math.fock import cutoff_fock_space_dim, get_fock_space_basis
+from piquasso._math.fock import (
+    cutoff_fock_space_dim,
+    get_fock_space_basis,
+    get_postselected_fock_basis,
+)
 from piquasso._math.linalg import is_unitary
 
 from piquasso._simulators.passive.probabilities import (
@@ -152,6 +157,15 @@ class PassiveState(State):
 
         self._config.cutoff -= sum(photon_counts)
         self._postselections = postselections
+
+    def _copy_with_postselection(
+        self, modes: Tuple[int, ...], photon_counts: Tuple[int, ...]
+    ) -> Self:
+        new_state = self.copy()
+
+        new_state._set_postselection(modes, photon_counts)
+
+        return new_state
 
     def _is_postselected(self) -> bool:
         return self._postselections != {}
@@ -479,6 +493,36 @@ class PassiveState(State):
     @property
     def fock_probabilities(self) -> np.ndarray:
         """The Fock basis probabilities of the state."""
+
+        if self.is_lossy or self.is_partially_distinguishable:
+            if len(self._occupation_numbers) != 1:
+                raise NotImplementedCalculation(
+                    "Fock probabilities calculation is not implemented for lossy or "
+                    "partially distinguishable states with multiple input occupation "
+                    "numbers. "
+                    "If you would like to use this feature, please create an issue at "
+                    "https://github.com/Budapest-Quantum-Computing-Group/piquasso/issues"  # noqa: E501
+                )
+
+            occupation_numbers = get_postselected_fock_basis(
+                d=self.d,
+                cutoff=self._config.cutoff,
+                postselected_modes=self._get_postselected_modes(),
+                postselected_photons=self._get_postselected_photons(),
+            )
+
+            particle_overlap = (
+                1.0 if self._particle_overlap is None else self._particle_overlap
+            )
+
+            return get_lossy_partially_distinguishable_detection_probabilities(
+                occupation_numbers=occupation_numbers,
+                transmission_matrix=self.interferometer,
+                input_occupation=self._occupation_numbers[0],
+                particle_overlap=particle_overlap,
+                connector=self._connector,
+            )
+
         np = self._connector.np
 
         state_vector = self.state_vector

--- a/piquasso/_simulators/simulation_steps.py
+++ b/piquasso/_simulators/simulation_steps.py
@@ -13,11 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Dict, Tuple, List, Callable
+from fractions import Fraction
+from itertools import product
+from typing import Callable, Dict, List, Optional, Tuple, cast
 
 import numpy as np
-
-from fractions import Fraction
 
 from piquasso.api.state import State
 from piquasso.api.branch import Branch
@@ -29,7 +29,7 @@ def create_imperfect_particle_number_measurement(
     particle_number_measurement_simulation_step: Callable,
 ) -> Callable:
     def imperfect_particle_number_measurement(
-        state: State, instruction: Instruction, shots: int
+        state: State, instruction: Instruction, shots: Optional[int]
     ) -> List[Branch]:
         branches = particle_number_measurement_simulation_step(
             state, instruction, shots
@@ -40,32 +40,32 @@ def create_imperfect_particle_number_measurement(
             dtype=state._config.dtype,
         )
 
-        rng = state._config.rng
-
-        detected_counts: Dict[Tuple[int, ...], int] = {}
+        detected_frequencies: Dict[Tuple[int, ...], Fraction] = {}
         imperfect_branches: List[Branch] = []
 
         for branch in branches:
-            multiplicity = (branch.frequency * shots).numerator
-
-            detected_outcomes = _sample_detected_outcomes_for_branch(
-                actual_outcome=branch.outcome,
-                multiplicity=multiplicity,
+            branch_frequencies = _get_imperfect_branch_frequencies(
+                branch=branch,
+                shots=shots,
                 detector_efficiency_matrix=detector_efficiency_matrix,
-                rng=rng,
+                rng=state._config.rng,
             )
 
-            for detected_outcome, detected_multiplicity in detected_outcomes.items():
+            for detected_outcome, frequency in branch_frequencies.items():
+                if frequency == 0:
+                    continue
+
                 if branch.state is None:
-                    detected_counts[detected_outcome] = (
-                        detected_counts.get(detected_outcome, 0) + detected_multiplicity
+                    detected_frequencies[detected_outcome] = (
+                        detected_frequencies.get(detected_outcome, Fraction(0, 1))
+                        + frequency
                     )
                 else:
                     imperfect_branches.append(
                         Branch(
                             state=branch.state.copy(),
                             outcome=detected_outcome,
-                            frequency=Fraction(detected_multiplicity, shots),
+                            frequency=frequency,
                         )
                     )
 
@@ -73,9 +73,9 @@ def create_imperfect_particle_number_measurement(
             Branch(
                 state=None,
                 outcome=outcome,
-                frequency=Fraction(multiplicity, shots),
+                frequency=frequency,
             )
-            for outcome, multiplicity in detected_counts.items()
+            for outcome, frequency in detected_frequencies.items()
         )
 
         return imperfect_branches
@@ -83,19 +83,70 @@ def create_imperfect_particle_number_measurement(
     return imperfect_particle_number_measurement
 
 
-def _sample_detected_outcomes_for_branch(
-    actual_outcome: Tuple[int, ...],
-    multiplicity: int,
+def _get_imperfect_branch_frequencies(
+    branch: Branch,
+    shots: Optional[int],
     detector_efficiency_matrix: np.ndarray,
     rng: np.random.Generator,
-) -> Dict[Tuple[int, ...], int]:
-    number_of_detectable_counts, number_of_actual_counts = (
-        detector_efficiency_matrix.shape
+) -> Dict[Tuple[int, ...], Fraction]:
+    actual_outcome = cast(Tuple[int, ...], branch.outcome)
+
+    if shots is None:
+        return {
+            outcome: branch.frequency * probability
+            for outcome, probability in _get_detected_outcome_probabilities(
+                actual_outcome=actual_outcome,
+                detector_efficiency_matrix=detector_efficiency_matrix,
+            ).items()
+        }
+
+    multiplicity = (branch.frequency * shots).numerator
+
+    return {
+        outcome: Fraction(count, shots)
+        for outcome, count in _sample_detected_outcomes(
+            actual_outcome=actual_outcome,
+            multiplicity=multiplicity,
+            detector_efficiency_matrix=detector_efficiency_matrix,
+            rng=rng,
+        ).items()
+    }
+
+
+def _get_detected_outcome_probabilities(
+    actual_outcome: Tuple[int, ...],
+    detector_efficiency_matrix: np.ndarray,
+) -> Dict[Tuple[int, ...], Fraction]:
+    probabilities_by_mode = _get_probabilities_by_mode(
+        actual_outcome=actual_outcome,
+        detector_efficiency_matrix=detector_efficiency_matrix,
     )
 
-    detected_counts = np.arange(number_of_detectable_counts)
+    number_of_detectable_counts = detector_efficiency_matrix.shape[0]
+    detected_outcome_probabilities: Dict[Tuple[int, ...], Fraction] = {}
 
-    detected_counts_by_mode = []
+    for detected_outcome in product(
+        range(number_of_detectable_counts),
+        repeat=len(actual_outcome),
+    ):
+        probability = Fraction(1, 1)
+
+        for mode, detected_count in enumerate(detected_outcome):
+            probability *= Fraction(
+                float(probabilities_by_mode[mode][detected_count])
+            ).limit_denominator()
+
+        if probability != 0:
+            detected_outcome_probabilities[detected_outcome] = probability
+
+    return detected_outcome_probabilities
+
+
+def _get_probabilities_by_mode(
+    actual_outcome: Tuple[int, ...],
+    detector_efficiency_matrix: np.ndarray,
+) -> List[np.ndarray]:
+    number_of_actual_counts = detector_efficiency_matrix.shape[1]
 
     for actual_count in actual_outcome:
         if actual_count >= number_of_actual_counts:
@@ -104,20 +155,40 @@ def _sample_detected_outcomes_for_branch(
                 f"{actual_count}. Increase the number of columns."
             )
 
-        probabilities = detector_efficiency_matrix[:, actual_count]
-        probabilities = probabilities / np.sum(probabilities)
+    return [
+        detector_efficiency_matrix[:, actual_count] for actual_count in actual_outcome
+    ]
 
-        detected_counts_by_mode.append(
-            rng.choice(
-                detected_counts,
-                size=multiplicity,
-                p=probabilities,
-            )
+
+def _sample_detected_outcomes(
+    actual_outcome: Tuple[int, ...],
+    multiplicity: int,
+    detector_efficiency_matrix: np.ndarray,
+    rng: np.random.Generator,
+) -> Dict[Tuple[int, ...], int]:
+    probabilities_by_mode = _get_probabilities_by_mode(
+        actual_outcome=actual_outcome,
+        detector_efficiency_matrix=detector_efficiency_matrix,
+    )
+
+    number_of_detectable_counts = detector_efficiency_matrix.shape[0]
+
+    detected_counts_by_mode = [
+        rng.choice(
+            number_of_detectable_counts,
+            size=multiplicity,
+            p=probabilities,
         )
+        for probabilities in probabilities_by_mode
+    ]
 
-    detected_outcomes = np.stack(detected_counts_by_mode, axis=1)
+    detected_outcomes = np.column_stack(detected_counts_by_mode)
+
     unique_outcomes, first_indices, counts = np.unique(
-        detected_outcomes, axis=0, return_index=True, return_counts=True
+        detected_outcomes,
+        axis=0,
+        return_index=True,
+        return_counts=True,
     )
 
     order = np.argsort(first_indices)

--- a/tests/_simulators/passive/test_gates.py
+++ b/tests/_simulators/passive/test_gates.py
@@ -541,71 +541,58 @@ def test_Interferometer_fock_probabilities(connector):
     )
 
 
-@pytest.mark.parametrize("connector", (pq.NumpyConnector(), pq.JaxConnector()))
-def test_LossyInterferometer_fock_probabilities(connector):
+def test_LossyInterferometer_fock_probabilities():
+    singular_values = np.array([0.9, 0.8, 0.5])
+
+    omega = np.exp(2j * np.pi / 3)
+
     U = np.array(
         [
-            [
-                -0.17959207 - 0.29175972j,
-                -0.64550941 - 0.02897055j,
-                -0.023922 - 0.38854671j,
-                -0.07908932 + 0.35617293j,
-                -0.39779191 + 0.14902272j,
-            ],
-            [
-                -0.36896208 + 0.19468375j,
-                -0.11545557 + 0.20434514j,
-                0.25548079 + 0.05220164j,
-                -0.51002161 + 0.38442256j,
-                0.48106678 - 0.25210091j,
-            ],
-            [
-                0.25912844 + 0.16131742j,
-                0.11886251 + 0.12632645j,
-                0.69028213 - 0.25734432j,
-                0.01276639 + 0.05841739j,
-                0.03713264 + 0.57364845j,
-            ],
-            [
-                -0.20314019 - 0.18973473j,
-                0.59146854 + 0.28605532j,
-                -0.11096495 - 0.26870144j,
-                -0.47290354 - 0.0489408j,
-                -0.42459838 + 0.01554643j,
-            ],
-            [
-                -0.5021973 - 0.53474291j,
-                0.24524545 - 0.0741398j,
-                0.37786104 + 0.10225255j,
-                0.46696955 + 0.10636677j,
-                0.07171789 - 0.09194236j,
-            ],
-        ]
-    )
+            [1.0, 1.0, 1.0],
+            [1.0, omega, omega**2],
+            [1.0, omega**2, omega],
+        ],
+        dtype=complex,
+    ) / np.sqrt(3)
 
-    singular_values = np.array([0.9, 0.8, 0.7, 0.6, 0.5])
-
-    lossy_interferometer_matrix = U @ np.diag(singular_values) @ U @ U.T
+    lossy_interferometer_matrix = U @ np.diag(singular_values) @ U.conj().T
 
     with pq.Program() as program:
-        pq.Q(all) | pq.NumberState([2, 1, 1, 0, 1])
+        pq.Q(all) | pq.NumberState([2, 1, 0])
 
         pq.Q(all) | pq.LossyInterferometer(lossy_interferometer_matrix)
 
-    simulator = pq.PassiveSimulator(
-        d=5, connector=connector, config=pq.Config(cutoff=6)
-    )
+    simulator = pq.PassiveSimulator(d=3, config=pq.Config(cutoff=4))
     state = simulator.execute(program).state
 
     assert state.is_lossy
 
-    with pytest.raises(pq.api.exceptions.NotImplementedCalculation) as excinfo:
-        _ = state.fock_probabilities
-
-    assert (
-        "State vector calculation is not implemented for lossy or partially "
-        "distinguishable states." in str(excinfo.value)
+    expected_fock_probabilities = np.array(
+        [
+            0.1051844444,
+            0.2337373333,
+            0.1067068889,
+            0.0062313333,
+            0.138173037,
+            0.2703917037,
+            0.0086308148,
+            0.0135382963,
+            0.0053396296,
+            0.0003620741,
+            0.012532214,
+            0.1726864198,
+            0.0025813333,
+            0.0171614444,
+            0.0069342469,
+            0.0003969012,
+            0.0003366091,
+            0.0003969012,
+            0.0000693333,
+            0.0000090412,
+        ]
     )
+
+    assert np.allclose(state.fock_probabilities, expected_fock_probabilities)
 
 
 @pytest.mark.parametrize("connector", (pq.NumpyConnector(), pq.JaxConnector()))

--- a/tests/_simulators/passive/test_measurements.py
+++ b/tests/_simulators/passive/test_measurements.py
@@ -1640,3 +1640,95 @@ class TestImperfectParticleNumberMeasurement:
             (0,),
             (1,),
         }
+
+    def test_marginal_imperfect_particle_number_measurement_with_shots_none(self):
+        detector_efficiency_matrix = np.array(
+            [
+                [1.0, 0.25],
+                [0.0, 0.75],
+            ]
+        )
+
+        with pq.Program() as program:
+            pq.Q() | pq.NumberState([1, 0])
+            pq.Q(0) | pq.ImperfectParticleNumberMeasurement(
+                detector_efficiency_matrix=detector_efficiency_matrix,
+            )
+
+        simulator = pq.PassiveSimulator(d=2, config=pq.Config(seed_sequence=42))
+
+        result = simulator.execute(program, shots=None)
+
+        branches = result.branches
+
+        assert len(branches) == 2
+
+        frequencies_by_outcome = {
+            branch.outcome: branch.frequency for branch in branches
+        }
+
+        assert np.isclose(frequencies_by_outcome[(0,)], 0.25)
+        assert np.isclose(frequencies_by_outcome[(1,)], 0.75)
+
+        assert all(branch.state is not None for branch in branches)
+        assert all(branch.state._postselections == {0: 1} for branch in branches)
+
+        assert np.isclose(sum(branch.frequency for branch in branches), 1.0)
+
+    def test_marginal_imperfect_particle_number_measurement_with_shots_none_nontrivial(
+        self,
+    ):
+        detector_efficiency_matrix = np.array(
+            [
+                [1.0, 0.25, 0.10],
+                [0.0, 0.50, 0.30],
+                [0.0, 0.25, 0.60],
+            ]
+        )
+
+        with pq.Program() as program:
+            pq.Q() | pq.NumberState([2, 0])
+            pq.Q(0, 1) | pq.Beamsplitter(np.pi / 4)
+
+            pq.Q(0) | pq.ImperfectParticleNumberMeasurement(
+                detector_efficiency_matrix=detector_efficiency_matrix,
+            )
+
+        simulator = pq.PassiveSimulator(d=2, config=pq.Config(seed_sequence=42))
+
+        result = simulator.execute(program, shots=None)
+
+        branches = result.branches
+
+        assert len(branches) == 7
+
+        assert all(branch.state is not None for branch in branches)
+
+        frequencies_by_actual_and_detected = {
+            (branch.state._postselections[0], branch.outcome[0]): branch.frequency
+            for branch in branches
+        }
+
+        expected_frequencies = {
+            (0, 0): 0.25,
+            (1, 0): 0.125,
+            (1, 1): 0.25,
+            (1, 2): 0.125,
+            (2, 0): 0.025,
+            (2, 1): 0.075,
+            (2, 2): 0.15,
+        }
+
+        assert frequencies_by_actual_and_detected.keys() == expected_frequencies.keys()
+
+        for key, expected_frequency in expected_frequencies.items():
+            assert np.isclose(
+                frequencies_by_actual_and_detected[key],
+                expected_frequency,
+            )
+
+        assert np.isclose(sum(branch.frequency for branch in branches), 1.0)
+
+        assert {branch.state._postselections[0] for branch in branches} == {0, 1, 2}
+
+        assert {branch.outcome for branch in branches} == {(0,), (1,), (2,)}


### PR DESCRIPTION
Add exact-probability support for `ParticleNumberMeasurement` and `ImperfectParticleNumberMeasurement` in `PassiveSimulator` when `shots=None`.

The passive measurement step now returns exact `Branch` frequencies from the Fock-basis probability map, including marginal measurements with postselected branch states. Imperfect particle-number detection now propagates detector probabilities exactly when `shots=None`, while preserving sampled behavior for finite shots.

Also refactor passive postselection handling and add regression tests for marginal imperfect measurements with exact probabilities.