### PR TITLE
chore: Add packaging tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,4 +31,3 @@ jobs:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       with:
         fail_ci_if_error: false
-

--- a/tox.ini
+++ b/tox.ini
@@ -6,15 +6,24 @@
 [tox]
 requires =
     tox>=4
-env_list = py{310,311,312,313,314}
+env_list =
+    py{310,311,312,313,314}
+    py{310,311,312,313,314}-plain
 
 [gh-actions]
 python =
-    3.10: py310
-    3.11: py311
-    3.12: py312
-    3.13: py313
-    3.14: py314
+    3.10: py310, py310-plain
+    3.11: py311, py311-plain
+    3.12: py312, py312-plain
+    3.13: py313, py313-plain
+    3.14: py314, py314-plain
+
+[testenv:py{310,311,312,313,314}-plain]
+extras =
+deps =
+change_dir = {envtmpdir}
+commands =
+    python -c "import piquasso"
 
 [testenv]
 extras =


### PR DESCRIPTION
Tests are added to check that the plain Piquasso package install can do a successful import. This can catch certain import errors, such as the one fixed in 1fc28ed.